### PR TITLE
feat(relay): report which Chrome profile the relay is driving (#60)

### DIFF
--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -159,6 +159,7 @@ pub fn run_connect(args: &[String], json: bool) {
     let relay_url = relay_url();
     let live_extension_version = relay_ext_version();
     let expected_extension_version = env!("AB_CONNECT_VERSION");
+    let driving_profile = relay_ext_profile();
     if json {
         println!(
             "{}",
@@ -179,6 +180,8 @@ pub fn run_connect(args: &[String], json: bool) {
                     "relayUp": relay_url.is_some(),
                     "relayUrl": relay_url,
                     "chromeExtension": extension_status,
+                    "drivingProfileId": driving_profile.as_ref().map(|(id, _)| id.clone()),
+                    "drivingProfileEmail": driving_profile.as_ref().and_then(|(_, e)| e.clone()),
                 }
             }))
             .unwrap_or_default()
@@ -201,6 +204,20 @@ pub fn run_connect(args: &[String], json: bool) {
             println!("✓ extension relay (__nm-host): up");
         } else {
             println!("  extension relay (__nm-host): not currently connected");
+        }
+        // Which Chrome profile is the relay bound to (issue #60). With many
+        // profiles, this disambiguates a "logged out" result (wrong profile vs.
+        // genuinely not logged in).
+        match &driving_profile {
+            Some((id, Some(email))) => println!("✓ driving Chrome profile: {email} ({id})"),
+            Some((id, None)) => println!(
+                "✓ driving Chrome profile id: {id} \
+                 (grant the extension the optional `identity` permission to also see the email)"
+            ),
+            None => println!(
+                "  driving Chrome profile: unknown (extension predates profile reporting, or \
+                 hasn't sent hello yet)"
+            ),
         }
         if let Some(status) = extension_status {
             print_chrome_extension_status(&status, expected_extension_version);
@@ -780,6 +797,42 @@ pub fn relay_ext_version() -> Option<String> {
     }
 }
 
+/// Sidecar recording WHICH Chrome profile the relay is bound to, written by the
+/// host from the extension's `hello` (issue #60). With many profiles, "logged
+/// out" on a site is otherwise indistinguishable from "wrong profile entirely" —
+/// this lets `doctor`/`extension status` name the driving profile. Sibling of
+/// `relay-cdp-url`.
+fn relay_ext_profile_path() -> PathBuf {
+    relay_url_path().with_file_name("relay-ext-profile")
+}
+
+/// The Chrome profile the relay is currently driving, as `(id, email)` learned
+/// from the extension's `hello`. `id` is a stable per-profile UUID (always
+/// present on a new-enough extension); `email` is the signed-in account, only
+/// present when the profile granted the optional `identity` permission. `None`
+/// when no profile-aware extension has connected yet.
+pub fn relay_ext_profile() -> Option<(String, Option<String>)> {
+    let s = std::fs::read_to_string(relay_ext_profile_path()).ok()?;
+    parse_ext_profile(&s)
+}
+
+/// Parse the `relay-ext-profile` sidecar JSON into `(id, email)`. Pure, so the
+/// shape can be unit-tested without touching the filesystem. Returns `None` when
+/// the id is absent/blank; an empty/missing email becomes `None`.
+fn parse_ext_profile(s: &str) -> Option<(String, Option<String>)> {
+    let v: serde_json::Value = serde_json::from_str(s.trim()).ok()?;
+    let id = v.get("id").and_then(|x| x.as_str())?.trim().to_string();
+    if id.is_empty() {
+        return None;
+    }
+    let email = v
+        .get("email")
+        .and_then(|x| x.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    Some((id, email))
+}
+
 /// Hidden `__nm-host` mode: launched by Chrome for the ab-connect extension.
 ///
 /// Bridges the extension (native-messaging stdio, envelope protocol) to a local
@@ -908,6 +961,15 @@ async fn nm_host_main() {
             if let Some(ver) = v.get("version").and_then(|x| x.as_str()) {
                 let _ = std::fs::write(relay_ext_version_path(), ver);
             }
+            // Record which profile is driving (issue #60), if the extension
+            // reported one. Stored as JSON so `email` can be added when present.
+            if let Some(id) = v.get("profileId").and_then(|x| x.as_str()) {
+                let rec = serde_json::json!({
+                    "id": id,
+                    "email": v.get("profileEmail").and_then(|x| x.as_str()),
+                });
+                let _ = std::fs::write(relay_ext_profile_path(), rec.to_string());
+            }
             continue;
         }
         let outs = {
@@ -943,6 +1005,7 @@ async fn nm_host_main() {
     nm_log("[nm-host] stdin EOF — Chrome closed the port");
     let _ = std::fs::remove_file(relay_url_path());
     let _ = std::fs::remove_file(relay_ext_version_path());
+    let _ = std::fs::remove_file(relay_ext_profile_path());
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1026,6 +1089,33 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::path::Path;
+
+    #[test]
+    fn parse_ext_profile_reads_id_and_optional_email() {
+        // id + email present
+        assert_eq!(
+            parse_ext_profile(r#"{"id":"uuid-1","email":"me@example.com"}"#),
+            Some(("uuid-1".to_string(), Some("me@example.com".to_string())))
+        );
+        // id only (no identity permission) → email None
+        assert_eq!(
+            parse_ext_profile(r#"{"id":"uuid-2","email":null}"#),
+            Some(("uuid-2".to_string(), None))
+        );
+        assert_eq!(
+            parse_ext_profile(r#"{"id":"uuid-3"}"#),
+            Some(("uuid-3".to_string(), None))
+        );
+        // blank email is treated as absent
+        assert_eq!(
+            parse_ext_profile(r#"{"id":"uuid-4","email":"  "}"#),
+            Some(("uuid-4".to_string(), None))
+        );
+        // missing/blank id → None; malformed → None
+        assert_eq!(parse_ext_profile(r#"{"email":"x@y.z"}"#), None);
+        assert_eq!(parse_ext_profile(r#"{"id":"   "}"#), None);
+        assert_eq!(parse_ext_profile("not json"), None);
+    }
 
     #[test]
     fn store_url_points_at_the_published_store_build_not_the_dev_id() {

--- a/cli/src/doctor/versions.rs
+++ b/cli/src/doctor/versions.rs
@@ -75,6 +75,28 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         }
     }
 
+    // Driving Chrome profile — with many profiles, the relay binds to whichever
+    // profile's extension worker connected; naming it disambiguates a "logged
+    // out" result (wrong profile vs. genuinely not logged in) (issue #60).
+    match connect::relay_ext_profile() {
+        Some((id, Some(email))) => checks.push(Check::new(
+            "relay.profile",
+            category,
+            Status::Info,
+            format!("driving Chrome profile: {email} ({id})"),
+        )),
+        Some((id, None)) => checks.push(Check::new(
+            "relay.profile",
+            category,
+            Status::Info,
+            format!(
+                "driving Chrome profile id: {id} (grant the extension's optional `identity` \
+                 permission to also see the account email)"
+            ),
+        )),
+        None => {}
+    }
+
     // Skill — ships inside the same release artifact as the binary, so it's
     // version-locked here. Copies made elsewhere via `skills add` aren't.
     checks.push(Check::new(

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -110,6 +110,40 @@ async function tabScopeHints(tabId) {
   return { openerTargetId, abGroup }
 }
 
+// Resolve a stable identifier for the Chrome profile this worker runs in, for
+// the `hello` handshake (issue #60). `profileId` is a UUID minted once and kept
+// in this profile's chrome.storage.local — distinct per profile, no permission
+// needed. `profileEmail` is included only when the optional `identity` permission
+// is present and the profile is signed in; otherwise it's omitted (never throws).
+async function buildHelloIdentity() {
+  const extra = {}
+  try {
+    const KEY = 'ab_profile_id'
+    const got = await chrome.storage.local.get(KEY)
+    let id = got && got[KEY]
+    if (!id) {
+      id =
+        (crypto && crypto.randomUUID && crypto.randomUUID()) ||
+        'p-' + Math.abs(Date.now()).toString(36)
+      await chrome.storage.local.set({ [KEY]: id })
+    }
+    extra.profileId = id
+  } catch {}
+  try {
+    if (chrome.identity && chrome.identity.getProfileUserInfo) {
+      const info = await new Promise((resolve) => {
+        try {
+          chrome.identity.getProfileUserInfo({ accountStatus: 'ANY' }, resolve)
+        } catch {
+          resolve(null)
+        }
+      })
+      if (info && info.email) extra.profileEmail = info.email
+    }
+  } catch {}
+  return extra
+}
+
 function postToHost(msg) {
   try {
     if (port) port.postMessage(msg)
@@ -230,12 +264,23 @@ function connectHost() {
     // reconnect. Keep chrome.debugger attached so reconnect is cheap.
     for (const tabId of tabs.keys()) setBadge(tabId, 'connecting')
   })
-  // Report our version so the host can tell the CLI/`doctor` which extension
-  // build is live (otherwise the extension version is a black box — the user
-  // can't tell they're on an old one). Best-effort; ignored by older hosts.
-  try {
-    postToHost({ method: 'hello', version: chrome.runtime.getManifest().version })
-  } catch {}
+  // Report our version + a stable per-profile id so the host can tell the
+  // CLI/`doctor` which extension build is live AND which Chrome profile the relay
+  // is bound to. With many profiles, "logged out" on a site is otherwise
+  // indistinguishable from "wrong profile" — the id removes that ambiguity
+  // (issue #60). The id is a UUID persisted in this profile's chrome.storage.local
+  // (no extra permission). If the profile is signed into Chrome AND the optional
+  // `identity` permission is granted, we also include the account email; absent
+  // that, email is simply omitted. Best-effort; ignored by older hosts.
+  void buildHelloIdentity().then((extra) => {
+    try {
+      postToHost({
+        method: 'hello',
+        version: chrome.runtime.getManifest().version,
+        ...extra,
+      })
+    } catch {}
+  })
   // Tell the daemon about everything we already have attached, then attach
   // anything new.
   void reannounceAttachedTabs()

--- a/extensions/ab-connect/manifest.json
+++ b/extensions/ab-connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "chrome-use",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Let chrome-use drive your logged-in Chrome \u2014 install once, no token, no per-use confirmation.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6vQIyscGIPYPZdSpPwPL0+0gxUROyRgCpmvCSDoc8XUm4qm97VbKnD9Ijc1lV22lNWZtE78gaRjt6BeSfuMgnBymnhLKjN1gU6AI5QUU0mrJyeHdWKvrKQR5FmsM2A7Xr1ykE2SiiS8zNUS3Y/6O5l+Nva7wrVy6E4a2dkBVQkOsu+DV+nEZvhIyuDY5D5SPXqNwUTWTaglwj5mjvHz36xSwCWlPmrtJ+ED0AUyrb2z4GIOmvk4kqtBVrh/UD058klLo4CkYOnIybB5aV6WYuwarfPY4bF/dLggPem+ewLNTUNBuwrxj/A4nUv0LJTuRO8rR7f8WR9qnRCY0Ic5saQIDAQAB",
   "icons": {

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -109,6 +109,14 @@ popup never fires. `chrome-use extension connect` is the explicit form of the
 same path. Zero-confirmation, zero-token. Use `--launch` instead when a fresh,
 isolated browser is fine.
 
+> **Many Chrome profiles? Check which one you're driving.** The relay binds to
+> whichever profile's extension worker is talking to the native host. If a site
+> comes back logged out, confirm it's the right profile before assuming the login
+> is gone: `chrome-use extension status` (or `doctor`) now reports the **driving
+> Chrome profile** — the account email if the extension has the optional
+> `identity` permission, otherwise a stable per-profile id. A logged-out result
+> on the *wrong* profile is not a missing login.
+
 `--launch` opens an **isolated, empty test profile** — no cookies, no login, no
 extensions (so the extension-relay path is off). Its window is labelled
 `chrome-use (<session>)` in Chrome's profile menu so a human watching the


### PR DESCRIPTION
Ships the **observability** half of #60 — the part the issue flagged as "small, high value." (Profile *selection* / `--browser` is a larger architectural change; see below.)

## Problem
With many Chrome profiles, the relay binds to whichever profile's extension worker is talking to the native host, and there was **no way to see which**. A "logged out" site result was indistinguishable from "right profile, genuinely not logged in" vs "wrong profile entirely."

## What ships
- **Extension**: `hello` now carries a stable per-profile **`profileId`** — a UUID kept in that profile's `chrome.storage.local`, **no new permission**. Also `profileEmail` *when* the optional `identity` permission is present and the profile is signed in (omitted otherwise, never throws).
- **Host**: records it next to the relay url (`relay-ext-profile`), cleared on disconnect.
- **`extension status`** (text + `--json`) and **`doctor`** now report the driving profile: the email when known, else the id + a hint that `identity` unlocks the email.
- **Skill**: "many profiles? check which one you're driving before assuming a login is gone."

manifest `0.5.2 → 0.5.3`. Pure parse helper unit-tested (`parse_ext_profile`).

## Notes
- The extension half reaches users only after a **Web Store republish** (same as #59). The CLI reporting ships in the next CLI release.
- No new permission by default; the email is opt-in via `identity` (which would need a re-review/re-consent), so it's strictly additive.

## Deferred (separate, larger) — profile selection
`--browser <id>` / a `switch`-browser command to *pin* a session to a chosen profile. The relay is a single native-host connection, so letting a session choose among several connected profiles is an architectural change (multi-host routing), not an add-on. Filed mentally as the follow-up; happy to scope it next.