### PR TITLE
fix(daemon): implement eval action + stop upload matching unrelated inputs

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1546,6 +1546,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             "expect" => handle_expect(cmd, state).await,
             "extract" => handle_extract(cmd, state).await,
             "form_fill" => handle_form_fill(cmd, state).await,
+            "eval" => handle_eval(cmd, state).await,
             "evalhandle" => handle_evalhandle(cmd, state).await,
             "drag" => handle_drag(cmd, state).await,
             "solve_slider" => handle_solve_slider(cmd, state).await,
@@ -8626,6 +8627,44 @@ async fn handle_find(cmd: &Value, state: &DaemonState) -> Result<Value, String> 
 
     let result = mgr.evaluate(&js, None).await?;
     Ok(json!({ "elements": result, "selector": selector }))
+}
+
+// Evaluate a JS expression in the active page and return its value by value.
+// Sibling to `evalhandle` (which returns a remote object handle instead). Used
+// e.g. to read DOM state after an action (`document.querySelector(...).disabled`).
+async fn handle_eval(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+    // Accept `expression` (canonical) or `script` (alias, matching evalhandle).
+    let expression = cmd
+        .get("expression")
+        .or_else(|| cmd.get("script"))
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'expression' parameter")?;
+
+    let result: super::cdp::types::EvaluateResult = mgr
+        .client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &super::cdp::types::EvaluateParams {
+                expression: expression.to_string(),
+                return_by_value: Some(true),
+                await_promise: Some(true),
+            },
+            Some(&session_id),
+        )
+        .await?;
+
+    // Surface a thrown JS exception as a command error rather than a null result.
+    if let Some(exc) = result.exception_details {
+        let msg = exc
+            .exception
+            .and_then(|o| o.description.or(o.value.map(|v| v.to_string())))
+            .unwrap_or_else(|| exc.text.clone());
+        return Err(format!("eval threw: {}", msg));
+    }
+
+    Ok(json!({ "result": result.result.value.unwrap_or(Value::Null) }))
 }
 
 async fn handle_evalhandle(cmd: &Value, state: &DaemonState) -> Result<Value, String> {

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -2857,8 +2857,14 @@ impl BrowserManager {
             }
             // A trigger button/element: walk up to the nearest container that
             // owns a file input (el-upload puts the hidden input as a sibling).
+            // Stop at <body>/<html>: a file input found only at page-root level
+            // is not associated with this element — it's just "some other input
+            // on the page". Matching it would be a false-success upload (e.g.
+            // uploading to an <h1> that merely shares <body> with an unrelated
+            // hidden input). A real upload widget wraps its input in a container.
             let p = el;
             for (let i = 0; i < 8 && p; i++, p = p.parentElement) {
+                if (p.tagName === 'BODY' || p.tagName === 'HTML') break;
                 if (p.querySelector) {
                     const found = p.querySelector('input[type=file]');
                     if (found) return found;


### PR DESCRIPTION
Greens the **Native E2E** job — the last red job on main. Both bugs were masked while CI died at the fmt step (fixed in #82), so the e2e tests never ran; fixing fmt unmasked them.

### 1. `eval` not implemented in the daemon path
The launched-Chrome dispatch (`execute_action`) had an `evalhandle` arm but **no `eval`**, so `{action:"eval"}` hit the catch-all `"Not yet implemented: eval"`. Added `handle_eval`: `Runtime.evaluate` with `returnByValue`, returns `{result}`, and surfaces a thrown JS exception as an error (better than `evalhandle`). Fixes `e2e_upload_hidden_input`, `e2e_upload_via_trigger_button`.

### 2. Upload wrongly succeeds on a no-input selector
`resolve_file_input_object_id` walked up to 8 ancestors and matched **any** `input[type=file]` in the subtree — so uploading to `<h1>` (which only shares `<body>` with the fixture's unrelated hidden input) resolved to that input and reported success. Stop the walk at `<body>`/`<html>`: an input found only at page-root isn't associated with the target. Fixes `e2e_upload_no_input_does_not_navigate`. (This completes the intent of the earlier `fix(upload): never navigate on a failed/no-input upload`.)

### Verification (local, short checkout)
- `cargo fmt --check` clean · `cargo clippy -D warnings` clean
- 978 unit tests pass
- **all** upload e2e pass (5/5)

The one `e2e_drag_action_sends_buttons_during_move` failure in my full-suite run is a **macOS-local** headless pointer-emulation quirk (the drag action, id 3, runs before any eval and never touches upload resolution — these changes can't affect it). It passed on CI in the prior run (it was among the 71 passing), so it stays green on CI's Linux runner.

https://claude.ai/code/session_01F4CMoZBGuqvoZJdroYTNeH