### PR TITLE
fix(session): eval --frame, reconnect alias, actionable stale-target errors, concurrency docs (#58)

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1334,6 +1334,24 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         // === Eval ===
         "eval" => {
+            // Optional leading `--frame <selector|url|index>` (issue #58): run the
+            // script in that frame's context instead of the main frame. Default
+            // (no flag) stays the main frame. Leading-only so it never eats a token
+            // from the script body.
+            let mut frame: Option<String> = None;
+            let rest: Vec<&str> = if rest.first() == Some(&"--frame") {
+                let val = rest.get(1).copied().ok_or(ParseError::InvalidValue {
+                    message: "eval --frame requires a value (CSS selector, @ref, url substring, \
+                              or frame index)"
+                        .to_string(),
+                    usage: "eval --frame <selector|url|index> <js>",
+                })?;
+                frame = Some(val.to_string());
+                rest[2..].to_vec()
+            } else {
+                rest.clone()
+            };
+
             // Check for flags: -b/--base64, --stdin, or --file <path>
             let (is_base64, is_stdin, is_file, script_parts): (bool, bool, bool, &[&str]) =
                 if rest.first() == Some(&"-b") || rest.first() == Some(&"--base64") {
@@ -1385,7 +1403,11 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     raw_script
                 }
             };
-            Ok(json!({ "id": id, "action": "evaluate", "script": script }))
+            let mut action = json!({ "id": id, "action": "evaluate", "script": script });
+            if let Some(f) = frame {
+                action["frame"] = Value::String(f);
+            }
+            Ok(action)
         }
 
         "site" => {
@@ -5298,6 +5320,41 @@ mod tests {
         let cmd = parse_command(&args("eval document.title"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "evaluate");
         assert_eq!(cmd["script"], "document.title");
+    }
+
+    #[test]
+    fn test_eval_no_frame_field_by_default() {
+        let cmd = parse_command(&args("eval document.title"), &default_flags()).unwrap();
+        assert!(cmd.get("frame").is_none());
+    }
+
+    #[test]
+    fn test_eval_frame_flag() {
+        let cmd = parse_command(
+            &args("eval --frame accounts.google.com location.href"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "evaluate");
+        assert_eq!(cmd["frame"], "accounts.google.com");
+        assert_eq!(cmd["script"], "location.href");
+    }
+
+    #[test]
+    fn test_eval_frame_flag_with_index_and_base64() {
+        // --frame composes with the source flags; index value preserved verbatim.
+        let cmd = parse_command(
+            &args("eval --frame 2 -b ZG9jdW1lbnQudGl0bGU="),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["frame"], "2");
+        assert_eq!(cmd["script"], "document.title");
+    }
+
+    #[test]
+    fn test_eval_frame_flag_requires_value() {
+        assert!(parse_command(&args("eval --frame"), &default_flags()).is_err());
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -993,6 +993,16 @@ fn main() {
         return;
     }
 
+    // `reconnect` is a friendly alias for `extension connect` (issue #58): re-bind
+    // the session to the running Chrome's relay without any reinstall. Rewrite it
+    // into `extension connect …` (preserving any flags like --silent) and let the
+    // block below handle it.
+    if clean.first().map(|s| s.as_str()) == Some("reconnect") {
+        let mut rebuilt = vec!["extension".to_string(), "connect".to_string()];
+        rebuilt.extend(clean.into_iter().skip(1));
+        clean = rebuilt;
+    }
+
     // Handle extension: native-messaging host install/status, and
     // `extension connect` which attaches to the live relay (auto-discovers the
     // CDP url the host wrote) by rewriting into the normal `connect <url>` flow.

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2794,9 +2794,162 @@ async fn handle_evaluate(cmd: &Value, state: &DaemonState) -> Result<Value, Stri
         .and_then(|v| v.as_str())
         .ok_or("Missing 'script' parameter")?;
 
-    let result = mgr.evaluate(script, None).await?;
+    // `--frame <index|url-substring|@ref|css-selector>` (issue #58): run in that
+    // frame's context instead of the main frame. No flag → main frame (unchanged).
+    let result = match cmd.get("frame").and_then(|v| v.as_str()) {
+        Some(spec) => {
+            let frame_id =
+                resolve_frame_spec(mgr, &state.ref_map, &state.iframe_sessions, spec).await?;
+            mgr.evaluate_in_frame(script, &frame_id, &state.iframe_sessions)
+                .await?
+        }
+        None => mgr.evaluate(script, None).await?,
+    };
     let url = mgr.get_url().await.unwrap_or_default();
     Ok(json!({ "result": result, "origin": url }))
+}
+
+/// Resolve an `eval --frame` spec to a frameId. Accepts (in precedence order):
+/// a numeric index into `chrome-use frames`, an `@ref`/CSS selector pointing at an
+/// `<iframe>`, or a URL substring matched against the live frame list.
+async fn resolve_frame_spec(
+    mgr: &BrowserManager,
+    ref_map: &super::element::RefMap,
+    iframe_sessions: &HashMap<String, String>,
+    spec: &str,
+) -> Result<String, String> {
+    let session_id = mgr.active_session_id()?.to_string();
+
+    // 1. Numeric index into the `frames` listing.
+    if let Ok(idx) = spec.parse::<usize>() {
+        let frames =
+            super::element::collect_all_frames_text(&mgr.client, &session_id, iframe_sessions)
+                .await?;
+        return frames.get(idx).map(|f| f.frame_id.clone()).ok_or_else(|| {
+            format!(
+                "eval --frame {idx}: only {} frame(s) present (see `chrome-use frames`)",
+                frames.len()
+            )
+        });
+    }
+
+    // 2. @ref or CSS selector pointing at an <iframe>/<frame> element.
+    let looks_like_selector = super::element::parse_ref(spec).is_some()
+        || spec.starts_with('#')
+        || spec.starts_with('.')
+        || spec.starts_with('[');
+    if looks_like_selector {
+        if let Some(frame_id) = resolve_iframe_selector(mgr, ref_map, &session_id, spec).await? {
+            return Ok(frame_id);
+        }
+    }
+
+    // 3. URL substring against the live frame list.
+    let frames =
+        super::element::collect_all_frames_text(&mgr.client, &session_id, iframe_sessions).await?;
+    if let Some(f) = frames.iter().find(|f| f.url.contains(spec)) {
+        return Ok(f.frame_id.clone());
+    }
+
+    // Fall back to selector resolution for anything not yet matched (covers a bare
+    // tag selector like `iframe` that didn't trip the heuristic above).
+    if let Some(frame_id) = resolve_iframe_selector(mgr, ref_map, &session_id, spec).await? {
+        return Ok(frame_id);
+    }
+
+    Err(format!(
+        "eval --frame: no frame matched '{spec}' (try an index from `chrome-use frames`, a URL \
+         substring, or an iframe @ref/CSS selector)"
+    ))
+}
+
+/// Resolve a `<iframe>`/`<frame>` element (by `@ref` or CSS selector) to the
+/// frameId of the document it hosts. Returns `Ok(None)` when the selector matches
+/// nothing or a non-frame element, so the caller can fall through to other specs.
+async fn resolve_iframe_selector(
+    mgr: &BrowserManager,
+    ref_map: &super::element::RefMap,
+    session_id: &str,
+    selector: &str,
+) -> Result<Option<String>, String> {
+    let backend_node_id = if let Some(ref_id) = super::element::parse_ref(selector) {
+        match ref_map.get(&ref_id).and_then(|e| e.backend_node_id) {
+            Some(bid) => bid,
+            None => return Ok(None),
+        }
+    } else {
+        let js = format!(
+            "(() => {{ const el = document.querySelector({}); return el ? 1 : 0; }})()",
+            serde_json::to_string(selector).unwrap_or_default()
+        );
+        if mgr.evaluate(&js, None).await?.as_i64() != Some(1) {
+            return Ok(None);
+        }
+        let resolved: Value = mgr
+            .client
+            .send_command(
+                "DOM.getDocument",
+                Some(json!({ "depth": 0 })),
+                Some(session_id),
+            )
+            .await?;
+        let root = resolved
+            .get("root")
+            .and_then(|r| r.get("nodeId"))
+            .and_then(|v| v.as_i64())
+            .ok_or("DOM.getDocument returned no root")?;
+        let q: Value = mgr
+            .client
+            .send_command(
+                "DOM.querySelector",
+                Some(json!({ "nodeId": root, "selector": selector })),
+                Some(session_id),
+            )
+            .await?;
+        let node_id = q.get("nodeId").and_then(|v| v.as_i64()).unwrap_or(0);
+        if node_id == 0 {
+            return Ok(None);
+        }
+        let desc: Value = mgr
+            .client
+            .send_command(
+                "DOM.describeNode",
+                Some(json!({ "nodeId": node_id })),
+                Some(session_id),
+            )
+            .await?;
+        match desc
+            .get("node")
+            .and_then(|n| n.get("backendNodeId"))
+            .and_then(|v| v.as_i64())
+        {
+            Some(bid) => bid,
+            None => return Ok(None),
+        }
+    };
+
+    let describe: Value = mgr
+        .client
+        .send_command(
+            "DOM.describeNode",
+            Some(json!({ "backendNodeId": backend_node_id, "depth": 1 })),
+            Some(session_id),
+        )
+        .await?;
+    let node = describe.get("node");
+    let node_name = node
+        .and_then(|n| n.get("nodeName"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if node_name != "IFRAME" && node_name != "FRAME" {
+        return Ok(None);
+    }
+    Ok(node
+        .and_then(|n| n.get("contentDocument"))
+        .and_then(|cd| cd.get("frameId"))
+        .and_then(|v| v.as_str())
+        .or_else(|| node.and_then(|n| n.get("frameId")).and_then(|v| v.as_str()))
+        .map(|s| s.to_string()))
 }
 
 /// Run a site adapter: navigate to its `@meta.domain` (only if we're not already

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -370,6 +370,20 @@ fn is_stale_target_error(error: &str) -> bool {
 /// Converts common error messages into AI-friendly, actionable descriptions.
 pub fn to_ai_friendly_error(error: &str) -> String {
     let lower = error.to_lowercase();
+    // A read (snapshot/screenshot/eval/get) hit a session whose target is gone —
+    // typically a cross-process navigation like an OAuth redirect (issue #58).
+    // `navigate` auto-reattaches, but reads deliberately fail loudly rather than
+    // silently retarget onto the wrong tab (#8.1). The raw CDP text ("stale
+    // sessionId … its tab is gone") tells the agent nothing actionable, so spell
+    // out the recovery instead.
+    if is_stale_target_error(error) {
+        return "the tab this command was driving is gone — it navigated across processes (e.g. \
+                an OAuth/SSO redirect), was closed, or the relay lost it. The session did NOT \
+                silently retarget, since that could read or click the wrong tab. Recover by \
+                re-placing the page yourself: `open <url>` / `navigate <url>` re-attaches to a \
+                fresh tab, or `adopt <url-substring>` the tab you want — then re-`snapshot`."
+            .to_string();
+    }
     if lower.contains("strict mode violation") {
         return "Element matched multiple results. Use a more specific selector.".to_string();
     }
@@ -1477,7 +1491,57 @@ impl BrowserManager {
 
     pub async fn evaluate(&self, script: &str, _args: Option<Value>) -> Result<Value, String> {
         let session_id = self.active_session_id()?.to_string();
+        self.eval_in_context(script, &session_id, None).await
+    }
 
+    /// Evaluate `script` in a specific frame's context (issue #58 `eval --frame`).
+    ///
+    /// - **Out-of-process iframe** (cross-origin; has its own auto-attached session
+    ///   in `iframe_sessions`): run on that session, which lands in the frame's own
+    ///   **main world** — exactly what you want for a cross-origin embed like a
+    ///   Google account-picker.
+    /// - **Same-process (in-page) frame**: there is no stealth-safe way to reach the
+    ///   frame's main world without `Runtime.enable`, so we run in a per-call
+    ///   **isolated world** via `Page.createIsolatedWorld`. The DOM is fully
+    ///   readable there, but page JS globals are not visible (same trade-off
+    ///   `get text --all-frames` already makes).
+    pub async fn evaluate_in_frame(
+        &self,
+        script: &str,
+        frame_id: &str,
+        iframe_sessions: &HashMap<String, String>,
+    ) -> Result<Value, String> {
+        if let Some(oopif_session) = iframe_sessions.get(frame_id) {
+            return self.eval_in_context(script, oopif_session, None).await;
+        }
+
+        let session_id = self.active_session_id()?.to_string();
+        let ctx: Value = self
+            .client
+            .send_command(
+                "Page.createIsolatedWorld",
+                Some(json!({ "frameId": frame_id, "worldName": "chrome_use_eval" })),
+                Some(&session_id),
+            )
+            .await?;
+        let ctx_id = ctx
+            .get("executionContextId")
+            .and_then(|c| c.as_i64())
+            .ok_or_else(|| {
+                format!("Could not resolve an execution context for frame {frame_id}")
+            })?;
+        self.eval_in_context(script, &session_id, Some(ctx_id))
+            .await
+    }
+
+    /// Shared core of `eval`: build the `Runtime.evaluate` params, send on the
+    /// given session (optionally pinned to `context_id`), and unwrap the result.
+    async fn eval_in_context(
+        &self,
+        script: &str,
+        session_id: &str,
+        context_id: Option<i64>,
+    ) -> Result<Value, String> {
         // `replMode: true` lets successive `eval`s re-declare top-level
         // `let`/`const` instead of throwing "Identifier 'x' has already been
         // declared" (issue #38 — independent `eval` steps in a test suite collided
@@ -1493,18 +1557,23 @@ impl BrowserManager {
             || script.contains("Promise");
         let declares = script.contains("let ") || script.contains("const ");
         let repl_mode = declares && !mentions_async;
+        let mut params = json!({
+            "expression": script,
+            "returnByValue": true,
+            "awaitPromise": !repl_mode,
+            "replMode": repl_mode,
+        });
+        if let Some(cid) = context_id {
+            // `contextId` and `replMode` are mutually exclusive in Chrome; when we
+            // pin a frame context, drop replMode (a fresh isolated world per call
+            // can't collide on re-declared top-level bindings anyway).
+            params["replMode"] = json!(false);
+            params["awaitPromise"] = json!(true);
+            params["contextId"] = json!(cid);
+        }
         let result: EvaluateResult = self
             .client
-            .send_command_typed(
-                "Runtime.evaluate",
-                &json!({
-                    "expression": script,
-                    "returnByValue": true,
-                    "awaitPromise": !repl_mode,
-                    "replMode": repl_mode,
-                }),
-                Some(&session_id),
-            )
+            .send_command_typed("Runtime.evaluate", &params, Some(session_id))
             .await?;
 
         if let Some(ref details) = result.exception_details {
@@ -3669,6 +3738,20 @@ mod tests {
     fn test_to_ai_friendly_error_unknown() {
         let msg = "Some custom error message";
         assert_eq!(to_ai_friendly_error(msg), msg);
+    }
+
+    #[test]
+    fn test_to_ai_friendly_error_stale_target_is_actionable() {
+        // The cryptic relay/CDP stale-target text (issue #58) becomes recovery
+        // guidance: re-open/navigate/adopt, and an explicit note that we did NOT
+        // silently retarget (preserving the #8.1 safety contract).
+        let raw = "CDP error (Page.captureScreenshot): stale sessionId cb-tab-123 for \
+                   Page.captureScreenshot — its tab is gone (closed, navigated across processes)";
+        let m = to_ai_friendly_error(raw);
+        assert!(m.contains("navigated across processes"));
+        assert!(m.contains("open <url>") && m.contains("adopt"));
+        assert!(m.contains("did NOT") || m.contains("not silently"));
+        assert_ne!(m, raw, "should rewrite the cryptic CDP text");
     }
 
     /// Errors containing "not found" but NOT "element" should pass through unchanged.

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2022,9 +2022,19 @@ Usage: chrome-use eval [options] <script>
 
 Executes JavaScript code in the browser context and returns the result.
 
+Runs in the MAIN frame by default. Use --frame to target a child frame's
+context (see `chrome-use frames` for the index/url list).
+
 Options:
   -b, --base64         Decode script from base64 (avoids shell escaping issues)
   --stdin              Read script from stdin (useful for heredocs/multiline)
+  --file <path>        Read script from a file (verbatim UTF-8; no shell mangling)
+  --frame <f>          Run in a child frame instead of the main frame. <f> is a
+                       frame index (from `chrome-use frames`), a URL substring, or
+                       an iframe @ref/CSS selector. Cross-origin (out-of-process)
+                       frames run in their own MAIN world; same-process in-page
+                       frames run in an isolated world (DOM visible, page globals
+                       not).
 
 Global Options:
   --json               Output as JSON
@@ -2035,6 +2045,8 @@ Examples:
   chrome-use eval "window.location.href"
   chrome-use eval "document.querySelectorAll('a').length"
   chrome-use eval -b "ZG9jdW1lbnQudGl0bGU="
+  chrome-use eval --frame accounts.google.com "location.href"  # into a child frame
+  chrome-use eval --frame 1 "document.body.innerText"          # frame #1 from `frames`
 
   # Read from stdin with heredoc
   cat <<'EOF' | chrome-use eval --stdin
@@ -3326,6 +3338,8 @@ Core Commands:
   snapshot                   Accessibility tree with refs (for AI)
   eval <js>                  Run JavaScript
   connect <port|url>         Connect to browser via CDP
+  reconnect                  Re-bind to the running Chrome's relay (alias for
+                             `extension connect`) — recover a dropped relay, no reinstall
   keep                       Leave the active tab for the user — exempt it from
                              auto-close/idle cleanup + remove it from the session
                              tab group (so scratch tabs get cleaned, this one stays)

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -152,11 +152,30 @@ most drops you never even see. If a command *does* surface the error:
 3. **Never** tell the user to quit/restart Chrome with `--remote-debugging-port`
    to recover a dropped relay — that throws away their tabs and defeats the
    extension path. (The old error text said this; it no longer does.)
-4. **Can't restore the browser at all?** Don't stall waiting for a screenshot —
+4. `chrome-use reconnect` is a friendly alias for `extension connect` — re-binds
+   the session to the running Chrome without any reinstall.
+
+> **Don't serialize agents to dodge fragility.** Relay drops are transient and
+> self-heal; they are *not* a sign that the shared browser can't be driven
+> concurrently. Concurrent multi-agent **is** supported — each `--session` gets
+> its own tab group and drives only its own tabs (see *Strict multi-agent
+> isolation* below). Give each agent a distinct `--session` and let them run in
+> parallel; you don't need to run them one at a time.
+5. **Can't restore the browser at all?** Don't stall waiting for a screenshot —
    **fall back to non-visual verification**: `get text` / `eval` / read the
    deployed page over `curl`/`WebFetch`. Confirming a change via the DOM/HTML or
    the live URL is a *correct* result, not a failure. Reserve screenshots for a
    genuine visual check you report to the user.
+
+> **After an OAuth/SSO redirect, a read may fail "its tab is gone / stale
+> sessionId".** A login handoff (GitHub/Google OAuth, SSO) navigates the tab
+> *across processes*, which orphans the old session. `navigate`/`open`
+> auto-reattach, but reads (`snapshot`/`screenshot`/`eval`/`get`) deliberately
+> **fail loudly** rather than silently retarget onto the wrong tab. Recovery is
+> what the error now tells you: re-`open <url>` / `navigate <url>` the page (it
+> re-attaches to a fresh tab), or `adopt <url-substring>` the post-redirect tab,
+> then re-`snapshot`. Don't treat the stale error as fatal — it's a one-command
+> recovery.
 
 Each `--session` that connects gets its **own colored Chrome tab group** (named
 after the session) and drives only its own tabs — multiple agents share the one
@@ -374,6 +393,14 @@ So: when text looks missing or wrong, you don't have to guess — just
 holds what), run `chrome-use frames`. To **cut boilerplate** (global nav/header/
 footer, "related items" sidebars), use `chrome-use get text --main`. If content
 is lazy-loaded, `scroll` it into view first, then read.
+
+**`eval` runs in the MAIN frame by default.** It does not silently bind to
+whichever frame Chrome returns — a bare `eval` always targets the top document.
+To run inside a child frame (e.g. a cross-origin Google account-picker), pass
+`--frame <index|url-substring|@ref|css-selector>` (indices/urls come from
+`chrome-use frames`): `eval --frame accounts.google.com "location.href"`.
+Cross-origin (out-of-process) frames run in their own **main world**; same-process
+in-page frames run in an **isolated world** (DOM readable, page JS globals not).
 
 **Closed shadow DOM.** Some injected UI (browser-extension debug panels, web
 components) renders into a *closed* shadow root that `eval`/`innerText` cannot


### PR DESCRIPTION
Addresses the session-fragility rough edges in #58. The relay idle-drop **root cause (#58.1)** already landed via #59 (MV3 20s keepalive ping); this PR adds the complementary, **safe + verifiable** pieces and improves the docs.

## #58.3 — `eval --frame <index|url|@ref|css>`
eval still defaults to the **main frame** and never silently binds to a subframe. To target a child frame deterministically:

```
chrome-use eval --frame accounts.google.com "location.href"   # by url substring
chrome-use eval --frame 1 "document.body.innerText"           # by index (chrome-use frames)
chrome-use eval --frame "#kid" "..."                          # by @ref / css selector
```

- **Cross-origin (out-of-process)** frames run in their own **MAIN world** via the frame's own session — the exact case the issue hit with Google's nested account-picker.
- **Same-process in-page** frames run in an **isolated world** (DOM readable, page JS globals not), mirroring `get text --all-frames`.
- No match → loud, actionable error.

Verified live against a parent+child iframe repro: main-frame default, and `--frame` by index / url / @ref / selector all resolve correctly; no-match fails loudly.

## #58.1 — `chrome-use reconnect`
Friendly alias for `extension connect` — re-binds the session to the running Chrome's relay with no reinstall. (The transient auto-retry + ~25s relay self-heal already exist; #59 fixes the underlying MV3 idle-drop.)

## #58.2 — actionable stale-target errors (safe part; full auto-reattach deferred)
A read orphaned by a **cross-process navigation** (OAuth/SSO redirect) used to surface the cryptic `stale sessionId … its tab is gone`. It now routes through `to_ai_friendly_error` into a clear recovery path (re-`open`/`navigate`, or `adopt`), **while still failing loudly rather than silently retargeting** onto the wrong tab — preserving the #8.1 / #52 read-safety contract.

> **Deliberately deferred:** truly *auto*-reattaching the active page to the post-nav target. `update_page_target_info` matches by `target_id`, but a cross-process nav produces a **new** target_id, so recovery requires matching it back to the same tab via relay-internal keys. That needs a live relay+OAuth repro to verify safely; a blind change risks the shipped #52/#8.1 + debounced-prune safety. Happy to pair on it with a live repro.

## #58.4 — docs
Core skill now: states concurrent multi-agent **is** supported (don't serialize agents to dodge transient relay drops), documents `reconnect`, `eval --frame`, and the OAuth stale-read recovery.

## Tests
Parse tests for `eval --frame` (incl. compose-with-`-b`, missing-value error), a stale-error-guidance test, eval main-frame-default test. Full suite green (`cargo fmt` + `clippy` clean).