### PR TITLE
feat(guards): --if-present / --optional — skip a selector action when target absent

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -413,6 +413,14 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
         }
     }
 
+    // Action guards (#65 followup): stamp the `--if-present`/`--optional` flag onto
+    // the action so the daemon turns an "element absent" error into a skip.
+    if flags.if_present {
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("ifPresent".to_string(), json!(true));
+        }
+    }
+
     Ok(result)
 }
 
@@ -3941,6 +3949,7 @@ mod tests {
             enable: Vec::new(),
             cdp: None,
             browser: None,
+            if_present: false,
             profile: None,
             state: None,
             proxy: None,
@@ -5733,6 +5742,17 @@ mod tests {
         let c = parse_command(&args("expect no-errors"), &default_flags()).unwrap();
         assert_eq!(c["kind"], "errors");
         assert_eq!(c["max"], 0);
+    }
+
+    #[test]
+    fn test_if_present_stamps_action() {
+        let mut f = default_flags();
+        f.if_present = true;
+        let c = parse_command(&args("click #x"), &f).unwrap();
+        assert_eq!(c["ifPresent"], true);
+        // off by default
+        let c = parse_command(&args("click #x"), &default_flags()).unwrap();
+        assert!(c.get("ifPresent").is_none());
     }
 
     // === extract parse tests ===

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -339,6 +339,9 @@ pub struct Flags {
     pub idle_timeout: Option<String>, // Canonical milliseconds string for AGENT_BROWSER_IDLE_TIMEOUT_MS
     pub default_timeout: Option<u64>, // AGENT_BROWSER_DEFAULT_TIMEOUT in ms
     pub no_auto_dialog: bool,
+    /// `--if-present`/`--optional`: skip a selector action (success {skipped})
+    /// instead of erroring when the target element is absent (issue #65 followup).
+    pub if_present: bool,
     pub model: Option<String>,
     pub verbose: bool,
     pub quiet: bool,
@@ -603,6 +606,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
             .and_then(|s| s.parse::<u64>().ok()),
         no_auto_dialog: env_var_is_truthy("AGENT_BROWSER_NO_AUTO_DIALOG")
             || config.no_auto_dialog.unwrap_or(false),
+        if_present: false,
         model: env::var("AI_GATEWAY_MODEL").ok().or(config.model),
         verbose: false,
         quiet: false,
@@ -947,6 +951,9 @@ pub fn parse_flags(args: &[String]) -> Flags {
                     i += 1;
                 }
             }
+            "--if-present" | "--optional" => {
+                flags.if_present = true;
+            }
             "--model" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.model = Some(s.clone());
@@ -989,6 +996,12 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         "--content-boundaries",
         "--confirm-interactive",
         "--no-auto-dialog",
+        // Action guards (issue #65 followup): skip an action instead of erroring
+        // when its target element is absent. Stripped here so they don't break a
+        // command's positional parsing; injected into the action JSON via
+        // parse_command from Flags.if_present.
+        "--if-present",
+        "--optional",
         "-v",
         "--verbose",
         "-q",

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1484,6 +1484,22 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         _ => Err(format!("Not yet implemented: {}", action)),
     };
 
+    // Action guards (#65 followup): with `--if-present`/`--optional`, an action
+    // whose target element is absent becomes a no-op success ({skipped:true})
+    // instead of an error — so optional steps (dismiss a maybe-present banner,
+    // toggle a maybe-missing control) don't need a pre-check read and flows stay
+    // idempotent. Only swallows "element absent" errors, never real failures.
+    let if_present = cmd
+        .get("ifPresent")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let result = match result {
+        Err(e) if if_present && is_element_absent_error(&e) => {
+            Ok(json!({ "skipped": true, "reason": "target not present (--if-present)" }))
+        }
+        other => other,
+    };
+
     let mut resp = match result {
         Ok(data) => success_response(&id, data),
         Err(e) => error_response(&id, &super::browser::to_ai_friendly_error(&e)),
@@ -5365,6 +5381,22 @@ fn describe_expect(cmd: &Value) -> String {
         _ => "?".to_string(),
     };
     format!("{not}{body}")
+}
+
+/// Whether an error means "the target element isn't on the page" (vs a real
+/// failure). Used by the `--if-present`/`--optional` guards to skip rather than
+/// error. Matches the locator/resolve "not found" phrasings; deliberately does
+/// NOT match timeouts, navigation, or transport errors.
+fn is_element_absent_error(e: &str) -> bool {
+    let l = e.to_lowercase();
+    l.contains("element not found")
+        || l.contains("no element")
+        || l.contains("did not match any element")
+        || l.contains("could not resolve")
+        || l.contains("no node found")
+        || l.contains("unknown ref")
+        || l.contains("node with given id does not exist")
+        || l.contains("cannot find")
 }
 
 /// `extract --schema` — compile the schema to ONE eval that returns structured
