### PR TITLE
feat(expect): assertion verb with 3-way exit code (the did-it-work gate)

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -36,6 +36,7 @@ pub enum ParseError {
 const KNOWN_COMMANDS: &[&str] = &[
     "open",
     "navigate",
+    "expect",
     "click",
     "fill",
     "type",
@@ -1783,6 +1784,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         // === Is (state checks) ===
         "is" => parse_is(&rest, &id),
+        "expect" => parse_expect(&rest, &id),
 
         // === Find (locators) ===
         "find" => parse_find(&rest, &id),
@@ -2989,6 +2991,229 @@ fn parse_is(rest: &[&str], id: &str) -> Result<Value, ParseError> {
             context: "is".to_string(),
             usage: "is <visible|enabled|checked> <selector>",
         }),
+    }
+}
+
+/// `expect <condition>` — pass/fail assertion verb. Subject-first for element
+/// state (`expect <sel> visible`), keyword-first for the rest (count/text/value/
+/// attr/url/request/no-errors). Waits up to --timeout by default. See the help
+/// text in output.rs for the full grammar.
+fn parse_expect(rest: &[&str], id: &str) -> Result<Value, ParseError> {
+    // Split out boolean/value flags first; the positional grammar is parsed from
+    // what's left, so flags may appear anywhere after the subject.
+    let mut pos: Vec<&str> = Vec::new();
+    let mut timeout: Option<u64> = None;
+    let mut no_wait = false;
+    let mut regex = false;
+    let mut not = false;
+    let mut method: Option<String> = None;
+    let mut status: Option<String> = None;
+    let mut rtype: Option<String> = None;
+    let mut req_count: Option<u64> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i] {
+            "--no-wait" => no_wait = true,
+            "--regex" => regex = true,
+            "--not" => not = true,
+            "--timeout" => {
+                timeout = rest.get(i + 1).and_then(|v| v.parse().ok());
+                i += 1;
+            }
+            "--method" => {
+                method = rest.get(i + 1).map(|s| s.to_string());
+                i += 1;
+            }
+            "--status" => {
+                status = rest.get(i + 1).map(|s| s.to_string());
+                i += 1;
+            }
+            "--type" => {
+                rtype = rest.get(i + 1).map(|s| s.to_string());
+                i += 1;
+            }
+            "--count" => {
+                req_count = rest.get(i + 1).and_then(|v| v.parse().ok());
+                i += 1;
+            }
+            other => pos.push(other),
+        }
+        i += 1;
+    }
+
+    let usage = "expect <sel> <visible|hidden|gone|present>  |  expect count <sel> <op> <n>  |  expect text|value <sel> <equals|contains|matches> <str>  |  expect attr <sel> <name> <pred> <str>  |  expect url <pred> <str>  |  expect request <url-substr> [--method M --status S]  |  expect no-errors";
+    let miss = |ctx: &str| ParseError::MissingArguments {
+        context: ctx.to_string(),
+        usage,
+    };
+    let mut obj = serde_json::Map::new();
+    obj.insert("id".into(), json!(id));
+    obj.insert("action".into(), json!("expect"));
+    if let Some(t) = timeout {
+        obj.insert("timeout".into(), json!(t));
+    }
+    obj.insert("noWait".into(), json!(no_wait));
+    obj.insert("not".into(), json!(not));
+
+    let first = *pos.first().ok_or_else(|| miss("expect"))?;
+    match first {
+        "count" => {
+            let sel = pos.get(1).ok_or_else(|| miss("expect count"))?;
+            if sel.starts_with('@') {
+                return Err(ParseError::InvalidValue {
+                    message: "expect count takes a CSS selector, not an @ref".to_string(),
+                    usage,
+                });
+            }
+            let op_raw = *pos
+                .get(2)
+                .ok_or_else(|| miss("expect count <sel> <op> <n>"))?;
+            let op = canon_count_op(op_raw).ok_or_else(|| ParseError::InvalidValue {
+                message: format!("bad count op '{op_raw}' (use ==,!=,>,<,>=,<= or eq/ne/gt/lt/ge/le; quote > and <)"),
+                usage,
+            })?;
+            let n: u64 = pos.get(3).and_then(|v| v.parse().ok()).ok_or_else(|| {
+                ParseError::InvalidValue {
+                    message: "expect count needs a numeric <n>".to_string(),
+                    usage,
+                }
+            })?;
+            obj.insert("kind".into(), json!("count"));
+            obj.insert("selector".into(), json!(sel));
+            obj.insert("op".into(), json!(op));
+            obj.insert("value".into(), json!(n));
+        }
+        "text" | "value" => {
+            let sel = pos.get(1).ok_or_else(|| miss("expect text/value"))?;
+            let pred = *pos
+                .get(2)
+                .ok_or_else(|| miss("expect text <sel> <equals|contains|matches> <str>"))?;
+            canon_predicate(pred).ok_or_else(|| ParseError::InvalidValue {
+                message: format!("bad predicate '{pred}' (use equals|contains|matches)"),
+                usage,
+            })?;
+            let expected = pos.get(3..).map(|s| s.join(" ")).unwrap_or_default();
+            if pos.len() < 4 {
+                return Err(miss("expect text <sel> <pred> <str>"));
+            }
+            obj.insert("kind".into(), json!(first));
+            obj.insert("selector".into(), json!(sel));
+            obj.insert("predicate".into(), json!(pred));
+            obj.insert("expected".into(), json!(expected));
+            obj.insert("regex".into(), json!(regex || pred == "matches"));
+        }
+        "attr" => {
+            let sel = pos.get(1).ok_or_else(|| miss("expect attr"))?;
+            let name = pos
+                .get(2)
+                .ok_or_else(|| miss("expect attr <sel> <name> <pred> <str>"))?;
+            let pred = *pos
+                .get(3)
+                .ok_or_else(|| miss("expect attr <sel> <name> <pred> <str>"))?;
+            canon_predicate(pred).ok_or_else(|| ParseError::InvalidValue {
+                message: format!("bad predicate '{pred}' (use equals|contains|matches)"),
+                usage,
+            })?;
+            if pos.len() < 5 {
+                return Err(miss("expect attr <sel> <name> <pred> <str>"));
+            }
+            let expected = pos[4..].join(" ");
+            obj.insert("kind".into(), json!("attr"));
+            obj.insert("selector".into(), json!(sel));
+            obj.insert("attr".into(), json!(name));
+            obj.insert("predicate".into(), json!(pred));
+            obj.insert("expected".into(), json!(expected));
+            obj.insert("regex".into(), json!(regex || pred == "matches"));
+        }
+        "url" => {
+            let pred = *pos
+                .get(1)
+                .ok_or_else(|| miss("expect url <equals|contains|matches> <str>"))?;
+            canon_predicate(pred).ok_or_else(|| ParseError::InvalidValue {
+                message: format!("bad predicate '{pred}' (use equals|contains|matches)"),
+                usage,
+            })?;
+            let expected = pos.get(2..).map(|s| s.join(" ")).unwrap_or_default();
+            if pos.len() < 3 {
+                return Err(miss("expect url <pred> <str>"));
+            }
+            obj.insert("kind".into(), json!("url"));
+            obj.insert("predicate".into(), json!(pred));
+            obj.insert("expected".into(), json!(expected));
+            obj.insert("regex".into(), json!(regex));
+        }
+        "request" => {
+            let filter = pos
+                .get(1)
+                .ok_or_else(|| miss("expect request <url-substr>"))?;
+            obj.insert("kind".into(), json!("request"));
+            obj.insert("filter".into(), json!(filter));
+            if let Some(m) = method {
+                obj.insert("method".into(), json!(m));
+            }
+            if let Some(s) = status {
+                obj.insert("status".into(), json!(s));
+            }
+            if let Some(t) = rtype {
+                obj.insert("type".into(), json!(t));
+            }
+            if let Some(c) = req_count {
+                obj.insert("count".into(), json!(c));
+            }
+        }
+        "no-errors" => {
+            obj.insert("kind".into(), json!("errors"));
+            obj.insert("max".into(), json!(0));
+        }
+        // Subject-first element-state assertion: `expect <sel> <state>`.
+        sel => {
+            let state_raw = *pos
+                .get(1)
+                .ok_or_else(|| miss("expect <sel> <visible|hidden|gone|present>"))?;
+            let state = canon_element_state(state_raw).ok_or_else(|| ParseError::InvalidValue {
+                message: format!("unknown state '{state_raw}' (use visible|hidden|gone|present|attached|detached)"),
+                usage,
+            })?;
+            obj.insert("kind".into(), json!("element"));
+            obj.insert("selector".into(), json!(sel));
+            obj.insert("state".into(), json!(state));
+        }
+    }
+    Ok(Value::Object(obj))
+}
+
+/// Map a count operator token (symbolic or word) to canonical eq/ne/gt/lt/ge/le.
+fn canon_count_op(op: &str) -> Option<&'static str> {
+    match op {
+        "==" | "eq" => Some("eq"),
+        "!=" | "ne" => Some("ne"),
+        ">" | "gt" => Some("gt"),
+        "<" | "lt" => Some("lt"),
+        ">=" | "ge" => Some("ge"),
+        "<=" | "le" => Some("le"),
+        _ => None,
+    }
+}
+
+fn canon_predicate(p: &str) -> Option<&'static str> {
+    match p {
+        "equals" => Some("equals"),
+        "contains" => Some("contains"),
+        "matches" => Some("matches"),
+        _ => None,
+    }
+}
+
+/// Canonicalize an `expect` element state to what the wait helpers understand:
+/// `gone`→`detached`, `present`→`attached`; visible/hidden/attached/detached
+/// pass through. (Review fix: the helpers don't understand gone/present.)
+fn canon_element_state(s: &str) -> Option<&'static str> {
+    match s {
+        "visible" => Some("visible"),
+        "hidden" => Some("hidden"),
+        "gone" | "detached" => Some("detached"),
+        "present" | "attached" => Some("attached"),
+        _ => None,
     }
 }
 
