### PR TITLE
feat(extract): structured scrape to JSON via a declarative schema

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -37,6 +37,7 @@ const KNOWN_COMMANDS: &[&str] = &[
     "open",
     "navigate",
     "expect",
+    "extract",
     "click",
     "fill",
     "type",
@@ -1785,6 +1786,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         // === Is (state checks) ===
         "is" => parse_is(&rest, &id),
         "expect" => parse_expect(&rest, &id),
+        "extract" => parse_extract(&rest, &id),
 
         // === Find (locators) ===
         "find" => parse_find(&rest, &id),
@@ -2992,6 +2994,84 @@ fn parse_is(rest: &[&str], id: &str) -> Result<Value, ParseError> {
             usage: "is <visible|enabled|checked> <selector>",
         }),
     }
+}
+
+/// `extract --schema <json>` — declarative structured scrape → JSON. Schema:
+/// `{ "rows"?: "<css>", "fields": { "k": "<css>" | {"sel","get","all"} } }`.
+/// `get` = text (default) | @attr | html | value. Compiled to one eval (see
+/// handle_extract). `--frame` is leading-only, mirroring `eval`.
+fn parse_extract(rest: &[&str], id: &str) -> Result<Value, ParseError> {
+    let usage = "extract --schema <json> | --schema-file <path> | --stdin  [--frame <f>]";
+    // Leading-only --frame (copy eval's pattern so it never eats a schema token).
+    let mut frame: Option<String> = None;
+    let rest: Vec<&str> = if rest.first() == Some(&"--frame") {
+        let v = rest.get(1).copied().ok_or(ParseError::InvalidValue {
+            message: "extract --frame requires a value".to_string(),
+            usage,
+        })?;
+        frame = Some(v.to_string());
+        rest[2..].to_vec()
+    } else {
+        rest.to_vec()
+    };
+
+    let schema_str = match rest.first().copied() {
+        Some("--schema") => {
+            rest.get(1)
+                .map(|s| s.to_string())
+                .ok_or(ParseError::MissingArguments {
+                    context: "extract --schema".to_string(),
+                    usage,
+                })?
+        }
+        Some("--schema-file") => {
+            let path = rest.get(1).ok_or(ParseError::MissingArguments {
+                context: "extract --schema-file".to_string(),
+                usage,
+            })?;
+            std::fs::read_to_string(path).map_err(|e| ParseError::InvalidValue {
+                message: format!("extract --schema-file: cannot read {path}: {e}"),
+                usage,
+            })?
+        }
+        Some("--stdin") => {
+            use std::io::BufRead;
+            let stdin = std::io::stdin();
+            stdin
+                .lock()
+                .lines()
+                .map(|l| l.unwrap_or_default())
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+        _ => {
+            return Err(ParseError::MissingArguments {
+                context: "extract".to_string(),
+                usage,
+            })
+        }
+    };
+
+    let schema: Value =
+        serde_json::from_str(schema_str.trim()).map_err(|e| ParseError::InvalidValue {
+            message: format!("extract schema is not valid JSON: {e}"),
+            usage,
+        })?;
+    if !schema.get("fields").map(|f| f.is_object()).unwrap_or(false) {
+        return Err(ParseError::InvalidValue {
+            message: "extract schema needs a \"fields\" object".to_string(),
+            usage,
+        });
+    }
+
+    let mut obj = serde_json::Map::new();
+    obj.insert("id".into(), json!(id));
+    obj.insert("action".into(), json!("extract"));
+    obj.insert("schema".into(), schema);
+    if let Some(f) = frame {
+        obj.insert("frame".into(), json!(f));
+    }
+    Ok(Value::Object(obj))
 }
 
 /// `expect <condition>` — pass/fail assertion verb. Subject-first for element
@@ -5653,6 +5733,42 @@ mod tests {
         let c = parse_command(&args("expect no-errors"), &default_flags()).unwrap();
         assert_eq!(c["kind"], "errors");
         assert_eq!(c["max"], 0);
+    }
+
+    // === extract parse tests ===
+    #[test]
+    fn test_extract_schema_ok() {
+        let c = parse_command(
+            &args(r#"extract --schema {"rows":".card","fields":{"name":".t"}}"#),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(c["action"], "extract");
+        assert_eq!(c["schema"]["rows"], ".card");
+        assert_eq!(c["schema"]["fields"]["name"], ".t");
+    }
+
+    #[test]
+    fn test_extract_requires_fields_and_valid_json() {
+        // missing fields
+        assert!(
+            parse_command(&args(r#"extract --schema {"rows":".x"}"#), &default_flags()).is_err()
+        );
+        // invalid json
+        assert!(parse_command(&args("extract --schema {bad"), &default_flags()).is_err());
+        // no source
+        assert!(parse_command(&args("extract"), &default_flags()).is_err());
+    }
+
+    #[test]
+    fn test_extract_leading_frame() {
+        let c = parse_command(
+            &args(r#"extract --frame 1 --schema {"fields":{"a":".x"}}"#),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(c["frame"], "1");
+        assert_eq!(c["schema"]["fields"]["a"], ".x");
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1442,6 +1442,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "nth" => handle_nth(cmd, state).await,
         "find" => handle_find(cmd, state).await,
         "expect" => handle_expect(cmd, state).await,
+        "extract" => handle_extract(cmd, state).await,
         "evalhandle" => handle_evalhandle(cmd, state).await,
         "drag" => handle_drag(cmd, state).await,
         "solve_slider" => handle_solve_slider(cmd, state).await,
@@ -5364,6 +5365,86 @@ fn describe_expect(cmd: &Value) -> String {
         _ => "?".to_string(),
     };
     format!("{not}{body}")
+}
+
+/// `extract --schema` — compile the schema to ONE eval that returns structured
+/// JSON. No new CDP plumbing: BrowserManager::evaluate returns the JSON value
+/// directly (returnByValue). (Feature from #65-followup brainstorm.)
+async fn handle_extract(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let schema = cmd.get("schema").ok_or("extract: missing schema")?;
+    let fields = schema
+        .get("fields")
+        .and_then(|f| f.as_object())
+        .ok_or("extract: schema.fields must be an object")?;
+    let rows = schema.get("rows").and_then(|v| v.as_str());
+
+    // Normalize each field to {sel, get, all} so the JS template is uniform.
+    let mut norm = serde_json::Map::new();
+    for (k, v) in fields {
+        let spec = match v {
+            Value::String(s) => json!({ "sel": s, "get": "text", "all": false }),
+            Value::Object(o) => json!({
+                "sel": o.get("sel").and_then(|x| x.as_str()).unwrap_or(""),
+                "get": o.get("get").and_then(|x| x.as_str()).unwrap_or("text"),
+                "all": o.get("all").and_then(|x| x.as_bool()).unwrap_or(false),
+            }),
+            _ => {
+                return Err(format!(
+                    "extract: field '{k}' must be a css string or {{sel,get,all}} object"
+                ))
+            }
+        };
+        norm.insert(k.clone(), spec);
+    }
+    let fields_json = serde_json::to_string(&Value::Object(norm)).unwrap_or_default();
+    let rows_json = serde_json::to_string(&rows).unwrap_or_else(|_| "null".to_string());
+
+    let script = format!(
+        r#"(() => {{
+  const FIELDS = {fields_json};
+  const ROWSEL = {rows_json};
+  const pick = (el, get) => {{
+    if (!el) return null;
+    if (get && get[0] === '@') return el.getAttribute(get.slice(1));
+    if (get === 'html') return el.innerHTML;
+    if (get === 'value') return el.value != null ? el.value : null;
+    return ((el.innerText || el.textContent) || '').trim();
+  }};
+  const one = (root, spec) => {{
+    if (spec.all) {{
+      const nodes = spec.sel ? Array.from(root.querySelectorAll(spec.sel)) : [];
+      return nodes.map((n) => pick(n, spec.get));
+    }}
+    const el = spec.sel ? root.querySelector(spec.sel) : root;
+    return pick(el, spec.get);
+  }};
+  const extractRow = (root) => {{
+    const o = {{}};
+    for (const k in FIELDS) o[k] = one(root, FIELDS[k]);
+    return o;
+  }};
+  if (ROWSEL) return Array.from(document.querySelectorAll(ROWSEL)).map(extractRow);
+  return extractRow(document);
+}})()"#
+    );
+
+    let extracted = match cmd.get("frame").and_then(|v| v.as_str()) {
+        Some(spec) => {
+            let frame_id =
+                resolve_frame_spec(mgr, &state.ref_map, &state.iframe_sessions, spec).await?;
+            mgr.evaluate_in_frame(&script, &frame_id, &state.iframe_sessions)
+                .await?
+        }
+        None => mgr.evaluate(&script, None).await?,
+    };
+    let count = extracted.as_array().map(|a| a.len());
+    let url = mgr.get_url().await.unwrap_or_default();
+    let mut out = json!({ "extracted": extracted, "origin": url });
+    if let Some(c) = count {
+        out["count"] = json!(c);
+    }
+    Ok(out)
 }
 
 async fn handle_errors(state: &DaemonState) -> Result<Value, String> {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -277,6 +277,19 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
 
+        // `extract` → print the structured result as pretty JSON (its whole point
+        // is machine-readable data; that's also the best human view). Action-gated
+        // + early so generic renderers don't swallow it.
+        if action == Some("extract") {
+            if let Some(ex) = data.get("extracted") {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(ex).unwrap_or_else(|_| ex.to_string())
+                );
+            }
+            return;
+        }
+
         // Cloudflare challenge/clearance preflight (`cf-status`). Checked early
         // because its response carries `url`/`title`, which later generic
         // renderers would otherwise swallow.
@@ -1983,6 +1996,42 @@ Note: `expect request` only sees requests captured AFTER tracking is on — run
 "##
         }
 
+        // === Extract (structured scrape) ===
+        "extract" => {
+            r##"
+chrome-use extract - Scrape structured JSON from the page
+
+Usage:
+  chrome-use extract --schema <json>        inline schema
+  chrome-use extract --schema-file <path>   schema from a file
+  chrome-use extract --stdin                schema from stdin (heredoc)
+  [--frame <index|url|@ref|css>]            scope to a child frame (leading flag)
+
+One declarative call instead of N find/get round-trips or hand-written eval.
+Compiled to a single page evaluation; returns a JSON array (with `rows`) or a
+single object.
+
+Schema:
+  {
+    "rows": "<css>",        // optional: repeating container → array; omit → one object on the document
+    "fields": {
+      "name": ".title",                          // shorthand: css → trimmed text
+      "price": { "sel": ".price", "get": "text" },
+      "href":  { "sel": "a", "get": "@href" },   // @attr
+      "html":  { "sel": ".body", "get": "html" },
+      "value": { "sel": "input", "get": "value" },
+      "tags":  { "sel": ".tag", "get": "text", "all": true }   // array of every match
+    }
+  }
+  get = text (default) | @<attr> | html | value.  sel "" or omitted = the row root itself.
+
+Examples:
+  chrome-use extract --schema '{"rows":".product","fields":{"name":".name","price":".price"}}'
+  chrome-use extract --schema '{"fields":{"title":"h1","canonical":{"sel":"link[rel=canonical]","get":"@href"}}}'
+  cat schema.json | chrome-use extract --stdin
+"##
+        }
+
         // === Screenshot/PDF ===
         "screenshot" => {
             r##"
@@ -3407,6 +3456,8 @@ Core Commands:
   wait <sel|ms>              Wait for element or time
   expect <condition>         Assert (pass/fail + exit code): element visible/gone,
                              count, text/value/attr, url, request fired, no-errors
+  extract --schema <json>    Scrape structured JSON (rows+fields) → array/object
+                             (one call vs N find/get; generic, any logged-in site)
   screenshot [path]          Take screenshot (auto-downscaled to ≤2000px long edge;
                              --max-width/--max-height/--scale to override)
   pdf <path>                 Save as PDF

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -81,6 +81,7 @@ need a **real, logged-in browser** — not for reading text off a public page.
 | Discover what exists / find sources | `WebSearch` |
 | Specific facts from a static or public page | `WebFetch` or `curl` (no browser) |
 | **Structured data from a known site** (GitHub issues, Reddit/HN search, Bilibili/Twitter feed, …) — esp. behind login | `chrome-use site <name>/<cmd>` (see below) — skip snapshot+click entirely |
+| **Structured data from ANY page** (no community adapter) — tables, search results, feed rows, dashboards | `chrome-use extract --schema '{rows,fields}'` → clean JSON in one call (vs N find/get, or dumping HTML that blows the context window) |
 | Login state, interaction, JS-rendered or anti-bot pages | **chrome-use** (this skill) |
 | A page the user saved before / an internal system | `chrome-use find-url <keywords>` (their bookmarks), then open it |
 | The user's **own already-open, logged-in** Chrome window | the **extension connect** flow (below) |


### PR DESCRIPTION
Second feature from the brainstorm shortlist. `chrome-use extract --schema '{rows,fields}'` → clean JSON in **one call** instead of N find/get round-trips or hand-written eval (and instead of dumping HTML / the a11y tree, which blows the context window). Generic counterpart to per-site `site` adapters — any logged-in page.

Schema: `{ "rows"?: "<css>", "fields": { "k": "<css>" | {"sel","get","all"} } }`. rows → array; omitted → one object. get = text (default) | @attr | html | value; all:true → array of every match.

**Pure codegen-over-eval** (vetted spec): schema compiles to ONE eval returning the JSON value directly (returnByValue) — no new CDP/RefMap plumbing. Reuses `evaluate`/`evaluate_in_frame` + `resolve_frame_spec` (leading `--frame`); input via --schema/--schema-file/--stdin. Output formatter is action-gated (avoids the double-`data` nesting the review flagged).

Tests: 3 parse. Live-verified on example.com (single object w/ @href, and rows array). fmt+clippy clean. CLI-only.