### PR TITLE
feat(observe): --observe returns only what an action changed (+ doc auto ref-heal)

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -420,6 +420,12 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
             obj.insert("ifPresent".to_string(), json!(true));
         }
     }
+    // `--observe`: stamp so the daemon returns the post-action a11y delta.
+    if flags.observe {
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("observe".to_string(), json!(true));
+        }
+    }
 
     Ok(result)
 }
@@ -3950,6 +3956,7 @@ mod tests {
             cdp: None,
             browser: None,
             if_present: false,
+            observe: false,
             profile: None,
             state: None,
             proxy: None,
@@ -5753,6 +5760,16 @@ mod tests {
         // off by default
         let c = parse_command(&args("click #x"), &default_flags()).unwrap();
         assert!(c.get("ifPresent").is_none());
+    }
+
+    #[test]
+    fn test_observe_stamps_action() {
+        let mut f = default_flags();
+        f.observe = true;
+        let c = parse_command(&args("click @e1"), &f).unwrap();
+        assert_eq!(c["observe"], true);
+        let c = parse_command(&args("click @e1"), &default_flags()).unwrap();
+        assert!(c.get("observe").is_none());
     }
 
     // === extract parse tests ===

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -342,6 +342,9 @@ pub struct Flags {
     /// `--if-present`/`--optional`: skip a selector action (success {skipped})
     /// instead of erroring when the target element is absent (issue #65 followup).
     pub if_present: bool,
+    /// `--observe`: after a mutating action, return only what changed on the page
+    /// (a11y delta + url + requests) instead of the agent re-snapshotting.
+    pub observe: bool,
     pub model: Option<String>,
     pub verbose: bool,
     pub quiet: bool,
@@ -607,6 +610,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         no_auto_dialog: env_var_is_truthy("AGENT_BROWSER_NO_AUTO_DIALOG")
             || config.no_auto_dialog.unwrap_or(false),
         if_present: false,
+        observe: false,
         model: env::var("AI_GATEWAY_MODEL").ok().or(config.model),
         verbose: false,
         quiet: false,
@@ -954,6 +958,9 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--if-present" | "--optional" => {
                 flags.if_present = true;
             }
+            "--observe" => {
+                flags.observe = true;
+            }
             "--model" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.model = Some(s.clone());
@@ -1002,6 +1009,7 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
         // parse_command from Flags.if_present.
         "--if-present",
         "--optional",
+        "--observe",
         "-v",
         "--verbose",
         "-q",

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1306,6 +1306,34 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         );
     }
 
+    // `--observe` (issue #65 followup): for a mutating action, capture a cheap
+    // interactive-snapshot baseline BEFORE the action so we can return only what
+    // changed (added/removed nodes, new toasts/validation via the #57 surface,
+    // url change, requests fired) instead of the agent running act→wait→snapshot→
+    // diff by hand. Baseline into a THROWAWAY RefMap so a `@ref` the action uses
+    // still resolves against the live state.ref_map.
+    const OBSERVABLE_ACTIONS: &[&str] = &[
+        "click", "dblclick", "fill", "type", "press", "select", "check", "uncheck", "evaluate",
+    ];
+    let observe = cmd
+        .get("observe")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+        && OBSERVABLE_ACTIONS.contains(&action)
+        && state.browser.is_some()
+        && !matches!(state.backend_type, BackendType::WebDriver);
+    let observe_baseline: Option<(String, String, usize)> = if observe {
+        enable_request_tracking(state).await;
+        let _ = state.drain_cdp_events();
+        let req_mark = state.tracked_requests.len();
+        let mgr = state.browser.as_ref().unwrap();
+        let url = mgr.get_url().await.unwrap_or_default();
+        let snap = observe_snapshot(state).await;
+        Some((url, snap, req_mark))
+    } else {
+        None
+    };
+
     let result = match action {
         "launch" => handle_launch(cmd, state).await,
         "navigate" => handle_navigate(cmd, state).await,
@@ -1500,10 +1528,63 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         other => other,
     };
 