@@ -10808,6 +10840,24 @@ mod tests {
         assert_eq!(clearance_state(Some(2000.0), 1000.0), (true, false));
         // expired: expiry in the past
         assert_eq!(clearance_state(Some(500.0), 1000.0), (true, true));
+    }
+
+    #[test]
+    fn test_is_element_absent_error() {
+        assert!(is_element_absent_error("Element not found in the page DOM"));
+        assert!(is_element_absent_error("No element found for css 'x'"));
+        assert!(is_element_absent_error("Unknown ref: e9"));
+        assert!(is_element_absent_error(
+            "Selector 'x' did not match any element"
+        ));
+        // real failures are NOT swallowed
+        assert!(!is_element_absent_error("Operation timed out"));
+        assert!(!is_element_absent_error(
+            "Navigation failed: ERR_CONNECTION"
+        ));
+        assert!(!is_element_absent_error(
+            "stale sessionId ... its tab is gone"
+        ));
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -277,6 +277,21 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
 
+        // Action guard skip (`--if-present`/`--optional`): the target was absent so
+        // the action no-op'd. Surface it so a skip isn't mistaken for a real action.
+        if data
+            .get("skipped")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            let reason = data
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("skipped");
+            println!("{} {}", color::dim("↷"), color::dim(reason));
+            return;
+        }
+
         // `extract` → print the structured result as pretty JSON (its whole point
         // is machine-readable data; that's also the best human view). Action-gated
         // + early so generic renderers don't swallow it.
@@ -3695,6 +3710,8 @@ Options:
   --confirm-interactive      Interactive confirmation prompts; auto-denies if stdin is not a TTY (or AGENT_BROWSER_CONFIRM_INTERACTIVE)
   --engine <name>            Browser engine: chrome (default), lightpanda (or AGENT_BROWSER_ENGINE)
   --no-auto-dialog           Disable automatic dismissal of alert/beforeunload dialogs (or AGENT_BROWSER_NO_AUTO_DIALOG)
+  --if-present, --optional   Skip a selector action (success, no-op) instead of
+                             erroring when the target element is absent
   --model <name>             AI model for chat (or AI_GATEWAY_MODEL env)
   -v, --verbose              Show tool commands and their raw output
   -q, --quiet                Show only AI text responses (hide tool calls)

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -714,6 +714,13 @@ chrome-use requests --clear && chrome-use click @save \
 chrome-use expect no-errors                                     # no console errors?
 ```
 
+**Optional steps — `--if-present` (alias `--optional`).** Add it to any selector
+action to make it a no-op success (`↷ skipped`, exit 0) when the target is
+absent, instead of erroring — no pre-check read needed, and flows stay
+re-runnable: `chrome-use click ".cookie-accept" --if-present` (dismiss a banner
+that may not be there), `chrome-use check "#opt-in" --if-present`. Only "element
+absent" is skipped; real failures still error.
+
 It **waits** up to the timeout for the condition to hold (poll), so you often
 don't need a separate `wait`. Conditions: element `visible|hidden|gone|present`;
 `count <css> <op> <n>`; `text|value|attr … equals|contains|matches`; `url …`;


### PR DESCRIPTION
Third brainstorm feature. Add `--if-present` (alias `--optional`) to any selector action → absent target becomes a no-op success (`↷ skipped`, exit 0) instead of an error. No pre-check read; flows stay idempotent. e.g. `click ".cookie-accept" --if-present`.

Global flag (per review: routed through flags.rs GLOBAL_BOOL_FLAGS + clean_args + Flags.if_present), injected as `ifPresent` by the parse_command wrapper. Daemon honors it in ONE place — execute_command turns an Err into `{skipped:true}` only when `is_element_absent_error` matches (locator 'not found' phrasings), never timeouts/nav/transport.

**Dropped `--unless-checked`** from the original spec — check/uncheck are already idempotent (review caught this), so it added nothing.

Tests: absent-error truth table + flag-stamp parse test. Live-verified (absent→error exit1; +--if-present→skip exit0; present+--optional→acts). fmt+clippy clean. CLI-only.