### PR TITLE
fix(relay): only attach the agent's own tabs — no debugger banner on user pages

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -964,32 +964,18 @@ impl BrowserManager {
     async fn adopt_existing_target(&mut self, spec: &str) -> Result<(), String> {
         let all = self.collect_all_targets().await?;
         let spec_l = spec.to_lowercase();
-        let target = all
+        let target = match all
             .iter()
             .find(|t| t.target_id == spec)
             .or_else(|| all.iter().find(|t| t.url.to_lowercase().contains(&spec_l)))
-            .ok_or_else(|| {
-                let mut open: Vec<String> = all
-                    .iter()
-                    .map(|t| {
-                        let u = if t.url.len() > 80 {
-                            &t.url[..80]
-                        } else {
-                            &t.url
-                        };
-                        u.to_string()
-                    })
-                    .collect();
-                open.sort();
-                open.dedup();
-                format!(
-                    "adopt: no open tab matching `{spec}` (by targetId or URL substring).\n\
-                     {} tab(s) the extension can see:\n  {}",
-                    open.len(),
-                    open.join("\n  ")
-                )
-            })?
-            .clone();
+        {
+            Some(t) => t.clone(),
+            // Not in the already-attached set. Since we no longer eagerly attach
+            // the user's tabs (so Chrome's debugger banner stays off their pages),
+            // ask the extension to discover the tab by URL/targetId via chrome.tabs
+            // metadata and attach JUST that one on demand, then adopt it.
+            None => self.adopt_by_url_on_demand(spec).await?,
+        };
 
         let attach: AttachToTargetResult = self
             .client
@@ -1016,6 +1002,59 @@ impl BrowserManager {
         self.pin_active_target();
         self.enable_domains(&attach.session_id).await?;
         Ok(())
+    }
+
+    /// Ask the extension to find a pre-existing tab by `spec` (targetId or URL
+    /// substring) via `chrome.tabs` metadata and attach ONLY that one, returning
+    /// its now-live `TargetInfo`. Needed because the extension no longer eagerly
+    /// attaches the user's tabs (keeping the debugger banner off their pages), so
+    /// `collect_all_targets` can't see an unattached user tab until we adopt it.
+    /// On no match, surfaces the candidate URLs the extension reported.
+    async fn adopt_by_url_on_demand(&self, spec: &str) -> Result<TargetInfo, String> {
+        let resp: Value = self
+            .client
+            .send_command_typed("ABExt.adoptByUrl", &json!({ "spec": spec }), None)
+            .await
+            .map_err(|e| format!("adopt: discovery failed ({e})"))?;
+
+        if let Some(tid) = resp.get("targetId").and_then(|v| v.as_str()) {
+            return Ok(TargetInfo {
+                target_id: tid.to_string(),
+                target_type: "page".to_string(),
+                title: resp
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                url: resp
+                    .get("url")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                attached: Some(true),
+                browser_context_id: None,
+            });
+        }
+
+        // No match — list what the extension could see (its chrome.tabs view).
+        let mut open: Vec<String> = resp
+            .get("candidates")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|c| c.get("url").and_then(|u| u.as_str()))
+                    .map(|u| u.chars().take(80).collect::<String>())
+                    .collect()
+            })
+            .unwrap_or_default();
+        open.sort();
+        open.dedup();
+        Err(format!(
+            "adopt: no open tab matching `{spec}` (by targetId or URL substring).\n\
+             {} tab(s) the extension can see:\n  {}",
+            open.len(),
+            open.join("\n  ")
+        ))
     }
 
     async fn discover_and_attach_targets(&mut self) -> Result<(), String> {

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -43,6 +43,38 @@ function rememberSessionTarget(sessionId, targetId) {
 /** tab-group name -> chrome tabGroups id (best-effort cache) */
 const groupIdByName = new Map()
 
+// Tabs THIS extension owns: ones the agent created (Target.createTarget) or
+// explicitly adopted. We attach the debugger ONLY to these — never to the user's
+// own tabs — so Chrome's "started debugging this browser" banner never appears on
+// a page the user is actually working in (it only shows on attached tabs, and the
+// agent's are background tabs the user doesn't look at). Persisted in
+// chrome.storage.local so a service-worker restart re-attaches exactly these and
+// not the whole window. (Issue: banner occludes the user's foreground tab.)
+const ownedTabs = new Set()
+let ownedLoaded = false
+async function loadOwnedTabs() {
+  if (ownedLoaded) return
+  try {
+    const g = await chrome.storage.local.get('ab_owned_tabs')
+    for (const id of g.ab_owned_tabs || []) ownedTabs.add(id)
+  } catch {}
+  ownedLoaded = true
+}
+function persistOwnedTabs() {
+  try {
+    chrome.storage.local.set({ ab_owned_tabs: [...ownedTabs] })
+  } catch {}
+}
+function markOwned(tabId) {
+  if (tabId != null && !ownedTabs.has(tabId)) {
+    ownedTabs.add(tabId)
+    persistOwnedTabs()
+  }
+}
+function unmarkOwned(tabId) {
+  if (ownedTabs.delete(tabId)) persistOwnedTabs()
+}
+
 // Deterministic color per group name so a given session keeps the same color.
 const GROUP_COLORS = ['blue', 'cyan', 'green', 'yellow', 'orange', 'red', 'pink', 'purple', 'grey']
 function colorForName(name) {
@@ -281,10 +313,11 @@ function connectHost() {
       })
     } catch {}
   })
