### PR TITLE
fix(type): add --enter to commit async-autocomplete/tag widgets

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -602,11 +602,27 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             // `--key-events` (alias `--keys`): send real per-character keystrokes
             // instead of Input.insertText, so autocomplete/combobox widgets that
             // only react to key events fire (e.g. Google address postal lookup).
-            let key_events = rest.iter().any(|a| *a == "--key-events" || *a == "--keys");
+            let mut key_events = rest.iter().any(|a| *a == "--key-events" || *a == "--keys");
+            // `--enter` (alias `--commit-enter`): press Enter after typing to commit
+            // the highlighted candidate in an async-autocomplete widget (e.g.
+            // juejin's tag input — issue #50). Implies `--key-events`: a bulk
+            // Input.insertText never fires the keydown/input the dropdown queries
+            // off, so the candidate Enter would commit never appears.
+            let commit_enter = rest
+                .iter()
+                .any(|a| *a == "--enter" || *a == "--commit-enter");
+            if commit_enter {
+                key_events = true;
+            }
             let rest: Vec<&str> = rest
                 .iter()
                 .copied()
-                .filter(|a| *a != "--key-events" && *a != "--keys")
+                .filter(|a| {
+                    *a != "--key-events"
+                        && *a != "--keys"
+                        && *a != "--enter"
+                        && *a != "--commit-enter"
+                })
                 .collect();
             // `type --focused <text>` types into whatever element currently has
             // focus (no selector) — for custom widgets that move focus to a hidden
@@ -615,14 +631,16 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 return Ok(json!({
                     "id": id, "action": "type", "focused": true,
                     "text": rest[1..].join(" "), "keyEvents": key_events,
+                    "commitEnter": commit_enter,
                 }));
             }
             let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
                 context: "type".to_string(),
