### PR TITLE
fix(docs): mobile horizontal overflow — pin .du-main to the column

### DIFF
--- a/docs/assets/docs/docs.css
+++ b/docs/assets/docs/docs.css
@@ -375,6 +375,9 @@ img { max-width: 100%; }
   border-radius: 6px 8px 7px 9px;
   box-decoration-break: clone; -webkit-box-decoration-break: clone;
   transform: rotate(-.4deg); display: inline-block;
+  /* Cap to the container so a long highlighted phrase wraps instead of forcing
+     the whole page wider than the viewport (was the main mobile-overflow bug). */
+  max-width: 100%;
 }
 
 /* ------------------------------------------------------------ divider hr */
@@ -559,6 +562,10 @@ img { max-width: 100%; }
 /* sidebar -> drawer below 960px */
 @media (max-width: 960px) {
   .du-shell { grid-template-columns: minmax(0, 1fr); }
+  /* The desktop `margin: 0 auto` centering makes .du-main an auto-margined grid
+     item, which disables stretch and shrink-to-fits it to max-content — wider
+     than the phone. Fill the single column instead so content wraps/scrolls. */
+  .du-main { margin-inline: 0; width: 100%; max-width: 100%; }
   .du-hamburger { display: inline-flex; }
   .du-tabs { display: none; }
   .du-sidebar {


### PR DESCRIPTION
chrome-use.leeguoo.com scrolled sideways on phones — content was ~768px wide on a 390px screen.

**Cause:** `.du-main` uses `margin: 0 auto` to center inside the wide desktop grid track. Auto horizontal margins on a grid item **disable stretch** and shrink-to-fit the item to its max-content — so on mobile it stayed ~768px instead of filling the single column, pushing the right-anchored doodle off-screen too.

**Fix (shared `docs.css`, so every page benefits):**
- `@media (max-width: 960px)`: `.du-main { margin-inline: 0; width: 100%; max-width: 100%; }` — fill the column; content wraps, code blocks scroll internally.
- `.mark { max-width: 100% }` — a long highlighted phrase wraps instead of forcing width.

**Verified** at 390×844 (emulated): document width == viewport (390), `overflow=false` on both `/` and `/commands.html`. The highlighted hero phrase now wraps to two lines with its marker intact; the `curl … | sh` line scrolls inside its code box.

https://claude.ai/code/session_01F4CMoZBGuqvoZJdroYTNeH