### PR TITLE
feat(snapshot): --filter <regex> for desktop-shell web apps + eval await hint (#65)

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1325,6 +1325,12 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                             i += 1;
                         }
                     }
+                    "-f" | "--filter" => {
+                        if let Some(s) = rest.get(i + 1) {
+                            obj.insert("filter".to_string(), json!(s));
+                            i += 1;
+                        }
+                    }
                     _ => {}
                 }
                 i += 1;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3200,6 +3200,15 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     )
     .await?;
 
+    // `--filter <regex>` (issue #65): for desktop-shell web apps (Synology DSM,
+    // NAS/router panels) one snapshot holds many app windows — keep only the
+    // matching lines + their ancestor context so the target controls aren't
+    // buried/truncated. Refs survive (assigned above, before filtering).
+    let tree = match cmd.get("filter").and_then(|v| v.as_str()) {
+        Some(pattern) if !pattern.is_empty() => snapshot::filter_tree(&tree, pattern)?,
+        _ => tree,
+    };
+
     let url = mgr.get_url().await.unwrap_or_default();
 
     let refs: serde_json::Map<String, Value> = state

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -370,6 +370,17 @@ fn is_stale_target_error(error: &str) -> bool {
 /// Converts common error messages into AI-friendly, actionable descriptions.
 pub fn to_ai_friendly_error(error: &str) -> String {
     let lower = error.to_lowercase();
+    // Top-level `await` in `eval` fails with a bare "await is not defined" /
+    // "await is only valid in async" — unhelpful. Point at the wrapper (issue #65).
+    if lower.contains("await is not defined")
+        || lower.contains("await is only valid")
+        || (lower.contains("unexpected") && lower.contains("await"))
+    {
+        return format!(
+            "{error}\nHint: `eval` has no top-level `await` — wrap async code as \
+             `(async () => {{ /* await … */ }})()` (the promise is awaited and its value returned)."
+        );
+    }
     // A read (snapshot/screenshot/eval/get) hit a session whose target is gone —
     // typically a cross-process navigation like an OAuth redirect (issue #58).
     // `navigate` auto-reattaches, but reads deliberately fail loudly rather than
@@ -3738,6 +3749,19 @@ mod tests {
     fn test_to_ai_friendly_error_unknown() {
         let msg = "Some custom error message";
         assert_eq!(to_ai_friendly_error(msg), msg);
+    }
+
+    #[test]
+    fn test_to_ai_friendly_error_top_level_await_hint() {
+        let m = to_ai_friendly_error("Evaluation error: ReferenceError: await is not defined");
+        assert!(
+            m.contains("async () =>"),
+            "should suggest the async wrapper"
+        );
+        assert!(
+            m.contains("await is not defined"),
+            "keeps the original error"
+        );
     }
 
     #[test]

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -1711,6 +1711,51 @@ fn count_indent(line: &str) -> usize {
     (line.len() - trimmed.len()) / 2
 }
 
+/// Keep only snapshot lines matching `pattern` (case-insensitive regex), plus the
+/// ancestor chain of each match for window/section context. Refs on kept lines
+/// stay valid (assigned at snapshot time, independent of filtering).
+///
+/// For desktop-shell web apps (Synology DSM, NAS/router admin panels, ExtJS) one
+/// snapshot holds many independent app windows, so `snapshot -i` blows past the
+/// token cap and buries the target controls. `--filter "SSH|端口|应用|确定"` cuts
+/// it down to the few relevant lines (issue #65) — the productized form of the
+/// `| tail -80` workaround, but tree-aware and ref-preserving.
+pub fn filter_tree(tree: &str, pattern: &str) -> Result<String, String> {
+    let re = regex_lite::Regex::new(&format!("(?i){pattern}"))
+        .map_err(|e| format!("invalid --filter regex '{pattern}': {e}"))?;
+    let lines: Vec<&str> = tree.lines().collect();
+    let mut keep = vec![false; lines.len()];
+    for (i, line) in lines.iter().enumerate() {
+        if !re.is_match(line) {
+            continue;
+        }
+        keep[i] = true;
+        // Walk back to the root keeping only the strictly-shallower ancestor chain
+        // (direct parent, grandparent, …) — not shallower siblings.
+        let mut want = count_indent(line);
+        for j in (0..i).rev() {
+            let ind = count_indent(lines[j]);
+            if ind < want {
+                keep[j] = true;
+                want = ind;
+                if ind == 0 {
+                    break;
+                }
+            }
+        }
+    }
+    let kept: Vec<&str> = lines
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| keep[*i])
+        .map(|(_, l)| *l)
+        .collect();
+    if kept.is_empty() {
+        return Ok(format!("(no elements match /{pattern}/)"));
+    }
+    Ok(kept.join("\n"))
+}
+
 fn extract_ax_string(value: &Option<AXValue>) -> String {
     match value {
         Some(v) => match &v.value {
@@ -1870,6 +1915,47 @@ mod tests {
     fn test_compact_tree_empty_interactive() {
         let result = compact_tree("- generic\n", true);
         assert_eq!(result, "(no interactive elements)");
+    }
+
+    #[test]
+    fn test_filter_tree_keeps_matches_with_ancestors_and_refs() {
+        // Desktop-shell shape: two app windows; filter should keep only the
+        // matching controls + their window ancestor, dropping the other window.
+        let tree = "\
+- application
+  - group \"控制面板\"
+    - checkbox \"启动 SSH 功能\" [checked=true, ref=e5]
+    - textbox \"端口：\" [ref=e6]: 10022
+    - button \"应用\" [ref=e7]
+  - group \"Package Center\"
+    - listitem \"some package\" [ref=e20]
+    - listitem \"another\" [ref=e21]";
+        let out = filter_tree(tree, "SSH|端口|应用").unwrap();
+        // matched controls kept, with refs intact
+        assert!(out.contains("checkbox \"启动 SSH 功能\" [checked=true, ref=e5]"));
+        assert!(out.contains("textbox \"端口：\" [ref=e6]: 10022"));
+        assert!(out.contains("button \"应用\" [ref=e7]"));
+        // ancestor window kept for context
+        assert!(out.contains("控制面板"));
+        assert!(out.contains("- application"));
+        // the unrelated window + its items are gone
+        assert!(!out.contains("Package Center"));
+        assert!(!out.contains("some package"));
+    }
+
+    #[test]
+    fn test_filter_tree_case_insensitive_and_no_match() {
+        let tree = "- button \"Apply\" [ref=e1]";
+        assert!(filter_tree(tree, "apply").unwrap().contains("[ref=e1]"));
+        assert_eq!(
+            filter_tree(tree, "nonexistent").unwrap(),
+            "(no elements match /nonexistent/)"
+        );
+    }
+
+    #[test]
+    fn test_filter_tree_bad_regex_errors() {
+        assert!(filter_tree("- x", "[unclosed").is_err());
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1999,6 +1999,10 @@ Options:
   -c, --compact        Remove empty structural elements
   -d, --depth <n>      Limit tree depth
   -s, --selector <sel> Scope snapshot to CSS selector
+  -f, --filter <regex> Keep only lines matching <regex> (case-insensitive) + their
+                       ancestor context; refs preserved. For desktop-shell apps
+                       (Synology DSM, NAS/router panels) where one snapshot holds
+                       many windows. e.g. -f "SSH|端口|应用|确定"
 
 Global Options:
   --json               Output as JSON

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -348,8 +348,16 @@ chrome-use snapshot -i -u              # include href urls on links
 chrome-use snapshot -i -c              # compact (no empty structural nodes)
 chrome-use snapshot -i -d 3            # cap depth at 3 levels
 chrome-use snapshot -s "#main"         # scope to a CSS selector
+chrome-use snapshot -i -f "SSH|端口|应用"  # keep only matching lines + ancestors (regex)
 chrome-use snapshot -i --json          # machine-readable output
 ```
+
+**Huge / truncated snapshot on a "desktop-shell" web app?** Synology DSM, NAS /
+router admin panels, ExtJS apps render many independent app windows into one
+accessibility tree, so `snapshot -i` blows past the token cap and buries the
+target controls. Don't pipe to `tail` — use **`-f/--filter <regex>`** (or `-s
+<css>` to scope to one window's container): `snapshot -i -f "SSH|端口|应用|确定"`
+keeps only the matching lines plus their ancestor context, with refs intact.
 
 Snapshot output looks like:
 


### PR DESCRIPTION
Synology DSM / NAS / router admin panels / ExtJS apps render **many independent app windows into one accessibility tree**, so `snapshot -i` blows past the token cap and buries the target controls. The reporter had to `| tail -80` and still missed state (a new `确定` confirm button).

## `snapshot -f/--filter <regex>`
Keep only lines matching the (case-insensitive) regex **plus each match's ancestor chain** (so you still see which window/section it's in). **Refs are untouched** (assigned before filtering). Pure post-process (`filter_tree`), applied after render/compact and after iframe inlining → works with `-i`/`-c`/across frames. No match → `(no elements match /…/)`.

Live on a DSM-style repro (Package Center with 40 buttons + 控制面板 + 30 log rows):
```
$ snapshot -i            → 47 lines (truncation territory on the real thing)
$ snapshot -i -f "SSH|端口|应用|确定"
- region "控制面板 Terminal SNMP" [ref=e2]
  - checkbox " 启动 SSH 功能" [checked=true, ref=e4]
  - textbox "端口：" [ref=e7]: 10022
  - button "应用" [ref=e5]
  - button "确定" [ref=e6]
```
5 lines, refs intact, every other window gone. (Tip: `-s <css>` already scopes to one window's container if you have a selector.)

## eval top-level `await` hint (#65 item 3)
`await is not defined` now appends: wrap async code as `(async () => { … })()`.

## Tests
`filter_tree` (matches+ancestors+refs, case-insensitive, no-match, bad-regex) + the await hint. fmt + clippy clean.

## Deferred (noted on the issue)
`--active-window`/`--focused` (needs active-window detection), by-text `--scope` (CSS `-s` already covers scope-by-container), `network requests --include-response-body/--match`, explicit "Dialog appeared" after click (alerts already surface in the next snapshot via #57).