### PR TITLE
Fix iphone-use repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <sub>Point it at a page in your <b>real</b> Chrome → get structured data in one command. <a href="assets/demo.tape">(regenerate: <code>vhs assets/demo.tape</code>)</a></sub>
 </p>
 
-**chrome-use** drives your real, logged-in Chrome from any AI agent — it shares your existing login sessions and is undetectable by anti-bot systems because it *is* your real browser. Part of the `*-use` family ([iphone-use](https://github.com/leeguooooo) drives your real iPhone; [bitwarden-use](https://github.com/leeguooooo/bitwarden-use) pulls passwords/2FA/passkeys from your Bitwarden vault so an agent can log in with credentials; chrome-use drives your real Chrome).
+**chrome-use** drives your real, logged-in Chrome from any AI agent — it shares your existing login sessions and is undetectable by anti-bot systems because it *is* your real browser. Part of the `*-use` family ([iphone-use](https://github.com/leeguooooo/iphone-use) drives your real iPhone; [bitwarden-use](https://github.com/leeguooooo/bitwarden-use) pulls passwords/2FA/passkeys from your Bitwarden vault so an agent can log in with credentials; chrome-use drives your real Chrome).
 
 <sub>Originally based on [vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser) (Apache-2.0); now a standalone project — the stealth/extension-relay architecture, anti-detection, humanize, multi-agent isolation, and CLI have diverged substantially.</sub>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,7 +4,7 @@
 
 ![chrome-use](assets/hero.png)
 
-**chrome-use** 让任意 AI agent 直接操作你自己正在用的、已登录的 Chrome —— 复用你的登录态，对反爬/反自动化系统**完全不可检测**，因为它**就是**你的真实浏览器。属于 `*-use` 家族（iphone-use 驱动你的真实 iPhone，[bitwarden-use](https://github.com/leeguooooo/bitwarden-use) 从你的 Bitwarden 库里取密码、2FA 和 passkey，让 agent 用账号密码登录，chrome-use 驱动你的真实 Chrome）。
+**chrome-use** 让任意 AI agent 直接操作你自己正在用的、已登录的 Chrome —— 复用你的登录态，对反爬/反自动化系统**完全不可检测**，因为它**就是**你的真实浏览器。属于 `*-use` 家族（[iphone-use](https://github.com/leeguooooo/iphone-use) 驱动你的真实 iPhone，[bitwarden-use](https://github.com/leeguooooo/bitwarden-use) 从你的 Bitwarden 库里取密码、2FA 和 passkey，让 agent 用账号密码登录，chrome-use 驱动你的真实 Chrome）。
 
 <sub>最初基于 [vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser)（Apache-2.0）；现已是独立项目 —— 隐身/扩展中继架构、反检测、humanize、多 agent 隔离与 CLI 都已大幅分化。</sub>
 

--- a/docs/en/family.html
+++ b/docs/en/family.html
@@ -74,7 +74,7 @@
           <div class="du-card-title"><span class="du-card-ico">🌐</span> chrome-use</div>
           <p>Drives your real, already-logged-in Chrome. It shares your existing sessions and anti-bot systems can't detect it — because it <em>is</em> your real browser.</p>
         </a>
-        <a class="du-card" href="https://github.com/leeguooooo" target="_blank" rel="noopener">
+        <a class="du-card" href="https://github.com/leeguooooo/iphone-use" target="_blank" rel="noopener">
           <div class="du-card-title"><span class="du-card-ico">📱</span> iphone-use</div>
           <p>Drives your real iPhone. Operate iOS apps with no API, export data that only lives on the phone, tap/type/scroll/screenshot.</p>
         </a>
@@ -186,7 +186,7 @@ cases:
         <code>iphone-use</code> brings the same "take over the real device" idea to iOS — tapping,
         typing, scrolling, and screenshotting through macOS iPhone Mirroring to operate apps that
         will never give you an API. Repo:
-        <a href="https://github.com/leeguooooo" target="_blank" rel="noopener">github.com/leeguooooo</a>.
+        <a href="https://github.com/leeguooooo/iphone-use" target="_blank" rel="noopener">github.com/leeguooooo/iphone-use</a>.
       </p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ Each tool installs separately</div>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -217,7 +217,7 @@
           <div class="du-card-title"><span class="du-card-ico">🌐</span> chrome-use</div>
           <p>Drives your real, logged-in Chrome.</p>
         </a>
-        <a class="du-card" href="https://github.com/leeguooooo" target="_blank" rel="noopener">
+        <a class="du-card" href="https://github.com/leeguooooo/iphone-use" target="_blank" rel="noopener">
           <div class="du-card-title"><span class="du-card-ico">📱</span> iphone-use</div>
           <p>Drives your real iPhone.</p>
         </a>

--- a/docs/family.html
+++ b/docs/family.html
@@ -73,7 +73,7 @@
           <div class="du-card-title"><span class="du-card-ico">🌐</span> chrome-use</div>
           <p>驱动你真实、已登录的 Chrome。共享现成会话，反爬系统检测不到——因为它<em>就是</em>你的真实浏览器。</p>
         </a>
-        <a class="du-card" href="https://github.com/leeguooooo" target="_blank" rel="noopener">
+        <a class="du-card" href="https://github.com/leeguooooo/iphone-use" target="_blank" rel="noopener">
           <div class="du-card-title"><span class="du-card-ico">📱</span> iphone-use</div>
           <p>驱动你真实的 iPhone。操作没有 API 的 iOS App、导出手机上的数据、点按/输入/滚动/截图。</p>
         </a>
@@ -183,7 +183,7 @@ cases:
         有些数据只活在手机上：Apple Health、银行 App、没有开放 API 的 IM。
         <code>iphone-use</code> 把同样的「接管真实设备」思路搬到 iOS——通过 macOS 的 iPhone 镜像
         点按、输入、滚动、截图，操作那些永远不会给你 API 的 App。仓库地址：
-        <a href="https://github.com/leeguooooo" target="_blank" rel="noopener">github.com/leeguooooo</a>。
+        <a href="https://github.com/leeguooooo/iphone-use" target="_blank" rel="noopener">github.com/leeguooooo/iphone-use</a>。
       </p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ 各工具独立安装</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -228,7 +228,7 @@
           <div class="du-card-title"><span class="du-card-ico">🌐</span> chrome-use</div>
           <p>驱动你真实、已登录的 Chrome。</p>
         </a>
-        <a class="du-card" href="https://github.com/leeguooooo" target="_blank" rel="noopener">
+        <a class="du-card" href="https://github.com/leeguooooo/iphone-use" target="_blank" rel="noopener">
           <div class="du-card-title"><span class="du-card-ico">📱</span> iphone-use</div>
           <p>驱动你真实的 iPhone。</p>
         </a>


### PR DESCRIPTION
## Summary
- Point homepage and family-page iphone-use cards to leeguooooo/iphone-use
- Update inline family-page repo links for iphone-use
- Keep README family links consistent with the repo URL

## Testing
- git diff --check
- rg stale iphone-use profile link patterns