### PR TITLE
feat(relay): auto-recover a dropped relay on the next command (the 用不了 fix)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1338,6 +1338,47 @@ fn main() {
         return;
     }
 
+    // Relay self-heal (the "用不了" fix). On the extension-relay path, a dropped
+    // relay used to mean either a 2-minute hang (a stale daemon still bound to the
+    // dead relay ws keeps sending into the void) or a hard error that forced the
+    // user to run `chrome-use reconnect` by hand. Instead, when we're about to
+    // drive the user's real Chrome and the relay is down (host installed but
+    // `relay-cdp-url` gone), recover automatically: drop the stale daemon so it
+    // can't reuse the dead binding, then wait (bounded, with progress) for the MV3
+    // worker to republish the relay — the fresh daemon then connects clean. Opt
+    // out with AGENT_BROWSER_NO_AUTO_RECONNECT. Skipped for --launch/--cdp.
+    if flags.auto_connect
+        && flags.cdp.is_none()
+        && !flags.force_launch
+        && std::env::var("AGENT_BROWSER_NO_AUTO_RECONNECT").is_err()
+        && connect::host_installed()
+        && connect::relay_url().is_none()
+    {
+        connection::kill_stale_daemon(&flags.session);
+        connect::ensure_host_installed();
+        // Reap any zombie native-messaging host (it already lost its Chrome port —
+        // relay-cdp-url is gone — but the process can linger). Killing it makes the
+        // extension worker's port disconnect fire immediately, so it reconnects and
+        // republishes the relay in ~2s instead of waiting ~30s for the keepalive
+        // alarm. Best-effort, unix-only; safe here because the relay is already down.
+        #[cfg(unix)]
+        {
+            let _ = std::process::Command::new("pkill")
+                .args(["-f", "__nm-host"])
+                .output();
+        }
+        eprint!(
+            "{} Chrome relay dropped — reconnecting…",
+            color::success_indicator()
+        );
+        let _ = std::io::Write::flush(&mut std::io::stderr());
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(45);
+        while connect::relay_url().is_none() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        }
+        eprintln!();
+    }
+
     // Parse proxy URL to separate server from credentials for the daemon.
     let (proxy_server, proxy_username, proxy_password) = if let Some(ref proxy_str) = flags.proxy {
         let parsed = parse_proxy(proxy_str);


### PR DESCRIPTION
**Pain:** when the relay drops (MV3 worker idle/sleep, zombie native-host), the next command hangs ~2min (stale daemon bound to the dead relay ws) or hard-errors → user must run `chrome-use reconnect` by hand. The '用不了' complaint.

**Fix (CLI-only, no republish):** every relay command self-heals when the relay is down (host installed but `relay-cdp-url` gone): drop the stale daemon (no 2-min hang), reap any zombie `__nm-host` (worker reconnects in ~2s vs ~30s alarm), wait bounded 45s with a progress note for the worker to republish, then the fresh daemon connects clean and the command runs. No hang, no manual reconnect.

**Verified:** killed the relay → `open` auto-recovered in 2–20s instead of a 2-min hang. No-op when healthy (gated on relay-cdp-url missing). Opt out: `AGENT_BROWSER_NO_AUTO_RECONNECT`; skipped for --launch/--cdp. clippy clean.

Follow-up: residual 2–20s is worker-wake latency; an extension-side faster-wake + the banner fix ship together in a republish.