### PR TITLE
fix(ab-connect): stop reattach retry storm on permanently-unattachable tabs

### DIFF
--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -336,6 +336,21 @@ function tabIdFromSession(sessionId) {
   return m ? Number(m[1]) : null
 }
 
+// A chrome.debugger.attach failure that will NEVER succeed for this tab, no
+// matter how long we wait: the tab is another extension's page, a chrome:// page,
+// or otherwise off-limits to us. Distinct from the transient "detached mid
+// process-swap" errors (handled in sendCdpToTab), which DO clear on retry — so we
+// match the specific permanent phrases, not a bare "cannot access". Used to bail
+// out of the reattach retry loops instead of burning 6 attempts (and 6 warnings)
+// on a page we can't touch (issue: reattach warning storm on multi-extension
+// Chrome).
+function isPermanentAttachError(e) {
+  const m = String((e && e.message) || e)
+  return /different extension|Cannot access a chrome:\/\/|must request permission|Cannot access contents|Cannot attach to (this|the) target/i.test(
+    m,
+  )
+}
+
 // Ensure the debugger is attached to a `cb-tab-<tabId>` session's tab, re-attaching
 // across the transient window of a process swap (with a couple of short retries).
 // Returns the tabId on success, or null when the tab is genuinely gone
@@ -351,7 +366,10 @@ async function recoverSessionTab(sessionId) {
       try {
         await attachTab(tabId)
         if (tabs.has(tabId)) return tabId
-      } catch {
+      } catch (e) {
+        // Permanently off-limits (other extension's page etc.) — stop the tabId
+        // fast-path and let the stable-targetId path below try a different tab.
+        if (isPermanentAttachError(e)) break
         // mid-swap: tab exists but isn't attachable yet — back off and retry.
       }
       await new Promise((r) => setTimeout(r, 120 + i * 150))
@@ -378,7 +396,10 @@ async function recoverSessionTab(sessionId) {
               sessionToTab.set(sessionId, t.tabId) // alias dead session -> live tab
               return t.tabId
             }
-          } catch {
+          } catch (e) {
+            // The tab hosting our target is a page we can never attach to — no
+            // amount of waiting fixes that, so give up the recovery now.
+            if (isPermanentAttachError(e)) return null
             // not attachable yet — keep waiting for the swap to settle.
           }
         }
@@ -689,6 +710,11 @@ chrome.debugger.onDetach.addListener((source, reason) =>
         await attachTab(tabId)
         return
       } catch (e) {
+        // The tab became a page we can never attach to (another extension's page,
+        // chrome://, restricted). Retrying can't help — bail quietly instead of
+        // logging the same failure 6×. (`eligible()` filters most of these, but a
+        // tab can navigate into one between our check and the attach.)
+        if (isPermanentAttachError(e)) return
         console.warn(`ab-connect: reattach attempt ${i + 1} for tab ${tabId} failed:`, e)
       }
     }

--- a/extensions/ab-connect/manifest.json
+++ b/extensions/ab-connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "chrome-use",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Let chrome-use drive your logged-in Chrome \u2014 install once, no token, no per-use confirmation.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6vQIyscGIPYPZdSpPwPL0+0gxUROyRgCpmvCSDoc8XUm4qm97VbKnD9Ijc1lV22lNWZtE78gaRjt6BeSfuMgnBymnhLKjN1gU6AI5QUU0mrJyeHdWKvrKQR5FmsM2A7Xr1ykE2SiiS8zNUS3Y/6O5l+Nva7wrVy6E4a2dkBVQkOsu+DV+nEZvhIyuDY5D5SPXqNwUTWTaglwj5mjvHz36xSwCWlPmrtJ+ED0AUyrb2z4GIOmvk4kqtBVrh/UD058klLo4CkYOnIybB5aV6WYuwarfPY4bF/dLggPem+ewLNTUNBuwrxj/A4nUv0LJTuRO8rR7f8WR9qnRCY0Ic5saQIDAQAB",
   "icons": {


### PR DESCRIPTION
## Symptom
On a Chrome with several extensions, the `ab-connect` service-worker console fills with warnings:
```
ab-connect: reattach attempt 1..6 for tab <id> failed:
  Error: Cannot access a chrome-extension:// URL of different extension
```
A user driving their real Chrome saw 30+ of these. They're **noise, not a failure** (the relay is healthy), but they bury real errors and waste retries.

## Cause
The `chrome.debugger.onDetach` reattach loop retries 6× with backoff. When the detached tab is one we can **never** attach to — another extension's `chrome-extension://` page, a `chrome://` page, a restricted target — every attempt fails the same way. `eligible()` filters most of these, but a tab can navigate into one *between* the eligibility check and the attach, so the errors still surface.

## Fix
Add `isPermanentAttachError()` that matches only the **permanent** phrases (`different extension`, `Cannot access a chrome://`, `must request permission`, `Cannot access contents`, `Cannot attach to … target`) — deliberately **not** the bare "cannot access" that `sendCdpToTab` already treats as a *transient* mid-process-swap detach (so we don't regress cross-process-nav recovery).

Bail on a permanent error in all three reattach loops:
- **onDetach** reattach loop → `return` (kills the warning storm)
- **recoverSessionTab** tabId fast-path → `break` to the stable-targetId path (a different tab may host the target)
- **recoverSessionTab** targetId path → `return null` (the target's tab is restricted; give up)

Pure DX/noise reduction — no behavior change for attachable tabs. Verified the regex matches the real error and ignores transient detach messages (`node` check + a match table). `node --check` passes. manifest `0.5.3 → 0.5.4`.

## Note
Reaches users only after a Web Store republish (bundle with the 0.5.2/0.5.3 keepalive that's also pending upload). Store zip built at `/tmp/ab-connect-v0.5.4.zip` (key stripped).