-                usage: "type <selector> <text>   (or: type --focused <text>) [--key-events]",
+                usage:
+                    "type <selector> <text>   (or: type --focused <text>) [--key-events] [--enter]",
             })?;
             Ok(
-                json!({ "id": id, "action": "type", "selector": sel, "text": rest[1..].join(" "), "keyEvents": key_events }),
+                json!({ "id": id, "action": "type", "selector": sel, "text": rest[1..].join(" "), "keyEvents": key_events, "commitEnter": commit_enter }),
             )
         }
         "pick" => {
@@ -4422,6 +4440,7 @@ mod tests {
         assert_eq!(cmd["selector"], "#input");
         assert_eq!(cmd["text"], "some text");
         assert_eq!(cmd["keyEvents"], false);
+        assert_eq!(cmd["commitEnter"], false);
     }
 
     #[test]
@@ -4442,6 +4461,30 @@ mod tests {
             parse_command(&args("type --focused 201-0001 --keys"), &default_flags()).unwrap();
         assert_eq!(focused["focused"], true);
         assert_eq!(focused["text"], "201-0001");
+        assert_eq!(focused["keyEvents"], true);
+    }
+
+    #[test]
+    fn test_type_commit_enter() {
+        // --enter commits the typed value with a trailing Enter (async-autocomplete
+        // tag widgets, issue #50) and must imply --key-events so the dropdown the
+        // Enter commits has actually been triggered.
+        let cmd = parse_command(&args("type #tag ChatGPT --enter"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "type");
+        assert_eq!(cmd["selector"], "#tag");
+        assert_eq!(cmd["text"], "ChatGPT");
+        assert_eq!(cmd["commitEnter"], true);
+        assert_eq!(cmd["keyEvents"], true);
+
+        // Alias --commit-enter behaves identically, on the --focused path too.
+        let focused = parse_command(
+            &args("type --focused ChatGPT --commit-enter"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(focused["focused"], true);
+        assert_eq!(focused["text"], "ChatGPT");
+        assert_eq!(focused["commitEnter"], true);
         assert_eq!(focused["keyEvents"], true);
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3576,6 +3576,15 @@ async fn handle_type(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
+    // `--enter`: after typing, press Enter to commit the highlighted candidate in
+    // an async-autocomplete widget (juejin tag input — issue #50). The parser
+    // already forces key_events on when this is set, so the dropdown the Enter
+    // commits has actually been triggered by the per-character key events.
+    let commit_enter = cmd
+        .get("commitEnter")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
     // `type --focused <text>`: type into the currently-focused element without a
     // selector (custom widgets that move focus to a hidden input on open).
     if cmd
@@ -3595,7 +3604,10 @@ async fn handle_type(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
             key_events,
         )
         .await?;
-        return Ok(json!({ "typed": text, "focused": true }));
+        if commit_enter {
+            interaction::commit_with_enter(&mgr.client, &session_id).await?;
+        }
+        return Ok(json!({ "typed": text, "focused": true, "committed": commit_enter }));
     }
 
     let selector = cmd
@@ -3621,7 +3633,10 @@ async fn handle_type(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
         key_events,
     )
     .await?;
-    Ok(json!({ "typed": text }))
+    if commit_enter {
+        interaction::commit_with_enter(&mgr.client, &session_id).await?;
+    }
+    Ok(json!({ "typed": text, "committed": commit_enter }))
 }
 
 /// Atomic combobox select: `pick <selector> --option "<text>"`. Opens the control

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -859,6 +859,20 @@ pub async fn type_text_into_active_context(
     Ok(())
 }
 
+/// Commit the value just typed into an async-autocomplete / tag widget by pressing
+/// Enter (issue #50: juejin's 「添加标签」 input). Such widgets query their suggestion
+/// list off the per-character key events `type --key-events` fires, but the
+/// dropdown lands a tick later — so we let the page settle (RAF + microtask) so the
+/// candidate is mounted/highlighted before the Enter, which the widget reads as
+/// "accept the current candidate". Used by `type --enter`, which forces key-events
+/// typing on (a bulk insertText never triggers the dropdown Enter would commit).
+pub async fn commit_with_enter(client: &CdpClient, session_id: &str) -> Result<(), String> {
+    wait_for_paint_settled(client, session_id).await;
+    press_key(client, session_id, "enter").await?;
+    wait_for_paint_settled(client, session_id).await;
+    Ok(())
+}
+
 pub async fn press_key(client: &CdpClient, session_id: &str, key: &str) -> Result<(), String> {
     press_key_with_modifiers(client, session_id, key, None).await
 }

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -352,6 +352,13 @@ chrome-use type @e5 "201-0001" --key-events  # real keystrokes (not insertText) 
                                           # use for autocomplete/combobox fields that
                                           # only react to key events (e.g. a postal box
                                           # that auto-fills city/prefecture, Google Places)
+chrome-use type @e6 "ChatGPT" --enter  # type (real keystrokes, implies --key-events)
+                                          # then press Enter to COMMIT the candidate in an
+                                          # async-autocomplete / tag widget. Use when typing
+                                          # alone shows no dropdown and the field needs a tag
+                                          # confirmed (e.g. juejin 「添加标签」). If you'd rather
+                                          # pick from the list, type --key-events first, then
+                                          # snapshot -i and click the candidate.
 chrome-use press Enter                 # press a key at current focus (down+up)
 chrome-use press Control+a             # key combination
 chrome-use keydown d                   # HOLD a key down (no auto-release)


### PR DESCRIPTION
## Problem

When automating juejin.cn's article-publish modal, the 「添加标签」(add-tag) input can't be driven. It's a framework-controlled autocomplete: a bulk `Input.insertText` never fires the `keydown`/`input` events the widget queries its suggestion dropdown off, so no candidate ever appears and no tag can be added — and juejin requires ≥1 tag, so publish is blocked. (In the same modal, `click` for the category radios and `fill` for title/summary work fine; only this custom widget is unreachable.)

See #50 for the full repro.

## Fix

Add `type --enter` (alias `--commit-enter`):

- It **implies `--key-events`** — real per-character keystrokes, which *do* trigger the dropdown (a bulk `insertText` doesn't, so there'd be nothing for Enter to commit).
- After typing, it waits for the page to settle (RAF + microtask) so the candidate is mounted/highlighted, then presses **Enter** once, which these widgets read as "accept the current candidate".
- Works on both the selector path (`type @e6 "ChatGPT" --enter`) and the `--focused` path.

```bash
chrome-use type @e6 "ChatGPT" --enter   # types real keystrokes, then commits the candidate
```

If you'd rather pick from the list explicitly, the existing flow still works: `type --key-events`, then `snapshot -i` and `click` the candidate.

## Changes

- `cli/src/commands.rs` — parse `--enter`/`--commit-enter`, force `keyEvents` on, thread `commitEnter` through; updated usage string; added `test_type_commit_enter`.
- `cli/src/native/actions.rs` — call `commit_with_enter` after typing when set (selector + focused paths); return `committed` in the result.
- `cli/src/native/interaction.rs` — `commit_with_enter` helper (settle → Enter → settle).
- `skill-data/core/SKILL.md` — document `type --enter`.

## Test

`cargo test test_type_commit_enter` passes; full crate compiles.

Caveat: unit-tested the parser wiring; the Enter-commit event path was not live-tested against juejin from CI (no browser there). The event sequence mirrors the existing `--key-events` path plus a settled Enter.

Fixes #50