+    let ok = result.is_ok();
     let mut resp = match result {
         Ok(data) => success_response(&id, data),
         Err(e) => error_response(&id, &super::browser::to_ai_friendly_error(&e)),
     };
+
+    // `--observe`: after a successful mutating action, settle briefly, re-snapshot,
+    // and attach ONLY the delta vs the baseline (added/removed lines, url change,
+    // requests fired). Collapses act→wait→snapshot→diff into one reply.
+    if let (true, Some((url0, snap0, req_mark))) = (ok, observe_baseline) {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        let _ = state.drain_cdp_events();
+        let snap1 = observe_snapshot(state).await;
+        // Normalize trailing newline so the diff doesn't report a spurious
+        // remove+add for the last line ("No newline at end of file").
+        let d = super::diff::diff_snapshots(
+            &format!("{}\n", snap0.trim_end()),
+            &format!("{}\n", snap1.trim_end()),
+        );
+        let url1 = state
+            .browser
+            .as_ref()
+            .unwrap()
+            .get_url()
+            .await
+            .unwrap_or_default();
+        let new_reqs: Vec<String> = state
+            .tracked_requests
+            .get(req_mark..)
+            .map(|s| {
+                s.iter()
+                    .map(|r| format!("{} {}", r.method, r.url))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut observed = serde_json::Map::new();
+        observed.insert("changed".into(), json!(d.changed || url0 != url1));
+        if d.changed {
+            observed.insert("delta".into(), json!(d.diff));
+            observed.insert("added".into(), json!(d.additions));
+            observed.insert("removed".into(), json!(d.removals));
+        }
+        if url0 != url1 {
+            observed.insert("urlChanged".into(), json!({ "from": url0, "to": url1 }));
+        }
+        if !new_reqs.is_empty() {
+            observed.insert("requests".into(), json!(new_reqs));
+        }
+        if let Some(obj) = resp.as_object_mut() {
+            let data = obj
+                .entry("data")
+                .or_insert_with(|| Value::Object(serde_json::Map::new()));
+            if let Some(d) = data.as_object_mut() {
+                d.insert("observed".into(), Value::Object(observed));
+            }
+        }
+    }
 
     // Auto-report pending JavaScript dialog so agents know why commands may hang
     if action != "dialog" {
@@ -5381,6 +5462,35 @@ fn describe_expect(cmd: &Value) -> String {
         _ => "?".to_string(),
     };
     format!("{not}{body}")
+}
+
+/// Cheap interactive+compact snapshot into a THROWAWAY RefMap (so it never
+/// disturbs the session's live `@ref`s) — the baseline/after capture for
+/// `--observe`. Returns "" on failure so a snapshot error never breaks the action.
+async fn observe_snapshot(state: &DaemonState) -> String {
+    let Some(mgr) = state.browser.as_ref() else {
+        return String::new();
+    };
+    let Ok(session_id) = mgr.active_session_id() else {
+        return String::new();
+    };
+    let session_id = session_id.to_string();
+    let options = snapshot::SnapshotOptions {
+        interactive: true,
+        compact: true,
+        ..Default::default()
+    };
+    let mut tmp = super::element::RefMap::new();
+    snapshot::take_snapshot(
+        &mgr.client,
+        &session_id,
+        &options,
+        &mut tmp,
+        state.active_frame_id.as_deref(),
+        &state.iframe_sessions,
+    )
+    .await
+    .unwrap_or_default()
 }
 
 /// Whether an error means "the target element isn't on the page" (vs a real

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3712,6 +3712,8 @@ Options:
   --no-auto-dialog           Disable automatic dismissal of alert/beforeunload dialogs (or AGENT_BROWSER_NO_AUTO_DIALOG)
   --if-present, --optional   Skip a selector action (success, no-op) instead of
                              erroring when the target element is absent
+  --observe                  After a mutating action, return only what changed
+                             (a11y delta + url + requests) — skip act→snapshot→diff
   --model <name>             AI model for chat (or AI_GATEWAY_MODEL env)
   -v, --verbose              Show tool commands and their raw output
   -q, --quiet                Show only AI text responses (hide tool calls)

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -33,8 +33,17 @@ chrome-use snapshot -i       # 4. Re-snapshot after any page change
 
 Refs (`@e1`, `@e2`, ...) are assigned fresh on every snapshot. They become
 **stale the moment the page changes** — after clicks that navigate, form
-submits, dynamic re-renders, dialog opens. Always re-snapshot before your
-next ref interaction.
+submits, dynamic re-renders, dialog opens. Re-snapshot before your next ref
+interaction after a *navigation* or a structural change.
+
+> **@refs self-heal across re-renders — you don't need to re-snapshot for every
+> minor DOM churn.** Each ref records a fingerprint (role + accessible name +
+> ancestor path); if its node is gone when you use it, chrome-use automatically
+> relocates to the matching element on the *current* page and proceeds. So after a
+> React/Vue list re-render that keeps the same labels, `click @e3` still hits the
+> right element. If the element is genuinely gone, it refuses (loud error) rather
+> than click the wrong node — it never silently mis-targets. Re-snapshot only when
+> you navigated, or when the labels/structure actually changed.
 
 > **Hard rule: snapshot-first, never screenshot-to-locate.** For form fields and
 > buttons, ALWAYS `snapshot -i` and act on refs/selectors. Do **not** reach for
@@ -713,6 +722,15 @@ chrome-use requests --clear && chrome-use click @save \
   && chrome-use expect request /api/save --status 2xx           # the POST fired & 2xx?
 chrome-use expect no-errors                                     # no console errors?
 ```
+
+**See what an action changed — `--observe`.** Add it to a mutating action
+(`click`/`fill`/`type`/`select`/`check`/`press`/`eval`) and instead of you
+running act → wait → `snapshot` → `diff`, the result carries an `observed` delta:
+the added/removed interactive lines (new toasts/validation included via the alert
+surface), any url change, and requests fired — or `{changed:false}` if nothing
+moved. e.g. `chrome-use click @e8 --observe` → see the dialog/toast/row that
+appeared in one ~20-80 token reply. Use `expect` when you want a hard pass/fail
+gate; use `--observe` when you want to *see* what happened.
 
 **Optional steps — `--if-present` (alias `--optional`).** Add it to any selector
 action to make it a no-op success (`↷ skipped`, exit 0) when the target is


### PR DESCRIPTION
Fourth brainstorm feature + a doc for the fifth (`--heal`, which already exists).

**`--observe`** on a mutating action (click/fill/type/select/check/press/eval) → the result carries an `observed` delta instead of you running act→wait→snapshot→diff: added/removed interactive lines (new toasts/validation via the #57 alert surface), url change, requests fired — or `{changed:false}`. One ~20-80 token reply.

Global flag (same plumbing as --if-present), handled centrally in execute_command: cheap interactive+compact baseline into a **throwaway RefMap** (never disturbs live @refs) → run → settle ~250ms → re-snapshot → `diff_snapshots` (newline-normalized). Requests via drain+slice from a pre-mark. WebDriver skipped.

**`--heal` already exists** (documented, no code): adaptive relocation (`relocate_stale_ref` + `collect_current_fingerprints`) re-locates a stale @ref by its ElementFingerprint against the live a11y tree at resolve time — better than the brainstorm's 'retry whole action' (no double-exec; refuses on genuine removal). Verified live: relocates across full re-render + position shift, refuses when truly gone. Added a skill note so agents know they needn't re-snapshot for every minor re-render.

Tests: observe flag-stamp. Live-verified (click adding alert → delta; no-change → {changed:false}). fmt+clippy clean. CLI-only.