### PR TITLE
docs(skill): how to interact with canvas + closed-shadow UIs (#53)

### DIFF
--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -406,7 +406,27 @@ in-page frames run in an **isolated world** (DOM readable, page JS globals not).
 components) renders into a *closed* shadow root that `eval`/`innerText` cannot
 read. `chrome-use get text --pierce` reads through closed shadow roots and child
 documents via the CDP DOM tree — use it when content is clearly on screen (you
-see it in a screenshot) but `get text`/`eval` come back empty.
+see it in a screenshot) but `get text`/`eval` come back empty. Good news for
+*clicking*: `snapshot -i` is built from the accessibility tree, which **already
+pierces closed shadow roots** — a closed-shadow `<button>` / `[role=button]`
+shows up as a normal `@ref`. So shadow-rendered controls with a11y semantics are
+clickable the usual way; only a bare non-semantic clickable `<div>` inside a
+*closed* root can slip past both the AX tree and the cursor-element scan.
+
+**Canvas / WebGL UIs (game boards, voice-room mic seats, map tiles, design
+canvases).** These paint to a `<canvas>` — there is **no DOM node and no
+accessibility node** behind what you see, so `snapshot`/`find`/`eval
+querySelector` will never return a ref for them. This is a hard limitation, not a
+missing feature. To work with them:
+- **Read** the rendered pixels with `chrome-use canvas list` then `chrome-use
+  canvas capture [selector] <file>` (extracts the canvas bitmap), or a normal
+  `screenshot` of the region — then *you* interpret it.
+- **Act** by coordinate: compute the target point and `chrome-use click <x> <y>`
+  (or `box @ref` on a container to get its CSS-px box first). Coordinates are the
+  *correct* tool here — the snapshot-first rule explicitly carves out canvas.
+- On the **relay**, a coordinate click can drift onto the user's foreground tab;
+  prefer a `--launch`/owned tab for heavy canvas coordinate work, or confirm the
+  underlying state via the app's backend/API instead of driving the canvas.
 
 ## Interacting
 


### PR DESCRIPTION
#53: voice-room mic seats (Zego) invisible to `snapshot -i` and DOM queries. I verified the two sub-cases against a repro (closed-shadow button/role-div + a canvas-painted label):

| Case | Reality | In `snapshot -i`? |
|---|---|---|
| **Canvas/WebGL** (the mic-seat case) | painted pixels — **no DOM node, no AX node** | never (hard limitation) |
| **Closed shadow + a11y role** | real element in the a11y tree | **yes** — AX tree already pierces closed shadow → normal `@ref` |
| Bare non-semantic `<div>` in a *closed* root | no role, JS can't reach closed root | no (edge case, noted) |

So the mic-seat case is **canvas → fundamentally not snapshot-addressable**; there's no snapshot code that can surface canvas hit-regions (no node exists). The fix is the guidance the issue explicitly requested ("at minimum, a note in the core skill"):

- **Read** canvas with `canvas capture` / `screenshot`, then interpret.
- **Act** by coordinate (`box @ref` for a container box, then `click <x> <y>`) — the snapshot-first rule already carves out canvas/WebGL.
- Relay coordinate-drift caveat: prefer a `--launch`/owned tab for heavy canvas coordinate work, or verify state via the app's backend.
- Plus: clarified that closed-shadow controls **with** a11y semantics are already clickable via `snapshot -i` (no change needed there).

Docs-only.