### PR TITLE
fix: form-fill select by option text; self-heal no longer kills --launch daemons

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -952,6 +952,32 @@ fn is_transient_error(error: &str) -> bool {
         || error.contains("os error 10054") // Connection reset by peer (Windows)
 }
 
+/// Quick health probe of an existing session daemon: connect and send a
+/// lightweight `url` command with a short read timeout. Returns `true` only if
+/// the daemon answers within `timeout` — i.e. it's alive AND its browser is
+/// responsive. A daemon bound to a dead relay HANGS on `url` and times out
+/// (false); a daemon driving a launched browser answers fast (true); no daemon
+/// fails to connect (false). Lets the relay self-heal avoid killing a healthy
+/// `--launch` session's daemon when the relay happens to be down.
+pub fn probe_daemon_healthy(session: &str, timeout: Duration) -> bool {
+    let Ok(mut stream) = connect(session) else {
+        return false;
+    };
+    stream.set_read_timeout(Some(timeout)).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(2))).ok();
+    let probe = serde_json::json!({ "id": "probe", "action": "url" });
+    let Ok(mut json_str) = serde_json::to_string(&probe) else {
+        return false;
+    };
+    json_str.push('\n');
+    if stream.write_all(json_str.as_bytes()).is_err() {
+        return false;
+    }
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line).is_ok() && !line.trim().is_empty()
+}
+
 fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
     let mut stream = connect(session)?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1353,6 +1353,12 @@ fn main() {
         && std::env::var("AGENT_BROWSER_NO_AUTO_RECONNECT").is_err()
         && connect::host_installed()
         && connect::relay_url().is_none()
+        // Don't disturb a session that already has a healthy daemon — e.g. one
+        // driving a `--launch`ed browser (its follow-up commands omit --launch and
+        // would otherwise trip this relay-down branch and get the daemon killed). A
+        // daemon stuck on a dead relay fails this probe (hangs → times out) and is
+        // healed; a live launched browser answers fast and is left alone.
+        && !connection::probe_daemon_healthy(&flags.session, std::time::Duration::from_secs(3))
     {
         connection::kill_stale_daemon(&flags.session);
         connect::ensure_host_installed();

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5544,7 +5544,14 @@ async fn handle_form_fill(cmd: &Value, state: &DaemonState) -> Result<Value, Str
     try {{
       const t = el.tagName;
       if (el.isContentEditable) {{ el.focus(); el.textContent = String(val); el.dispatchEvent(new Event('input', {{ bubbles: true }})); results.push({{ key, ok: true, type: 'contenteditable' }}); }}
-      else if (t === 'SELECT') {{ setNative(el, String(val)); results.push({{ key, ok: el.value === String(val), type: 'select' }}); }}
+      else if (t === 'SELECT') {{
+        const opts = Array.from(el.options);
+        const m = opts.find((o) => o.value === String(val))
+          || opts.find((o) => lc(o.textContent) === lc(String(val)))
+          || opts.find((o) => lc(o.textContent).includes(lc(String(val))));
+        if (m) setNative(el, m.value);
+        results.push({{ key, ok: !!m && el.value === (m ? m.value : null), type: 'select' }});
+      }}
       else if (t === 'INPUT' && (el.type === 'checkbox')) {{ const want = val === true || val === 'true' || val === 1; if (el.checked !== want) el.click(); results.push({{ key, ok: el.checked === want, type: 'checkbox' }}); }}
       else if (t === 'INPUT' && el.type === 'radio') {{
         const grp = Array.from(document.querySelectorAll('input[type=radio][name="' + (el.name || '') + '"]'));


### PR DESCRIPTION
Two issues found while live-testing the new features on real Chrome:

1. **form fill select** matched only by option VALUE → `{"Plan":"Pro"}` silently failed when `<option value=pro>Pro</option>` (users pass the visible text). Now: value → exact text → text-substring. Verified `{"Plan":"Pro"}` selects "pro".

2. **self-heal regression** (v1.5.46): it killed the daemon whenever relay-cdp-url was missing — including a healthy daemon driving a `--launch`ed browser (follow-up commands omit --launch). Now it first probes the existing daemon (`probe_daemon_healthy`, short-timeout `url`): a live launched browser answers fast and is left alone; a daemon stuck on a dead relay times out and is healed as before. Verified: expect on a --launch session with relay down now passes instead of hitting about:blank.

Live-verified both. fmt+clippy clean. CLI-only.