-  // Tell the daemon about everything we already have attached, then attach
-  // anything new.
+  // Tell the daemon about everything we already have attached, then re-attach
+  // the tabs we own (NOT the user's tabs — that's what kept the banner off their
+  // pages).
   void reannounceAttachedTabs()
-  void attachAllTabs()
+  void reattachOwnedTabs()
   notifyConnChange(true)
   // Start the proactive heartbeat so the worker stays alive while paired.
   scheduleKeepalivePing()
@@ -297,11 +330,10 @@ async function onHostMessage(msg) {
     postToHost({ method: 'pong' })
     return
   }
-  // Daemon (re)connected — (re)attach and announce every tab so it discovers
-  // the user's existing tabs rather than racing an empty target list.
+  // Daemon (re)connected — re-announce + re-attach OUR tabs (not the user's).
   if (msg.method === 'attachAll') {
     void reannounceAttachedTabs()
-    await attachAllTabs()
+    await reattachOwnedTabs()
     return
   }
   if (typeof msg.id !== 'undefined' && msg.method === 'forwardCDPCommand') {
@@ -453,11 +485,42 @@ async function handleForwardCdpCommand(msg) {
     return { ungrouped: tabId ?? null }
   }
 
+  // On-demand adopt of a PRE-EXISTING tab (the user's own, or another session's).
+  // Since we no longer eagerly attach the user's tabs (banner!), `adopt <spec>`
+  // can't find them via the already-attached target list — so discover by
+  // chrome.tabs metadata (no debugger, no banner), and attach ONLY the one match
+  // (which announces it to the daemon and makes it ours). `spec` is a targetId or
+  // a URL substring. On no match, return the candidate URLs so the daemon can
+  // print a useful error.
+  if (method === 'ABExt.adoptByUrl') {
+    const spec = String(params?.spec || '').trim()
+    const specL = spec.toLowerCase()
+    let all = []
+    try {
+      all = await chrome.tabs.query({})
+    } catch {}
+    const candidates = all.filter((t) => eligible(t))
+    // Prefer an already-attached target whose id matches; else match a tab URL.
+    const match =
+      candidates.find((t) => tabs.get(t.id)?.targetId === spec) ||
+      candidates.find((t) => (t.url || '').toLowerCase().includes(specL))
+    if (!match || !match.id) {
+      return {
+        targetId: null,
+        candidates: candidates.map((t) => ({ url: t.url || '', title: t.title || '' })),
+      }
+    }
+    const entry = await attachTab(match.id) // attaches + announces attachedToTarget
+    markOwned(match.id)
+    return { targetId: entry.targetId, url: match.url || '', title: match.title || '' }
+  }
+
   // Browser-level Target methods that map onto chrome.tabs.
   if (method === 'Target.createTarget') {
     const url = typeof params?.url === 'string' && params.url ? params.url : 'about:blank'
     const tab = await chrome.tabs.create({ url, active: false })
     if (!tab.id) throw new Error('createTarget: no tab id')
+    markOwned(tab.id) // agent-created → ours to attach (and re-attach after SW restart)
     await new Promise((r) => setTimeout(r, 100))
     const t = await attachTab(tab.id)
     // Per-session tab grouping (non-CDP hint from the daemon). Best-effort.
@@ -616,19 +679,24 @@ function eligible(tab) {
   return !!tab && !!tab.id && typeof tab.url === 'string' && !SKIP_URL.test(tab.url)
 }
 
-async function attachAllTabs() {
-  let all = []
-  try {
-    all = await chrome.tabs.query({})
-  } catch {
-    return
-  }
-  for (const tab of all) {
-    if (eligible(tab) && !tabs.has(tab.id)) {
+// Re-attach ONLY the tabs this extension owns (agent-created / adopted) — never
+// the user's own tabs. This is what keeps the debugger banner off the user's
+// foreground pages. Runs on (re)connect and from the keepalive alarm, so an
+// agent's tabs survive a service-worker restart without dragging the whole window
+// (and its banners) along. Prunes ids whose tab is gone.
+async function reattachOwnedTabs() {
+  await loadOwnedTabs()
+  for (const tabId of [...ownedTabs]) {
+    const tab = await chrome.tabs.get(tabId).catch(() => null)
+    if (!tab || !eligible(tab)) {
+      unmarkOwned(tabId)
+      continue
+    }
+    if (!tabs.has(tabId)) {
       try {
-        await attachTab(tab.id)
+        await attachTab(tabId)
       } catch {
-        // Tab may be a restricted page or already attached elsewhere.
+        // Restricted page or transient — leave owned; next pass retries.
       }
     }
   }
@@ -732,7 +800,13 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) =>
     }
   }),
 )
-chrome.tabs.onRemoved.addListener((tabId) => void whenReady(() => detachTab(tabId, true)))
+chrome.tabs.onRemoved.addListener(
+  (tabId) =>
+    void whenReady(() => {
+      unmarkOwned(tabId)
+      detachTab(tabId, true)
+    }),
+)
 
 // ---- bootstrap + keepalive ------------------------------------------------
 
@@ -780,7 +854,7 @@ chrome.alarms.onAlarm.addListener((a) => {
   void whenReady(() => {
     if (!port) connectHost()
     else {
-      void attachAllTabs()
+      void reattachOwnedTabs()
       scheduleKeepalivePing()
     }
   })

--- a/extensions/ab-connect/manifest.json
+++ b/extensions/ab-connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "chrome-use",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Let chrome-use drive your logged-in Chrome \u2014 install once, no token, no per-use confirmation.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6vQIyscGIPYPZdSpPwPL0+0gxUROyRgCpmvCSDoc8XUm4qm97VbKnD9Ijc1lV22lNWZtE78gaRjt6BeSfuMgnBymnhLKjN1gU6AI5QUU0mrJyeHdWKvrKQR5FmsM2A7Xr1ykE2SiiS8zNUS3Y/6O5l+Nva7wrVy6E4a2dkBVQkOsu+DV+nEZvhIyuDY5D5SPXqNwUTWTaglwj5mjvHz36xSwCWlPmrtJ+ED0AUyrb2z4GIOmvk4kqtBVrh/UD058klLo4CkYOnIybB5aV6WYuwarfPY4bF/dLggPem+ewLNTUNBuwrxj/A4nUv0LJTuRO8rR7f8WR9qnRCY0Ic5saQIDAQAB",
   "icons": {

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -221,6 +221,14 @@ onto the wrong page. Consequence: `tab list` shows only *your* session's tabs; t
 drive a specific page, navigate to it in your own tab instead of expecting a
 pre-existing or popped-up tab to appear in the list.
 
+> **No debugger banner on the user's pages.** The extension attaches Chrome's
+> debugger **only to tabs the agent owns** (ones it created, or that you `adopt`),
+> never to the user's own tabs — so Chrome's "chrome-use started debugging this
+> browser" bar never covers a page they're working in (it only appears on attached
+> tabs, and the agent's are background tabs). `adopt <url>` attaches that one tab
+> on demand (the bar then shows on *that* tab — it's the one you asked to drive).
+> No Chrome restart, fully seamless.
+
 > **Need to read a tab the user already has open?** Use `chrome-use adopt
 > <url-substring|targetId>` — it finds that pre-existing tab (the user's own, or
 > another session's) across groups and drives it **without opening a new tab**.


### PR DESCRIPTION
## The problem
Chrome's **"chrome-use started debugging this browser"** infobar shows on every tab the extension attaches the debugger to, and it can't be dismissed at runtime — only suppressed by a startup flag (a Chrome **restart**, the opposite of seamless). The extension eager-attached **every** tab (`attachAllTabs` → `chrome.tabs.query({})`), so the bar covered the pages the user was actually working in.

## The fix — don't attach the user's tabs
Attach the debugger **only to tabs the agent owns** (created via `Target.createTarget`, or explicitly `adopt`ed). The user's foreground pages are never attached → **no banner, no restart**, fully seamless. The agent's own tabs are background, so the bar on those is invisible during normal use. This reinforces the existing "a session drives only the tabs it created" isolation model.

- `ownedTabs` set persisted in `chrome.storage.local`; `createTarget` marks owned, `onRemoved` unmarks.
- `reattachOwnedTabs()` replaces `attachAllTabs()` at every call site (connect / `attachAll` / keepalive alarm) — after a SW restart it re-attaches exactly the agent's tabs, not the whole window.
- **adopt still works**: user tabs aren't pre-attached, so `adopt <spec>` falls back to a new `ABExt.adoptByUrl` that discovers via `chrome.tabs` metadata (no debugger, no bar) and attaches just the one match on demand.

manifest `0.5.4 → 0.5.5`. Build + clippy clean; `node --check` passes.

## ⚠️ Needs live verification before merge — do NOT auto-merge
Touches the just-stabilized relay core; can't be self-verified (needs the extension in a real multi-tab Chrome). Verify: (1) normal `open`/`snapshot` on a busy Chrome → no banner on foreground tabs; (2) `adopt <url>` still attaches+drives one existing tab; (3) multi-agent isolation + SW-restart re-attach still hold. Store zip at `/tmp/ab-connect-v0.5.5.zip`.