### PR TITLE
fix(relay): proactive 20s heartbeat so the MV3 worker never idle-drops the relay

### DIFF
--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -241,6 +241,8 @@ function connectHost() {
   void reannounceAttachedTabs()
   void attachAllTabs()
   notifyConnChange(true)
+  // Start the proactive heartbeat so the worker stays alive while paired.
+  scheduleKeepalivePing()
 }
 
 async function onHostMessage(msg) {
@@ -678,14 +680,38 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   return true
 })
 
-// MV3 service workers get suspended; an alarm wakes us to keep the host link
-// and badges fresh.
+// Hot-path keepalive: while a native-messaging port is open, post a tiny ping
+// every 20s. Each port message resets the MV3 service-worker idle timer, so the
+// worker never reaches the ~30s idle-kill while we're paired and the relay stays
+// live — instead of dropping during any quiet stretch (no CDP traffic) and making
+// the next command hang until a reconnect. The setTimeout chain only survives as
+// long as the worker does, which is exactly what the ping guarantees; on a cold
+// worker restart the alarm below re-runs connectHost() which restarts this loop.
+const KEEPALIVE_PING_MS = 20000
+let keepaliveTimer = null
+function scheduleKeepalivePing() {
+  if (keepaliveTimer) clearTimeout(keepaliveTimer)
+  keepaliveTimer = setTimeout(() => {
+    keepaliveTimer = null
+    if (!port) return // disconnected; connectHost() will restart the loop
+    postToHost({ method: 'ping' }) // host pongs (or ignores); the send is what matters
+    scheduleKeepalivePing()
+  }, KEEPALIVE_PING_MS)
+}
+
+// Cold-restart backstop. MV3 service workers get suspended; an alarm wakes us to
+// reconnect the host link and restart the heartbeat. NOTE: chrome.alarms clamps
+// sub-minute periods (effective floor ~30s+), so the alarm alone can't outpace the
+// 30s idle-kill — that's why the 20s ping above is the real keeper, not this.
 chrome.alarms.create('keepalive', { periodInMinutes: 0.4 })
 chrome.alarms.onAlarm.addListener((a) => {
   if (a.name !== 'keepalive') return
   void whenReady(() => {
     if (!port) connectHost()
-    else void attachAllTabs()
+    else {
+      void attachAllTabs()
+      scheduleKeepalivePing()
+    }
   })
 })
 

--- a/extensions/ab-connect/manifest.json
+++ b/extensions/ab-connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "chrome-use",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Let chrome-use drive your logged-in Chrome \u2014 install once, no token, no per-use confirmation.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6vQIyscGIPYPZdSpPwPL0+0gxUROyRgCpmvCSDoc8XUm4qm97VbKnD9Ijc1lV22lNWZtE78gaRjt6BeSfuMgnBymnhLKjN1gU6AI5QUU0mrJyeHdWKvrKQR5FmsM2A7Xr1ykE2SiiS8zNUS3Y/6O5l+Nva7wrVy6E4a2dkBVQkOsu+DV+nEZvhIyuDY5D5SPXqNwUTWTaglwj5mjvHz36xSwCWlPmrtJ+ED0AUyrb2z4GIOmvk4kqtBVrh/UD058klLo4CkYOnIybB5aV6WYuwarfPY4bF/dLggPem+ewLNTUNBuwrxj/A4nUv0LJTuRO8rR7f8WR9qnRCY0Ic5saQIDAQAB",
   "icons": {


### PR DESCRIPTION
## What

The `ab-connect` MV3 service worker kept the native-messaging link alive only via a `keepalive` **alarm** at `periodInMinutes: 0.4` (24s). But `chrome.alarms` clamps sub-minute periods to a ~30s+ floor, so the alarm can't reliably outpace the MV3 **30s idle-kill**.

## Symptom (hit live)

During any quiet stretch with no CDP traffic — the agent reading a screenshot, the user typing — the worker reaches the idle timeout, the native port disconnects, and the **next CLI command hangs / returns empty** until an alarm wakes the worker and reconnects. Observed as the relay "dropping" across *all* sessions at once, then needing `extension connect` and a ~30s wait before commands work again.

Repro: drive a session, then leave it idle ~30–60s, then issue any command → empty/hang; `chrome-use extension connect` reports *"extension relay reconnecting (the worker wakes ~every 30s)"*.

## Fix

While a port is open, post a tiny `ping` every **20s**. A native-messaging port message resets the worker's idle timer, so the worker stays alive the whole time we're paired and the relay never goes cold on the hot path.

- The `setTimeout` chain lives exactly as long as the worker — which the ping guarantees — so it's self-sustaining while paired.
- On a genuine cold restart, the existing alarm re-runs `connectHost()`, which restarts the loop. The alarm is kept purely as that **cold-restart backstop**, with a comment explaining it can't be the primary keeper because of the clamp.

## Changes
- `background.js`: add `scheduleKeepalivePing()`; start it on connect and from the alarm handler.
- `manifest.json`: bump `0.5.1` → `0.5.2` so `doctor` can tell the build apart.

## Notes
- No new permissions (`alarms` already present; this leans on the existing native port).
- `node --check` passes; define-before-runtime-use ordering verified (consts/fn are initialized before `connectHost()` runs).
- The host already has a `ping`/`pong` path, so the extra ping is handled (or harmlessly ignored); the *send* is what resets the idle timer regardless.