### PR TITLE
feat(form): form fill --map — fill a whole form in one call

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -38,6 +38,7 @@ const KNOWN_COMMANDS: &[&str] = &[
     "navigate",
     "expect",
     "extract",
+    "form",
     "click",
     "fill",
     "type",
@@ -1801,6 +1802,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         "is" => parse_is(&rest, &id),
         "expect" => parse_expect(&rest, &id),
         "extract" => parse_extract(&rest, &id),
+        "form" => parse_form(&rest, &id),
 
         // === Find (locators) ===
         "find" => parse_find(&rest, &id),
@@ -3008,6 +3010,86 @@ fn parse_is(rest: &[&str], id: &str) -> Result<Value, ParseError> {
             usage: "is <visible|enabled|checked> <selector>",
         }),
     }
+}
+
+/// `form fill --map <json>` — fill a whole form from a {label|selector: value}
+/// map in one call, then optionally submit, returning per-field status + any
+/// inline validation errors. Values: string → text/select/radio, bool → checkbox.
+fn parse_form(rest: &[&str], id: &str) -> Result<Value, ParseError> {
+    let usage =
+        "form fill --map <json> [--submit <selector|text>]  (also --map-file <path> / --stdin)";
+    if rest.first().copied() != Some("fill") {
+        return Err(ParseError::UnknownSubcommand {
+            subcommand: rest.first().copied().unwrap_or("").to_string(),
+            valid_options: &["fill"],
+        });
+    }
+    let rest = &rest[1..];
+    let mut submit: Option<String> = None;
+    let mut map_str: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i] {
+            "--map" => {
+                map_str = rest.get(i + 1).map(|s| s.to_string());
+                i += 1;
+            }
+            "--map-file" => {
+                let p = rest.get(i + 1).ok_or(ParseError::MissingArguments {
+                    context: "form fill --map-file".to_string(),
+                    usage,
+                })?;
+                map_str =
+                    Some(
+                        std::fs::read_to_string(p).map_err(|e| ParseError::InvalidValue {
+                            message: format!("form fill --map-file: cannot read {p}: {e}"),
+                            usage,
+                        })?,
+                    );
+                i += 1;
+            }
+            "--stdin" => {
+                use std::io::BufRead;
+                let s = std::io::stdin();
+                map_str = Some(
+                    s.lock()
+                        .lines()
+                        .map(|l| l.unwrap_or_default())
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                );
+            }
+            "--submit" => {
+                submit = rest.get(i + 1).map(|s| s.to_string());
+                i += 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    let map_str = map_str.ok_or(ParseError::MissingArguments {
+        context: "form fill".to_string(),
+        usage,
+    })?;
+    let map: Value =
+        serde_json::from_str(map_str.trim()).map_err(|e| ParseError::InvalidValue {
+            message: format!("form fill --map is not valid JSON: {e}"),
+            usage,
+        })?;
+    if !map.is_object() || map.as_object().map(|m| m.is_empty()).unwrap_or(true) {
+        return Err(ParseError::InvalidValue {
+            message: "form fill --map must be a non-empty JSON object".to_string(),
+            usage,
+        });
+    }
+    let mut obj = serde_json::Map::new();
+    obj.insert("id".into(), json!(id));
+    obj.insert("action".into(), json!("form_fill"));
+    obj.insert("map".into(), map);
+    if let Some(s) = submit {
+        obj.insert("submit".into(), json!(s));
+    }
+    Ok(Value::Object(obj))
 }
 
 /// `extract --schema <json>` — declarative structured scrape → JSON. Schema:
@@ -5770,6 +5852,28 @@ mod tests {
         assert_eq!(c["observe"], true);
         let c = parse_command(&args("click @e1"), &default_flags()).unwrap();
         assert!(c.get("observe").is_none());
+    }
+
+    // === form fill parse tests ===
+    #[test]
+    fn test_form_fill_ok() {
+        let c = parse_command(
+            &args(r#"form fill --map {"Email":"a@b.com","Sub":true} --submit Save"#),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(c["action"], "form_fill");
+        assert_eq!(c["map"]["Email"], "a@b.com");
+        assert_eq!(c["map"]["Sub"], true);
+        assert_eq!(c["submit"], "Save");
+    }
+
+    #[test]
+    fn test_form_fill_validation() {
+        assert!(parse_command(&args("form fill --map {bad"), &default_flags()).is_err());
+        assert!(parse_command(&args("form fill --map {}"), &default_flags()).is_err());
+        assert!(parse_command(&args("form fill"), &default_flags()).is_err());
+        assert!(parse_command(&args("form wiggle"), &default_flags()).is_err());
     }
 
     // === extract parse tests ===

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1471,6 +1471,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         "find" => handle_find(cmd, state).await,
         "expect" => handle_expect(cmd, state).await,
         "extract" => handle_extract(cmd, state).await,
+        "form_fill" => handle_form_fill(cmd, state).await,
         "evalhandle" => handle_evalhandle(cmd, state).await,
         "drag" => handle_drag(cmd, state).await,
         "solve_slider" => handle_solve_slider(cmd, state).await,
@@ -5491,6 +5492,106 @@ async fn observe_snapshot(state: &DaemonState) -> String {
     )
     .await
     .unwrap_or_default()
+}
+
+/// `form fill --map` — fill a whole form from a {label|selector: value} map in
+/// ONE call (React-safe), optionally submit, then return per-field status + any
+/// inline validation errors (the #57 alert surface). Standard controls only
+/// (text/select/checkbox/radio); for rich editors (DraftJS/Monaco) use `fill`
+/// per field — it handles those. (Feature from #65-followup brainstorm.)
+async fn handle_form_fill(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let map = cmd.get("map").ok_or("form fill: missing map")?;
+    let submit = cmd.get("submit").and_then(|v| v.as_str());
+    let map_json = serde_json::to_string(map).unwrap_or_else(|_| "{}".to_string());
+    let submit_json = serde_json::to_string(&submit).unwrap_or_else(|_| "null".to_string());
+
+    // One eval fills every field React-safely (native value setter + input/change
+    // events so controlled components register the change), then optionally submits.
+    let script = format!(
+        r#"(() => {{
+  const MAP = {map_json};
+  const SUBMIT = {submit_json};
+  const lc = (s) => (s || '').trim().toLowerCase();
+  const isControl = (e) => e && /^(INPUT|SELECT|TEXTAREA)$/.test(e.tagName) || (e && e.isContentEditable);
+  const findControl = (key) => {{
+    try {{ const el = document.querySelector(key); if (isControl(el)) return el; }} catch (e) {{}}
+    const k = lc(key);
+    const lab = Array.from(document.querySelectorAll('label')).find((l) => lc(l.innerText).includes(k));
+    if (lab) {{
+      if (lab.htmlFor) {{ const c = document.getElementById(lab.htmlFor); if (isControl(c)) return c; }}
+      const c = lab.querySelector('input,select,textarea,[contenteditable]'); if (isControl(c)) return c;
+    }}
+    for (const e of document.querySelectorAll('input,select,textarea,[contenteditable]')) {{
+      const al = lc(e.getAttribute('aria-label')), ph = lc(e.getAttribute('placeholder')), nm = lc(e.getAttribute('name'));
+      if ((al && al.includes(k)) || (ph && ph.includes(k)) || nm === k) return e;
+    }}
+    return null;
+  }};
+  const setNative = (el, val) => {{
+    const proto = el.tagName === 'SELECT' ? HTMLSelectElement.prototype
+      : el.tagName === 'TEXTAREA' ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(proto, 'value') && Object.getOwnPropertyDescriptor(proto, 'value').set;
+    if (setter) setter.call(el, val); else el.value = val;
+    el.dispatchEvent(new Event('input', {{ bubbles: true }}));
+    el.dispatchEvent(new Event('change', {{ bubbles: true }}));
+  }};
+  const results = [];
+  for (const key of Object.keys(MAP)) {{
+    const val = MAP[key];
+    const el = findControl(key);
+    if (!el) {{ results.push({{ key, ok: false, reason: 'control not found' }}); continue; }}
+    try {{
+      const t = el.tagName;
+      if (el.isContentEditable) {{ el.focus(); el.textContent = String(val); el.dispatchEvent(new Event('input', {{ bubbles: true }})); results.push({{ key, ok: true, type: 'contenteditable' }}); }}
+      else if (t === 'SELECT') {{ setNative(el, String(val)); results.push({{ key, ok: el.value === String(val), type: 'select' }}); }}
+      else if (t === 'INPUT' && (el.type === 'checkbox')) {{ const want = val === true || val === 'true' || val === 1; if (el.checked !== want) el.click(); results.push({{ key, ok: el.checked === want, type: 'checkbox' }}); }}
+      else if (t === 'INPUT' && el.type === 'radio') {{
+        const grp = Array.from(document.querySelectorAll('input[type=radio][name="' + (el.name || '') + '"]'));
+        const pick = grp.find((r) => r.value === String(val)) || el;
+        if (!pick.checked) pick.click();
+        results.push({{ key, ok: pick.checked, type: 'radio' }});
+      }}
+      else {{ setNative(el, String(val)); results.push({{ key, ok: true, type: (el.type || t.toLowerCase()) }}); }}
+    }} catch (e) {{ results.push({{ key, ok: false, reason: String(e && e.message || e) }}); }}
+  }}
+  let submitted = false;
+  if (SUBMIT) {{
+    let btn = null;
+    try {{ btn = document.querySelector(SUBMIT); }} catch (e) {{}}
+    if (!btn) {{
+      const s = lc(SUBMIT);
+      btn = Array.from(document.querySelectorAll('button,input[type=submit],[role=button]'))
+        .find((b) => lc(b.innerText || b.value).includes(s));
+    }}
+    if (btn) {{ btn.click(); submitted = true; }}
+  }}
+  return {{ results, submitted }};
+}})()"#
+    );
+
+    let filled = mgr.evaluate(&script, None).await?;
+    let submitted = filled
+        .get("submitted")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let results = filled.get("results").cloned().unwrap_or(Value::Null);
+
+    // Let validation/toasts render, then collect inline errors (#57 alert lines).
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    let snap = observe_snapshot(state).await;
+    let errors: Vec<String> = snap
+        .lines()
+        .filter_map(|l| l.trim_start().strip_prefix("- alert "))
+        .map(|s| s.trim().trim_matches('"').to_string())
+        .collect();
+    let url = mgr.get_url().await.unwrap_or_default();
+    Ok(json!({
+        "filled": results,
+        "submitted": submitted,
+        "errors": errors,
+        "origin": url,
+    }))
 }
 
 /// Whether an error means "the target element isn't on the page" (vs a real

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2047,6 +2047,33 @@ Examples:
 "##
         }
 
