### PR TITLE
feat(friction): auto-log failed commands locally + chrome-use friction

### DIFF
--- a/cli/src/friction.rs
+++ b/cli/src/friction.rs
@@ -1,0 +1,252 @@
+//! Friction auto-reporting.
+//!
+//! When a chrome-use command genuinely fails, we append one structured line to a
+//! local JSONL log. Aggregating it (`chrome-use friction`) turns "what's painful
+//! to drive" from LLM guesswork into real usage data — so the next round of
+//! features is evidence-driven.
+//!
+//! Privacy: LOCAL ONLY (no upload — matches the tool's no-tracking ethos), and we
+//! record the page **host**, never the full URL/query/params. Opt out entirely
+//! with `AGENT_BROWSER_NO_FRICTION_LOG=1`.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+
+/// `~/.chrome-use/friction.jsonl` (sibling of the relay/state files).
+pub fn friction_path() -> PathBuf {
+    crate::connection::config_home().join("friction.jsonl")
+}
+
+/// Soft cap: once the log exceeds this many lines, the next aggregation/clear can
+/// trim it. Bounds disk without per-write cost.
+const MAX_LINES: usize = 4000;
+
+/// Coarse, stable category for an error message — the axis aggregation groups by.
+/// Kept small + substring-matched so similar failures bucket together.
+pub fn categorize(error: &str) -> &'static str {
+    let l = error.to_lowercase();
+    if l.contains("its tab is gone")
+        || l.contains("stale sessionid")
+        || l.contains("no attached tab")
+    {
+        "stale_target"
+    } else if l.contains("not found") || l.contains("no element") || l.contains("unknown ref") {
+        "element_not_found"
+    } else if l.contains("timed out") || l.contains("timeout") {
+        "timeout"
+    } else if l.contains("not visible") || l.contains("intercept") || l.contains("not clickable") {
+        "not_interactable"
+    } else if l.contains("navigation") || l.contains("err_") || l.contains("net::") {
+        "navigation"
+    } else if l.contains("evaluation error")
+        || l.contains("syntaxerror")
+        || l.contains("is not defined")
+    {
+        "eval_error"
+    } else if l.contains("could not connect") || l.contains("not connected") || l.contains("relay")
+    {
+        "connection"
+    } else {
+        "other"
+    }
+}
+
+/// Host of a URL string (no scheme/path/query) — the only location data we log.
+fn host_of(url: &str) -> Option<String> {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_string()))
+}
+
+/// Append one friction record. Best-effort + cheap; never fails a command.
+/// `now_unix` is passed in (callers stamp it) to keep this pure-ish and testable.
+pub fn record(action: &str, error: &str, origin: &str, now_unix: u64) {
+    if std::env::var("AGENT_BROWSER_NO_FRICTION_LOG").is_ok() {
+        return;
+    }
+    let rec = json!({
+        "ts": now_unix,
+        "action": action,
+        "category": categorize(error),
+        "error": error.chars().take(200).collect::<String>(),
+        "host": host_of(origin),
+        "version": env!("CARGO_PKG_VERSION"),
+    });
+    let path = friction_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = writeln!(f, "{}", rec);
+    }
+}
+
+/// Convenience for the daemon: stamp the time and record.
+pub fn record_now(action: &str, error: &str, origin: &str) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    record(action, error, origin, now);
+}
+
+/// Parse the log into records (skipping malformed lines).
+fn read_records() -> Vec<Value> {
+    let Ok(text) = std::fs::read_to_string(friction_path()) else {
+        return Vec::new();
+    };
+    text.lines()
+        .filter_map(|l| serde_json::from_str::<Value>(l).ok())
+        .collect()
+}
+
+/// Aggregate the log into a summary: totals, by-command, by-category, by-host,
+/// and a few recent examples. Pure over the input so it's unit-testable.
+pub fn aggregate(records: &[Value]) -> Value {
+    use std::collections::HashMap;
+    let mut by_action: HashMap<String, u64> = HashMap::new();
+    let mut by_category: HashMap<String, u64> = HashMap::new();
+    let mut by_host: HashMap<String, u64> = HashMap::new();
+    for r in records {
+        if let Some(a) = r.get("action").and_then(|v| v.as_str()) {
+            *by_action.entry(a.to_string()).or_default() += 1;
+        }
+        if let Some(c) = r.get("category").and_then(|v| v.as_str()) {
+            *by_category.entry(c.to_string()).or_default() += 1;
+        }
+        if let Some(h) = r.get("host").and_then(|v| v.as_str()) {
+            *by_host.entry(h.to_string()).or_default() += 1;
+        }
+    }
+    let sort_desc = |m: HashMap<String, u64>| {
+        let mut v: Vec<(String, u64)> = m.into_iter().collect();
+        v.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        v
+    };
+    let to_pairs = |v: Vec<(String, u64)>, n: usize| -> Vec<Value> {
+        v.into_iter()
+            .take(n)
+            .map(|(k, c)| json!({ "name": k, "count": c }))
+            .collect()
+    };
+    let recent: Vec<Value> = records.iter().rev().take(10).cloned().collect();
+    json!({
+        "total": records.len(),
+        "byCommand": to_pairs(sort_desc(by_action), 15),
+        "byCategory": to_pairs(sort_desc(by_category), 15),
+        "byHost": to_pairs(sort_desc(by_host), 10),
+        "recent": recent,
+    })
+}
+
+/// `chrome-use friction [--json] [--clear]` — local, no daemon. Surfaces the
+/// aggregated friction log so a human/agent can see what's actually painful.
+pub fn run_friction(args: &[String], json_out: bool) {
+    if args.iter().any(|a| a == "--clear") {
+        let _ = std::fs::remove_file(friction_path());
+        if json_out {
+            println!(
+                "{}",
+                json!({ "success": true, "data": { "cleared": true } })
+            );
+        } else {
+            println!("✓ friction log cleared");
+        }
+        return;
+    }
+
+    let mut records = read_records();
+    // Opportunistic trim so the file can't grow unbounded.
+    if records.len() > MAX_LINES {
+        let keep: Vec<Value> = records.split_off(records.len() - MAX_LINES);
+        if let Ok(mut f) = std::fs::File::create(friction_path()) {
+            for r in &keep {
+                let _ = writeln!(f, "{}", r);
+            }
+        }
+        records = keep;
+    }
+    let agg = aggregate(&records);
+
+    if json_out {
+        println!("{}", json!({ "success": true, "data": agg }));
+        return;
+    }
+
+    let total = agg.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
+    if total == 0 {
+        println!("no friction recorded yet — failures get logged here as you drive.");
+        println!("(local only; never uploaded. opt out: AGENT_BROWSER_NO_FRICTION_LOG=1)");
+        return;
+    }
+    println!("friction: {total} failed command(s) recorded\n");
+    let section = |title: &str, key: &str| {
+        if let Some(arr) = agg.get(key).and_then(|v| v.as_array()) {
+            if !arr.is_empty() {
+                println!("{title}");
+                for it in arr {
+                    let n = it.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+                    let c = it.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+                    println!("  {c:>4}  {n}");
+                }
+                println!();
+            }
+        }
+    };
+    section("by command:", "byCommand");
+    section("by error category:", "byCategory");
+    section("by host:", "byHost");
+    println!("(local only; `chrome-use friction --json` for raw, `--clear` to reset)");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_categorize() {
+        assert_eq!(
+            categorize("Element not found in the page DOM"),
+            "element_not_found"
+        );
+        assert_eq!(categorize("Unknown ref: e9"), "element_not_found");
+        assert_eq!(
+            categorize("stale sessionId ... its tab is gone"),
+            "stale_target"
+        );
+        assert_eq!(categorize("Operation timed out"), "timeout");
+        assert_eq!(categorize("element is not visible"), "not_interactable");
+        assert_eq!(categorize("Navigation failed: net::ERR_X"), "navigation");
+        assert_eq!(
+            categorize("Evaluation error: ReferenceError: x is not defined"),
+            "eval_error"
+        );
+        assert_eq!(categorize("something weird"), "other");
+    }
+
+    #[test]
+    fn test_host_of() {
+        assert_eq!(host_of("https://x.com/a/b?q=1"), Some("x.com".to_string()));
+        assert_eq!(host_of("not a url"), None);
+    }
+
+    #[test]
+    fn test_aggregate() {
+        let recs = vec![
+            json!({ "action": "click", "category": "element_not_found", "host": "a.com" }),
+            json!({ "action": "click", "category": "element_not_found", "host": "a.com" }),
+            json!({ "action": "fill", "category": "timeout", "host": "b.com" }),
+        ];
+        let agg = aggregate(&recs);
+        assert_eq!(agg["total"], 3);
+        assert_eq!(agg["byCommand"][0]["name"], "click");
+        assert_eq!(agg["byCommand"][0]["count"], 2);
+        assert_eq!(agg["byCategory"][0]["name"], "element_not_found");
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ mod cookie_export;
 mod doctor;
 mod findurl;
 mod flags;
+mod friction;
 mod install;
 mod native;
 mod output;
@@ -990,6 +991,13 @@ fn main() {
         Some("find-url") | Some("findurl")
     ) {
         findurl::run_find_url(&clean, flags.json);
+        return;
+    }
+
+    // `friction` (no daemon): aggregate the local friction log — what's been
+    // painful to drive. Data for the next round of features.
+    if clean.first().map(|s| s.as_str()) == Some("friction") {
+        friction::run_friction(&clean[1..], flags.json);
         return;
     }
 

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1530,6 +1530,18 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     };
 
     let ok = result.is_ok();
+    // Friction auto-reporting (#65 followup): a genuine command failure is a data
+    // point for "what's painful to drive". Record it locally (host only, never the
+    // full URL) using the CACHED url so we never block. `--if-present` skips became
+    // Ok above, so they're correctly excluded.
+    if let Err(ref e) = result {
+        let origin = state
+            .browser
+            .as_ref()
+            .map(|m| m.cached_active_url())
+            .unwrap_or_default();
+        crate::friction::record_now(action, e, &origin);
+    }
     let mut resp = match result {
         Ok(data) => success_response(&id, data),
         Err(e) => error_response(&id, &super::browser::to_ai_friendly_error(&e)),

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -1320,6 +1320,22 @@ impl BrowserManager {
             active_page_index_after_removal(self.active_page_index, pos, self.pages.len());
     }
 
+    /// The active page's last-known URL from cached page state — NO CDP round
+    /// trip (so it never hangs, even when the relay is dead). Best-effort, "" if
+    /// unknown. Used for cheap friction logging where calling `get_url` would
+    /// block on exactly the failures we want to record.
+    pub fn cached_active_url(&self) -> String {
+        let idx = resolve_active_index(
+            &self.pages,
+            self.active_target_id.as_deref(),
+            self.active_page_index,
+        );
+        self.pages
+            .get(idx)
+            .map(|p| p.url.clone())
+            .unwrap_or_default()
+    }
+
     /// Pin the current active page by target_id so later commands stick to it.
     /// Call after any explicit open / tab new / tab switch.
     fn pin_active_target(&mut self) {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2047,6 +2047,25 @@ Examples:
 "##
         }
 
+        // === Friction log ===
+        "friction" => {
+            r##"
+chrome-use friction - What's been painful to drive (local failure log)
+
+Usage:
+  chrome-use friction            aggregated summary (by command / category / host)
+  chrome-use friction --json     machine-readable aggregation
+  chrome-use friction --clear    reset the log
+
+Every command that genuinely FAILS is auto-recorded to a local JSONL log
+(~/.chrome-use/friction.jsonl) with its error category and the page host. This
+turns "what should we improve" into real usage data instead of guesswork.
+
+Privacy: LOCAL ONLY — never uploaded. Records the host (e.g. example.com), never
+the full URL/query/params. Opt out entirely: AGENT_BROWSER_NO_FRICTION_LOG=1.
+"##
+        }
+
         // === Form fill ===
         "form" => {
             r##"
@@ -3502,6 +3521,8 @@ Core Commands:
                              (one call vs N find/get; generic, any logged-in site)
   form fill --map <json>     Fill a whole form by label/selector, submit, return
                              per-field status + inline validation errors
+  friction [--json|--clear]  Local log of failed commands (what's painful to
+                             drive) — local only, never uploaded
   screenshot [path]          Take screenshot (auto-downscaled to ≤2000px long edge;
                              --max-width/--max-height/--scale to override)
   pdf <path>                 Save as PDF

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -21,6 +21,10 @@ web pages — see [When to load another skill](#when-to-load-another-skill).
 > **<https://github.com/leeguooooo/chrome-use/issues>** with the exact
 > command and what happened vs. what you expected. Agent-filed friction reports
 > are how this tool gets sharper; a 30-second issue is genuinely valuable.
+>
+> (Failures are also auto-logged locally — run `chrome-use friction` to see what's
+> been painful, by command/category/host. Local only, never uploaded; opt out
+> with `AGENT_BROWSER_NO_FRICTION_LOG=1`.)
 
 ## The core loop
 


### PR DESCRIPTION
Makes "what to improve next" **data-driven** instead of LLM-guessed (the thing we discussed — the brainstorm pain points were part-evidence, part-reasoning; this captures real evidence).

Every command that genuinely fails is appended to a local JSONL log with a coarse error category + page host; `chrome-use friction` aggregates it (by command / category / host + recent samples).

- **Recording**: execute_command Err branch (so `--if-present` skips are excluded), using a new `cached_active_url` — the CACHED url, never a live `get_url` that would hang on the very stale-relay failures we want to log.
- **Privacy**: LOCAL ONLY (no upload, matches the no-tracking ethos); **host only**, never full URL/query; error truncated. Opt out: `AGENT_BROWSER_NO_FRICTION_LOG=1`.
- **`friction` command** (no daemon): summary / --json / --clear; soft-trims at 4000 lines.
- Categories: stale_target / element_not_found / timeout / not_interactable / navigation / eval_error / connection / other.

Tests: categorize/host_of/aggregate. Live-verified: 4 induced failures logged + aggregated; --json/--clear/opt-out work. fmt+clippy clean. CLI-only.