### PR TITLE
feat(ab-connect): reconnect on wake-from-sleep via chrome.idle (0.5.7)

### DIFF
--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -829,6 +829,22 @@ chrome.runtime.onInstalled.addListener((details) => {
 })
 chrome.runtime.onStartup.addListener(() => void whenReady(connectHost))
 
+// Wake-from-sleep / return-from-idle fast reconnect. After the machine sleeps (or
+// the user is away long enough), the MV3 worker is killed and its native-messaging
+// port dies; previously only the keepalive alarm revived it — and chrome.alarms
+// clamps to a ~30s floor, so the relay stayed dead for up to ~30s after wake (the
+// "first command after coming back hangs/reconnects slowly" feeling). chrome.idle
+// fires on the transition back to "active" and is wake-eligible (it restarts a
+// suspended worker), so we reconnect the instant the user returns instead of
+// waiting for the alarm. `idle` is a no-warning permission, so this auto-updates
+// with no re-consent.
+try {
+  chrome.idle.setDetectionInterval(15)
+  chrome.idle.onStateChanged.addListener((state) => {
+    if (state === 'active') void whenReady(() => { if (!port) connectHost() })
+  })
+} catch {}
+
 // Popup status page asks for the live pairing state. Attempt a (re)connect on
 // demand so opening the popup also nudges the link awake, then report.
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/extensions/ab-connect/manifest.json
+++ b/extensions/ab-connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "chrome-use",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Let chrome-use drive your logged-in Chrome \u2014 install once, no token, no per-use confirmation.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6vQIyscGIPYPZdSpPwPL0+0gxUROyRgCpmvCSDoc8XUm4qm97VbKnD9Ijc1lV22lNWZtE78gaRjt6BeSfuMgnBymnhLKjN1gU6AI5QUU0mrJyeHdWKvrKQR5FmsM2A7Xr1ykE2SiiS8zNUS3Y/6O5l+Nva7wrVy6E4a2dkBVQkOsu+DV+nEZvhIyuDY5D5SPXqNwUTWTaglwj5mjvHz36xSwCWlPmrtJ+ED0AUyrb2z4GIOmvk4kqtBVrh/UD058klLo4CkYOnIybB5aV6WYuwarfPY4bF/dLggPem+ewLNTUNBuwrxj/A4nUv0LJTuRO8rR7f8WR9qnRCY0Ic5saQIDAQAB",
   "icons": {
@@ -17,6 +17,7 @@
     "nativeMessaging",
     "storage",
     "alarms",
+    "idle",
     "webNavigation",
     "notifications"
   ],


### PR DESCRIPTION
Cuts the residual reconnect latency after sleep/idle. The MV3 worker dies on sleep; previously only the keepalive alarm revived it, and `chrome.alarms` clamps to ~30s — so the relay stayed dead up to ~30s after wake (the CLI self-heal in v1.5.46 then had to wait that out).

`chrome.idle.onStateChanged` → on the 'active' transition (return from sleep/idle, wake-eligible so it restarts a suspended worker) we reconnect immediately. Pairs with the 20s keepalive ping (alive while connected) + the alarm (cold-restart backstop).

`idle` is a **no-warning** Chrome permission → auto-updates with no re-consent. manifest 0.5.6 → 0.5.7. node --check passes. Store zip will be built for upload.