### PR TITLE
fix(ab-connect): don't persist adopted tabs — clears stuck debugger banner (0.5.6)

### DIFF
--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -511,7 +511,11 @@ async function handleForwardCdpCommand(msg) {
       }
     }
     const entry = await attachTab(match.id) // attaches + announces attachedToTarget
-    markOwned(match.id)
+    // Do NOT markOwned: an adopted tab is the USER'S — attach it for this session,
+    // but never persist it into the re-attach set. Persisting would re-attach the
+    // user's tab on every SW restart forever, leaving Chrome's debugger banner
+    // stuck on a page they own. On SW restart the adoption simply releases (banner
+    // clears); re-`adopt` if still needed. Only agent-CREATED tabs are persisted.
     return { targetId: entry.targetId, url: match.url || '', title: match.title || '' }
   }
 
@@ -810,7 +814,19 @@ chrome.tabs.onRemoved.addListener(
 
 // ---- bootstrap + keepalive ------------------------------------------------
 
-chrome.runtime.onInstalled.addListener(() => void whenReady(connectHost))
+chrome.runtime.onInstalled.addListener((details) => {
+  // One-time purge: a prior build persisted ADOPTED user tabs into the owned set,
+  // which then re-attached them on every restart and left the debugger banner
+  // stuck on the user's pages. Clear the persisted set on install/update — agent
+  // tabs from a previous SW are dead anyway, and createTarget re-marks new ones.
+  if (details && (details.reason === 'update' || details.reason === 'install')) {
+    try {
+      chrome.storage.local.remove('ab_owned_tabs')
+    } catch {}
+    ownedTabs.clear()
+  }
+  void whenReady(connectHost)
+})
 chrome.runtime.onStartup.addListener(() => void whenReady(connectHost))
 
 // Popup status page asks for the live pairing state. Attempt a (re)connect on

--- a/extensions/ab-connect/manifest.json
+++ b/extensions/ab-connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "chrome-use",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Let chrome-use drive your logged-in Chrome \u2014 install once, no token, no per-use confirmation.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6vQIyscGIPYPZdSpPwPL0+0gxUROyRgCpmvCSDoc8XUm4qm97VbKnD9Ijc1lV22lNWZtE78gaRjt6BeSfuMgnBymnhLKjN1gU6AI5QUU0mrJyeHdWKvrKQR5FmsM2A7Xr1ykE2SiiS8zNUS3Y/6O5l+Nva7wrVy6E4a2dkBVQkOsu+DV+nEZvhIyuDY5D5SPXqNwUTWTaglwj5mjvHz36xSwCWlPmrtJ+ED0AUyrb2z4GIOmvk4kqtBVrh/UD058klLo4CkYOnIybB5aV6WYuwarfPY4bF/dLggPem+ewLNTUNBuwrxj/A4nUv0LJTuRO8rR7f8WR9qnRCY0Ic5saQIDAQAB",
   "icons": {


### PR DESCRIPTION
Follow-up to 0.5.5 (attach only the agent's own tabs). `ABExt.adoptByUrl` was persisting the adopted tab into `ab_owned_tabs`, so an adopted USER tab got re-attached on every SW restart forever → Chrome's debugger banner stuck on a page the user owns (hit live: a router-admin tab adopted during testing kept its banner).

- adopt no longer persists: attached for the live session only; SW restart releases it (banner clears), re-adopt if needed. Only agent-CREATED tabs are persisted/re-attached (background, no visible banner).
- `onInstalled` clears persisted `ab_owned_tabs` — one-time purge of any tab leaked by the prior build.

manifest 0.5.5 → 0.5.6. node --check passes. Store zip: `/tmp/ab-connect-v0.5.6.zip` (key stripped).