@@ -5345,6 +5570,101 @@ mod tests {
         assert_eq!(cmd["action"], "evaluate");
         assert_eq!(cmd["frame"], "accounts.google.com");
         assert_eq!(cmd["script"], "location.href");
+    }
+
+    // === expect (assertion verb) parse tests ===
+    #[test]
+    fn test_expect_element_state_canonicalized() {
+        let c = parse_command(&args("expect #x gone"), &default_flags()).unwrap();
+        assert_eq!(c["action"], "expect");
+        assert_eq!(c["kind"], "element");
+        assert_eq!(c["selector"], "#x");
+        assert_eq!(c["state"], "detached"); // gone → detached (review fix)
+        let c = parse_command(&args("expect @e5 visible"), &default_flags()).unwrap();
+        assert_eq!(c["kind"], "element");
+        assert_eq!(c["state"], "visible");
+        let c = parse_command(&args("expect #m present"), &default_flags()).unwrap();
+        assert_eq!(c["state"], "attached"); // present → attached
+    }
+
+    #[test]
+    fn test_expect_unknown_state_errors() {
+        assert!(parse_command(&args("expect #x wobbly"), &default_flags()).is_err());
+    }
+
+    #[test]
+    fn test_expect_count_ops() {
+        let c = parse_command(&args("expect count .row >= 3"), &default_flags()).unwrap();
+        assert_eq!(c["kind"], "count");
+        assert_eq!(c["op"], "ge");
+        assert_eq!(c["value"], 3);
+        let c = parse_command(&args("expect count .row == 5"), &default_flags()).unwrap();
+        assert_eq!(c["op"], "eq");
+        // word form + bad value / bad op
+        assert_eq!(
+            parse_command(&args("expect count .r ne 2"), &default_flags()).unwrap()["op"],
+            "ne"
+        );
+        assert!(parse_command(&args("expect count .r >= x"), &default_flags()).is_err());
+        assert!(parse_command(&args("expect count .r ?? 2"), &default_flags()).is_err());
+        // count rejects @ref
+        assert!(parse_command(&args("expect count @e1 == 1"), &default_flags()).is_err());
+    }
+
+    #[test]
+    fn test_expect_text_value_attr() {
+        let c = parse_command(&args("expect text @e1 equals Saved"), &default_flags()).unwrap();
+        assert_eq!(c["kind"], "text");
+        assert_eq!(c["predicate"], "equals");
+        assert_eq!(c["expected"], "Saved");
+        let c = parse_command(
+            &args("expect text #t contains hello world"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(c["expected"], "hello world"); // remaining tokens joined
+        let c = parse_command(&args("expect text #t matches ^Saved$"), &default_flags()).unwrap();
+        assert_eq!(c["regex"], true); // matches ⇒ regex
+        let c = parse_command(
+            &args("expect attr @e1 aria-expanded equals true"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(c["kind"], "attr");
+        assert_eq!(c["attr"], "aria-expanded");
+        assert!(parse_command(&args("expect text #t bogus x"), &default_flags()).is_err());
+    }
+
+    #[test]
+    fn test_expect_url_request_errors() {
+        let c = parse_command(&args("expect url contains /dash"), &default_flags()).unwrap();
+        assert_eq!(c["kind"], "url");
+        assert_eq!(c["predicate"], "contains");
+        let c = parse_command(
+            &args("expect request /api/save --method POST --status 2xx --count 1"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(c["kind"], "request");
+        assert_eq!(c["filter"], "/api/save");
+        assert_eq!(c["method"], "POST");
+        assert_eq!(c["status"], "2xx");
+        assert_eq!(c["count"], 1);
+        let c = parse_command(&args("expect no-errors"), &default_flags()).unwrap();
+        assert_eq!(c["kind"], "errors");
+        assert_eq!(c["max"], 0);
+    }
+
+    #[test]
+    fn test_expect_flags_stamped() {
+        let c = parse_command(
+            &args("expect #x visible --timeout 9000 --not --no-wait"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(c["timeout"], 9000);
+        assert_eq!(c["not"], true);
+        assert_eq!(c["noWait"], true);
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1943,6 +1943,22 @@ fn main() {
             // Extract action for context-specific output handling
             let action = cmd.get("action").and_then(|v| v.as_str());
             print_response_with_opts(&resp, action, &output_opts);
+            // `expect` is an assertion: map to a 3-way exit code so it composes in
+            // shells/CI — 0 pass, 1 condition false, 2 un-evaluable (transport
+            // error: no browser / bad grammar). Must run before the generic
+            // `!success → exit(1)` below.
+            if action == Some("expect") {
+                if !success {
+                    exit(2);
+                }
+                let pass = resp
+                    .data
+                    .as_ref()
+                    .and_then(|d| d.get("pass"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                exit(if pass { 0 } else { 1 });
+            }
             if !success {
                 exit(1);
             }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1441,6 +1441,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "getbytestid" => handle_getbytestid(cmd, state).await,
         "nth" => handle_nth(cmd, state).await,
         "find" => handle_find(cmd, state).await,
+        "expect" => handle_expect(cmd, state).await,
         "evalhandle" => handle_evalhandle(cmd, state).await,
         "drag" => handle_drag(cmd, state).await,
         "solve_slider" => handle_solve_slider(cmd, state).await,
@@ -5100,6 +5101,270 @@ fn console_capture_active(state: &DaemonState) -> bool {
 const CONSOLE_DISABLED_HINT: &str =
     "console/error capture is disabled for stealth (Runtime.enable is a detectable CDP \
      signal). Restart the session with AGENT_BROWSER_CAPTURE_CONSOLE=1 to capture page output.";
+
+/// `expect <condition>` — assertion verb. Polls the condition until it holds or
+/// the timeout elapses (unless --no-wait), then returns {pass, actual, ...}.
+/// main.rs maps the outcome to a process exit code (0 pass / 1 fail / 2
+/// un-evaluable, i.e. this returns Err). (Feature from #65-followup brainstorm.)
+async fn handle_expect(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let kind = cmd
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let not = cmd.get("not").and_then(|v| v.as_bool()).unwrap_or(false);
+    let no_wait = cmd.get("noWait").and_then(|v| v.as_bool()).unwrap_or(false);
+    let timeout = state.timeout_ms(cmd);
+
+    // no-errors is only meaningful if console/error capture is on — otherwise a
+    // PASS would be a false negative. Treat as un-evaluable (exit 2), not pass.
+    if kind == "errors" && !console_capture_active(state) {
+        return Err(format!(
+            "expect no-errors requires console capture — {CONSOLE_DISABLED_HINT}"
+        ));
+    }
+    if kind == "request" {
+        enable_request_tracking(state).await;
+    }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout);
+    let mut actual;
+    let mut pass;
+    loop {
+        // For network assertions, pull any buffered CDP events so requests that
+        // arrived during the poll window become visible (drain otherwise only runs
+        // once per command, before this handler).
+        if kind == "request" {
+            let _ = state.drain_cdp_events();
+        }
+        let (raw, act) = eval_expect_once(cmd, &kind, state).await?;
+        actual = act;
+        pass = raw ^ not;
+        if pass || no_wait || std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    Ok(json!({
+        "pass": pass,
+        "kind": kind,
+        "condition": describe_expect(cmd),
+        "actual": actual,
+        "timedOut": !pass && !no_wait,
+    }))
+}
+
+/// One evaluation of an expect condition. Returns (condition-holds, actual-value).
+/// Errs only when genuinely un-evaluable (no browser) — a missing element is a
+/// normal `false`/`true`, never an error.
+async fn eval_expect_once(
+    cmd: &Value,
+    kind: &str,
+    state: &DaemonState,
+) -> Result<(bool, Value), String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+    let sel = cmd.get("selector").and_then(|v| v.as_str()).unwrap_or("");
+    let predicate = cmd.get("predicate").and_then(|v| v.as_str()).unwrap_or("");
+    let expected = cmd.get("expected").and_then(|v| v.as_str()).unwrap_or("");
+    let regex = cmd.get("regex").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    match kind {
+        "element" => {
+            let want = cmd
+                .get("state")
+                .and_then(|v| v.as_str())
+                .unwrap_or("present");
+            let present = super::element::resolve_element_object_id(
+                &mgr.client,
+                &session_id,
+                &state.ref_map,
+                sel,
+                &state.iframe_sessions,
+            )
+            .await
+            .is_ok();
+            let holds = match want {
+                "attached" => present,
+                "detached" => !present,
+                "visible" => {
+                    present
+                        && super::element::is_element_visible(
+                            &mgr.client,
+                            &session_id,
+                            &state.ref_map,
+                            sel,
+                            &state.iframe_sessions,
+                        )
+                        .await
+                        .unwrap_or(false)
+                }
+                "hidden" => {
+                    !present
+                        || !super::element::is_element_visible(
+                            &mgr.client,
+                            &session_id,
+                            &state.ref_map,
+                            sel,
+                            &state.iframe_sessions,
+                        )
+                        .await
+                        .unwrap_or(false)
+                }
+                _ => present,
+            };
+            Ok((holds, json!({ "present": present })))
+        }
+        "count" => {
+            let op = cmd.get("op").and_then(|v| v.as_str()).unwrap_or("eq");
+            let want = cmd.get("value").and_then(|v| v.as_u64()).unwrap_or(0);
+            let n = super::element::get_element_count(&mgr.client, &session_id, sel)
+                .await
+                .unwrap_or(0)
+                .max(0) as u64;
+            Ok((compare_count(op, n, want), json!(n)))
+        }
+        "text" | "value" => {
+            let got = if kind == "text" {
+                super::element::get_element_text(
+                    &mgr.client,
+                    &session_id,
+                    &state.ref_map,
+                    sel,
+                    &state.iframe_sessions,
+                )
+                .await
+            } else {
+                super::element::get_element_input_value(
+                    &mgr.client,
+                    &session_id,
+                    &state.ref_map,
+                    sel,
+                    &state.iframe_sessions,
+                )
+                .await
+            };
+            match got {
+                Ok(s) => Ok((predicate_match(predicate, &s, expected, regex), json!(s))),
+                // element not found → condition false, not an error
+                Err(_) => Ok((false, Value::Null)),
+            }
+        }
+        "attr" => {
+            let name = cmd.get("attr").and_then(|v| v.as_str()).unwrap_or("");
+            match super::element::get_element_attribute(
+                &mgr.client,
+                &session_id,
+                &state.ref_map,
+                sel,
+                name,
+                &state.iframe_sessions,
+            )
+            .await
+            {
+                Ok(v) => {
+                    let s = v.as_str().map(|s| s.to_string()).unwrap_or_else(|| {
+                        if v.is_null() {
+                            String::new()
+                        } else {
+                            v.to_string()
+                        }
+                    });
+                    Ok((predicate_match(predicate, &s, expected, regex), json!(s)))
+                }
+                Err(_) => Ok((false, Value::Null)),
+            }
+        }
+        "url" => {
+            let url = mgr.get_url().await.unwrap_or_default();
+            let holds = match predicate {
+                "equals" => url == expected,
+                "contains" => url.contains(expected),
+                "matches" => {
+                    let pat = if regex {
+                        expected.to_string()
+                    } else {
+                        url_glob_to_regex(expected)
+                    };
+                    regex_lite::Regex::new(&pat)
+                        .map(|re| re.is_match(&url))
+                        .unwrap_or(false)
+                }
+                _ => false,
+            };
+            Ok((holds, json!(url)))
+        }
+        "request" => {
+            let filter = cmd.get("filter").and_then(|v| v.as_str());
+            let method = cmd.get("method").and_then(|v| v.as_str());
+            let status = cmd.get("status").and_then(|v| v.as_str());
+            let type_list: Vec<String> = cmd
+                .get("type")
+                .and_then(|v| v.as_str())
+                .map(|t| t.split(',').map(|s| s.trim().to_lowercase()).collect())
+                .unwrap_or_default();
+            let n = state
+                .tracked_requests
+                .iter()
+                .filter(|r| request_matches(r, filter, method, status, &type_list))
+                .count() as u64;
+            let holds = match cmd.get("count").and_then(|v| v.as_u64()) {
+                Some(want) => n == want,
+                None => n >= 1,
+            };
+            Ok((holds, json!(n)))
+        }
+        "errors" => {
+            let errs = state.event_tracker.get_errors_json();
+            let n = errs
+                .get("errors")
+                .and_then(|e| e.as_array())
+                .map(|a| a.len())
+                .unwrap_or(0);
+            Ok((n == 0, json!(n)))
+        }
+        other => Err(format!("expect: unknown kind '{other}'")),
+    }
+}
+
+/// Human-readable one-liner for an expect condition (for PASS/FAIL output).
+fn describe_expect(cmd: &Value) -> String {
+    let g = |k: &str| cmd.get(k).and_then(|v| v.as_str()).unwrap_or("");
+    let not = if cmd.get("not").and_then(|v| v.as_bool()).unwrap_or(false) {
+        "NOT "
+    } else {
+        ""
+    };
+    let body = match g("kind") {
+        "element" => format!("{} {}", g("selector"), g("state")),
+        "count" => format!(
+            "count {} {} {}",
+            g("selector"),
+            g("op"),
+            cmd.get("value").and_then(|v| v.as_u64()).unwrap_or(0)
+        ),
+        "text" | "value" => format!(
+            "{} {} {} \"{}\"",
+            g("kind"),
+            g("selector"),
+            g("predicate"),
+            g("expected")
+        ),
+        "attr" => format!(
+            "attr {} {} {} \"{}\"",
+            g("selector"),
+            g("attr"),
+            g("predicate"),
+            g("expected")
+        ),
+        "url" => format!("url {} \"{}\"", g("predicate"), g("expected")),
+        "request" => format!("request \"{}\"", g("filter")),
+        "errors" => "no-errors".to_string(),
+        _ => "?".to_string(),
+    };
+    format!("{not}{body}")
+}
 
 async fn handle_errors(state: &DaemonState) -> Result<Value, String> {
     let mut result = state.event_tracker.get_errors_json();
@@ -9434,6 +9699,66 @@ async fn handle_unroute(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
     Ok(json!({ "unrouted": label }))
 }
 
+/// Whether a tracked request matches the given filters. Shared by `requests`
+/// (list) and `expect request` (assert) so both filter identically.
+pub fn request_matches(
+    r: &TrackedRequest,
+    filter: Option<&str>,
+    method: Option<&str>,
+    status: Option<&str>,
+    type_list: &[String],
+) -> bool {
+    if let Some(f) = filter {
+        if !r.url.contains(f) {
+            return false;
+        }
+    }
+    if !type_list.is_empty() && !type_list.contains(&r.resource_type.to_lowercase()) {
+        return false;
+    }
+    if let Some(m) = method {
+        if !r.method.eq_ignore_ascii_case(m) {
+            return false;
+        }
+    }
+    if let Some(s) = status {
+        if !matches_status_filter(r.status, s) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Integer comparison for `expect count` (op is canonical eq/ne/gt/lt/ge/le).
+pub fn compare_count(op: &str, actual: u64, expected: u64) -> bool {
+    match op {
+        "eq" => actual == expected,
+        "ne" => actual != expected,
+        "gt" => actual > expected,
+        "lt" => actual < expected,
+        "ge" => actual >= expected,
+        "le" => actual <= expected,
+        _ => false,
+    }
+}
+
+/// String predicate for `expect text|value|attr` (equals/contains/matches).
+/// `matches` (or any predicate when `regex` is set) treats `needle` as a
+/// regex-lite pattern; an invalid pattern yields `false` (callers that want a
+/// hard error validate at parse time).
+pub fn predicate_match(predicate: &str, haystack: &str, needle: &str, regex: bool) -> bool {
+    if regex || predicate == "matches" {
+        return regex_lite::Regex::new(needle)
+            .map(|re| re.is_match(haystack))
+            .unwrap_or(false);
+    }
+    match predicate {
+        "equals" => haystack == needle,
+        "contains" => haystack.contains(needle),
+        _ => false,
+    }
+}
+
 pub fn matches_status_filter(status: Option<i64>, filter: &str) -> bool {
     let Some(code) = status else { return false };
     let f = filter.to_lowercase();
@@ -9500,27 +9825,7 @@ async fn handle_requests(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     let requests: Vec<&TrackedRequest> = state
         .tracked_requests
         .iter()
-        .filter(|r| {
-            if let Some(f) = filter {
-                if !r.url.contains(f) {
-                    return false;
-                }
-            }
-            if !type_list.is_empty() && !type_list.contains(&r.resource_type.to_lowercase()) {
-                return false;
-            }
-            if let Some(m) = method_filter {
-                if !r.method.eq_ignore_ascii_case(m) {
-                    return false;
-                }
-            }
-            if let Some(s) = status_filter {
-                if !matches_status_filter(r.status, s) {
-                    return false;
-                }
-            }
-            true
-        })
+        .filter(|r| request_matches(r, filter, method_filter, status_filter, &type_list))
         .collect();
 
     // NB: do NOT add a top-level `count` field here — the human formatter treats
@@ -10422,6 +10727,67 @@ mod tests {
         assert_eq!(clearance_state(Some(2000.0), 1000.0), (true, false));
         // expired: expiry in the past
         assert_eq!(clearance_state(Some(500.0), 1000.0), (true, true));
+    }
+
+    #[test]
+    fn test_compare_count() {
+        assert!(compare_count("eq", 3, 3) && !compare_count("eq", 3, 4));
+        assert!(compare_count("ne", 3, 4) && !compare_count("ne", 3, 3));
+        assert!(compare_count("gt", 4, 3) && !compare_count("gt", 3, 3));
+        assert!(compare_count("lt", 2, 3) && !compare_count("lt", 3, 3));
+        assert!(
+            compare_count("ge", 3, 3) && compare_count("ge", 4, 3) && !compare_count("ge", 2, 3)
+        );
+        assert!(
+            compare_count("le", 3, 3) && compare_count("le", 2, 3) && !compare_count("le", 4, 3)
+        );
+        assert!(!compare_count("??", 3, 3));
+    }
+
+    #[test]
+    fn test_predicate_match() {
+        assert!(predicate_match("equals", "Saved", "Saved", false));
+        assert!(!predicate_match("equals", "Saved!", "Saved", false));
+        assert!(predicate_match("contains", "error: bad", "error", false));
+        assert!(predicate_match("matches", "Saved", "^Sav", false));
+        // regex flag forces regex even with equals/contains predicate name
+        assert!(predicate_match("contains", "abc123", r"\d+", true));
+        // invalid regex → false, not panic
+        assert!(!predicate_match("matches", "x", "[unclosed", false));
+    }
+
+    #[test]
+    fn test_request_matches_parity() {
+        let r = TrackedRequest {
+            url: "https://x.com/api/save".to_string(),
+            method: "POST".to_string(),
+            headers: json!({}),
+            timestamp: 0,
+            resource_type: "xhr".to_string(),
+            request_id: "1".to_string(),
+            post_data: None,
+            status: Some(200),
+            response_headers: None,
+            mime_type: None,
+        };
+        assert!(request_matches(&r, Some("/api/save"), None, None, &[]));
+        assert!(request_matches(
+            &r,
+            Some("/api"),
+            Some("post"),
+            Some("2xx"),
+            &["xhr".to_string()]
+        ));
+        assert!(!request_matches(&r, Some("/nope"), None, None, &[]));
+        assert!(!request_matches(&r, None, Some("GET"), None, &[]));
+        assert!(!request_matches(&r, None, None, Some("4xx"), &[]));
+        assert!(!request_matches(
+            &r,
+            None,
+            None,
+            None,
+            &["document".to_string()]
+        ));
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -244,6 +244,39 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
 
+        // `expect` assertion result → a PASS/FAIL line. Action-gated and placed
+        // early so the generic key-based renderers don't swallow it. The exit code
+        // is set in main.rs.
+        if action == Some("expect") {
+            let pass = data.get("pass").and_then(|v| v.as_bool()).unwrap_or(false);
+            let cond = data.get("condition").and_then(|v| v.as_str()).unwrap_or("");
+            if pass {
+                println!("{} expect: {}", color::green("PASS"), cond);
+            } else {
+                let actual = data
+                    .get("actual")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let timed = data
+                    .get("timedOut")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let suffix = if timed { " (timed out)" } else { "" };
+                println!(
+                    "{} expect: {} — actual: {}{}",
+                    color::red("FAIL"),
+                    cond,
+                    if actual.is_null() {
+                        "∅".to_string()
+                    } else {
+                        actual.to_string()
+                    },
+                    suffix
+                );
+            }
+            return;
+        }
+
         // Cloudflare challenge/clearance preflight (`cf-status`). Checked early
         // because its response carries `url`/`title`, which later generic
         // renderers would otherwise swallow.
@@ -1910,6 +1943,46 @@ Examples:
 "##
         }
 
+        // === Expect (assertion) ===
+        "expect" => {
+            r##"
+chrome-use expect - Assert a condition (pass/fail with exit code)
+
+Usage: chrome-use expect <condition> [--timeout <ms>] [--no-wait] [--not]
+
+The "did it actually work?" gate. Waits up to --timeout for the condition to
+hold (poll), then exits: 0 = pass, 1 = condition false, 2 = un-evaluable
+(no browser / bad grammar). --json prints {pass, actual, ...} on both outcomes.
+
+Conditions:
+  expect <sel|@ref> visible|hidden|gone|present   element state
+  expect count <css> <op> <n>                     op: == != > < >= <= (quote > <) or eq/ne/gt/lt/ge/le
+  expect text|value <sel|@ref> equals|contains|matches <str>
+  expect attr <sel|@ref> <name> equals|contains|matches <str>
+  expect url equals|contains|matches <pat>        matches = glob (use --regex for raw regex)
+  expect request <url-substr> [--method M] [--status 2xx] [--type xhr] [--count N]
+  expect no-errors                                no console errors captured
+
+Flags:
+  --timeout <ms>   how long to wait for it to hold (default AGENT_BROWSER_DEFAULT_TIMEOUT)
+  --no-wait        evaluate once, don't poll
+  --not            invert (pass when the condition is false)
+  --regex          treat the match value as a raw regex (text/value/attr/url)
+
+Examples:
+  chrome-use click @e8 && chrome-use expect "#toast" visible
+  chrome-use expect count ".result" ">=" 1
+  chrome-use expect text @e3 contains "Saved"
+  chrome-use expect url contains /dashboard
+  chrome-use requests --clear && chrome-use click @save && chrome-use expect request /api/save --status 2xx
+  chrome-use expect no-errors
+
+Note: `expect request` only sees requests captured AFTER tracking is on — run
+`requests --clear` (or any network command) before the action that fires it.
+`expect no-errors` needs console capture active (run `console` once to enable).
+"##
+        }
+
         // === Screenshot/PDF ===
         "screenshot" => {
             r##"
@@ -3332,6 +3405,8 @@ Core Commands:
   scroll <dir> [px]          Scroll (up/down/left/right)
   scrollintoview <sel>       Scroll element into view
   wait <sel|ms>              Wait for element or time
+  expect <condition>         Assert (pass/fail + exit code): element visible/gone,
+                             count, text/value/attr, url, request fired, no-errors
   screenshot [path]          Take screenshot (auto-downscaled to ≤2000px long edge;
                              --max-width/--max-height/--scale to override)
   pdf <path>                 Save as PDF

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -695,6 +695,31 @@ After any page-changing action, pick one:
 Avoid bare `wait 2000` except when debugging — it makes scripts slow and
 flaky. Timeouts default to 25 seconds.
 
+### Confirm an action worked — `expect`
+
+After acting, **assert the result instead of eyeballing a snapshot**. `expect`
+is a pass/fail verb with an exit code (0 pass / 1 false / 2 un-evaluable), so it
+composes with `&&` and `chrome-use batch`, and costs ~1 line instead of a
+snapshot you have to read:
+
+```bash
+chrome-use click @e8 && chrome-use expect "#toast" visible      # did the toast show?
+chrome-use expect count ".result" ">=" 1                        # results loaded?
+chrome-use expect text @e3 contains "Saved"                     # success message?
+chrome-use expect url contains /dashboard                       # navigation landed?
+chrome-use expect "#spinner" gone                               # finished loading?
+chrome-use requests --clear && chrome-use click @save \
+  && chrome-use expect request /api/save --status 2xx           # the POST fired & 2xx?
+chrome-use expect no-errors                                     # no console errors?
+```
+
+It **waits** up to the timeout for the condition to hold (poll), so you often
+don't need a separate `wait`. Conditions: element `visible|hidden|gone|present`;
+`count <css> <op> <n>`; `text|value|attr … equals|contains|matches`; `url …`;
+`request <substr> [--status 2xx]`; `no-errors`. `--not` inverts, `--no-wait`
+checks once. (`expect request` only sees requests captured after tracking is on —
+`requests --clear` first; `no-errors` needs console capture — run `console` once.)
+
 ## Common workflows
 
 ### Log in


### PR DESCRIPTION
First feature from the brainstorm shortlist (top ROI). `chrome-use expect <condition>` lets an agent **confirm an action worked** instead of snapshotting + eyeballing — ~1 line + a boolean vs a multi-hundred-token read.

Exit **0 pass / 1 false / 2 un-evaluable**; `--json` emits {pass, actual, …} on both; composes with `&&` and `batch`.

Conditions (polls until it holds up to --timeout, unless --no-wait; --not inverts):
- `<sel|@ref> visible|hidden|gone|present` (gone/present → detached/attached, what the wait helpers understand — review fix)
- `count <css> <op> <n>`, `text|value|attr <sel> equals|contains|matches <str>`, `url … <pat>` (glob; --regex raw)
- `request <substr> [--method --status --count]` (drains events in the poll loop), `no-errors` (Err→exit 2 if console capture off — never a false pass)

Built on existing primitives per the vetted+adversarially-reviewed spec: `resolve_element_object_id` (adaptive @ref relocation), `get_element_{count,text,input_value,attribute}`, `is_element_visible`, `url_glob_to_regex`, `enable_request_tracking` + a new shared `request_matches` extracted from `handle_requests` (parity-tested). New pure helpers `compare_count`/`predicate_match`.

Tests: 6 parse + 3 helper. Live-verified on example.com (visible/count/text/url PASS→0, mismatch FAIL→1, #nope gone→PASS). fmt+clippy clean. **CLI-only**, no extension change.