### PR TITLE
docs: 引流链接指向主域 blog.leeguoo.com + 补高互动博文

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 > 📚 **Documentation:** **[chrome-use.leeguoo.com](https://chrome-use.leeguoo.com)** — full guides, workflows & command reference (中文 · English).
 >
 > 📖 **Deep dive:** [Letting an agent click into cross-origin iframes — how chrome-use solves the hardest part of browser control](https://blog.leeguoo.com/en/posts/chrome-use-cross-origin-iframe/)
+> · [Driving your already-logged-in real Chrome (CreepJS scores it 0% bot) — 中文](https://blog.leeguoo.com/zh/posts/chrome-use-drive-your-real-chrome/)
 
 ## Give your AI agent the browser you already live in
 
@@ -442,4 +443,4 @@ We deliberately **don't ship our own bot detector** — the strongest, most hone
 Apache-2.0
 ---
 
-> Built by **leeguooooo** — field notes on AI agents, reverse engineering & Cloudflare Workers at **[blog.misonote.com](https://blog.misonote.com)** · follow on **[X @leeguooooo](https://x.com/leeguooooo)**
+> Built by **leeguooooo** — field notes on AI agents, reverse engineering & Cloudflare Workers at **[blog.leeguoo.com](https://blog.leeguoo.com)** · follow on **[X @leeguooooo](https://x.com/leeguooooo)**

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,6 +9,8 @@
 <sub>最初基于 [vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser)（Apache-2.0）；现已是独立项目 —— 隐身/扩展中继架构、反检测、humanize、多 agent 隔离与 CLI 都已大幅分化。</sub>
 
 > 📚 **文档站：** **[chrome-use.leeguoo.com](https://chrome-use.leeguoo.com)** —— 完整指南、工作流与命令参考（中文 · English）。
+>
+> 📖 **深入原理：** [让任何 AI Agent 直接驱动你已登录的真实 Chrome，CreepJS 给它打 0% bot](https://blog.leeguoo.com/zh/posts/chrome-use-drive-your-real-chrome/)
 
 ## 把你**已经登录好**的浏览器，交给你的 AI agent
 
@@ -319,4 +321,4 @@ Apache-2.0
 
 ---
 
-> 由 **leeguooooo** 打造 —— AI agent、逆向工程与 Cloudflare Workers 的实战笔记见 **[blog.misonote.com](https://blog.misonote.com)** · 关注 **[X @leeguooooo](https://x.com/leeguooooo)**
+> 由 **leeguooooo** 打造 —— AI agent、逆向工程与 Cloudflare Workers 的实战笔记见 **[blog.leeguoo.com](https://blog.leeguoo.com)** · 关注 **[X @leeguooooo](https://x.com/leeguooooo)**


### PR DESCRIPTION
## 背景
GA4 数据显示 **github.com 是质量最高的引荐来源**(近28天 63 会话、52 用户、平均停留 11分40秒),且 chrome-use 系列博文粘性最强(《驱动你真实 Chrome》平均停留 79 分钟)。同时 misonote.com 正在下线、全站 301 迁移到 leeguoo.com。

## 改动
- **footer 链接**:`blog.misonote.com`(已迁移下线域)→ `blog.leeguoo.com`(主域),中英双 README。
- **顶部「深入原理」**:新增《驱动你已登录的真实 Chrome,CreepJS 0% bot》博文链接(当前粘性最高的内容)。

纯文档链接改动,无代码影响。