### PR TITLE
docs(readme): credibility badges + star nudge above the hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 **English** · [简体中文](README.zh.md)
 
+<p align="center">
+  <a href="https://github.com/leeguooooo/chrome-use/releases"><img alt="Release" src="https://img.shields.io/github/v/release/leeguooooo/chrome-use?sort=semver&color=2f81f7"></a>
+  <a href="https://github.com/leeguooooo/chrome-use/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/leeguooooo/chrome-use?color=f0b429"></a>
+  <a href="https://bot-detector.rebrowser.net/"><img alt="CreepJS 0% bot" src="https://img.shields.io/badge/CreepJS-0%25%20bot-2ea043"></a>
+  <img alt="Platforms" src="https://img.shields.io/badge/macOS%20·%20Linux%20·%20Windows-informational">
+  <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/github/license/leeguooooo/chrome-use?color=8957e5"></a>
+</p>
+
+<p align="center"><i>⭐ If it saves you a re-login, a star helps other devs find it.</i></p>
+
 ![chrome-use](assets/hero.png)
 
 **chrome-use** drives your real, logged-in Chrome from any AI agent — it shares your existing login sessions and is undetectable by anti-bot systems because it *is* your real browser. Part of the `*-use` family ([iphone-use](https://github.com/leeguooooo) drives your real iPhone; [bitwarden-use](https://github.com/leeguooooo/bitwarden-use) pulls passwords/2FA/passkeys from your Bitwarden vault so an agent can log in with credentials; chrome-use drives your real Chrome).


### PR DESCRIPTION
Small, non-destructive README polish ahead of a Trending/HN launch.

**What changed**
- Added a centered badge row under the title: Release · GitHub stars · **CreepJS 0% bot** · Platforms (macOS/Linux/Windows) · License.
- Added a one-line star CTA above the hero.

**What did NOT change**
- The hero copy, "Give your AI agent the browser you already live in", the comparison tables, the CreepJS/anti-detection sections, and all install docs are untouched.

**Still TODO for launch (needs a human):** a short **demo GIF/MP4** near the top — the single biggest HN/Trending conversion lever. Only static PNGs exist today; record a ~10s clip of the snapshot→find→act loop and drop it right under the hero.

https://claude.ai/code/session_01F4CMoZBGuqvoZJdroYTNeH