+        // === Form fill ===
+        "form" => {
+            r##"
+chrome-use form fill - Fill a whole form in one call
+
+Usage:
+  chrome-use form fill --map <json> [--submit <selector|text>]
+  chrome-use form fill --map-file <path> | --stdin   [--submit ...]
+
+Fills every field from a {label-or-selector: value} map in one shot, dispatching
+the right control type, then optionally clicks a submit button and returns
+per-field status + any inline validation errors (the alerts `snapshot -i` shows).
+Keys match a <label>, aria-label, placeholder, name, or a CSS selector.
+Values: string → text/select/radio; true/false → checkbox.
+
+Standard controls (input/select/textarea/checkbox/radio/contenteditable) only —
+for rich editors (DraftJS/Monaco/CodeMirror) fill those fields individually with
+`fill`, which handles them.
+
+Examples:
+  chrome-use form fill --map '{"Email":"a@b.com","Country":"US","Subscribe":true}'
+  chrome-use form fill --map '{"#email":"a@b.com"}' --submit "Sign up"
+
+Returns { filled:[{key,ok,type}], submitted, errors:[...] } — use --json for it.
+"##
+        }
+
         // === Screenshot/PDF ===
         "screenshot" => {
             r##"
@@ -3473,6 +3500,8 @@ Core Commands:
                              count, text/value/attr, url, request fired, no-errors
   extract --schema <json>    Scrape structured JSON (rows+fields) → array/object
                              (one call vs N find/get; generic, any logged-in site)
+  form fill --map <json>     Fill a whole form by label/selector, submit, return
+                             per-field status + inline validation errors
   screenshot [path]          Take screenshot (auto-downscaled to ≤2000px long edge;
                              --max-width/--max-height/--scale to override)
   pdf <path>                 Save as PDF

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -723,6 +723,17 @@ chrome-use requests --clear && chrome-use click @save \
 chrome-use expect no-errors                                     # no console errors?
 ```
 
+**Fill a whole form in one call — `form fill --map`.** Instead of N
+`fill`/`select`/`check` steps, pass a `{label-or-selector: value}` map: it
+resolves each field (by `<label>`, aria-label, placeholder, name, or CSS),
+dispatches the right control type (string → text/select/radio, `true/false` →
+checkbox), optionally submits (`--submit "<text|selector>"`), and returns
+`{filled, submitted, errors}` — `errors` are the inline validation messages, so a
+rejected submit tells you why in the same call. `chrome-use form fill --map
+'{"Email":"a@b.com","Country":"US","Subscribe":true}' --submit "Sign up"`. For
+rich editors (DraftJS/Monaco/CodeMirror) fill those fields with `fill` instead —
+it handles them; `form fill` covers standard controls.
+
 **See what an action changed — `--observe`.** Add it to a mutating action
 (`click`/`fill`/`type`/`select`/`check`/`press`/`eval`) and instead of you
 running act → wait → `snapshot` → `diff`, the result carries an `observed` delta:


### PR DESCRIPTION
Final brainstorm feature. Fill every field from a `{label-or-selector: value}` map in one shot (vs N fill/select/check), optionally submit, and get back per-field status + **inline validation errors** — a rejected submit tells you why in the same call (the social-posting / #57 pains).

Keys resolve by `<label>`, aria-label, placeholder, name, or CSS. Values: string → text/select/radio; true/false → checkbox.

One **React-safe eval** does the fill (native value setter + input/change events so controlled components register; checkbox/radio via click; contenteditable via textContent), clicks the optional `--submit` (selector or button text), settles 250ms, re-snapshots, and returns `- alert` lines as `errors` (#57 surface). Standard controls only — rich editors (DraftJS/Monaco) use `fill` per-field (documented).

The original review agent failed on this one → fresh single-eval design (one round-trip, no per-field resolution races).

Tests: 2 parse. Live-verified on an injected form: Email(text)+Country(select)+Subscribe(checkbox) all set **by label**, submitted, validation captured, DOM values confirmed. fmt+clippy clean. CLI-only.