### PR TITLE
fix(screenshot): resync targets so it captures the active tab, not a stale about:blank pin

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1148,6 +1148,7 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             let mut max_width: Option<u32> = None;
             let mut max_height: Option<u32> = None;
             let mut scale: Option<f64> = None;
+            let mut tab: Option<String> = None;
             let mut positional: Vec<&str> = Vec::new();
             let mut i = 0;
             // Parse a numeric value for a downscale flag (issue #42).
@@ -1179,6 +1180,19 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                             message: format!("--max-height expects a number, got '{v}'"),
                             usage: "screenshot --max-height <px>",
                         })?);
+                    }
+                    // Capture a specific tab (issue #88): `--tab t2` / `--tab <targetId>`.
+                    // Without it, screenshot always uses the active tab, which can
+                    // drift onto a background scratch pin.
+                    "--tab" => {
+                        let v = rest
+                            .get(i + 1)
+                            .ok_or_else(|| ParseError::MissingArguments {
+                                context: "screenshot --tab".to_string(),
+                                usage: "screenshot --tab <ref> [selector] [path]",
+                            })?;
+                        tab = Some(v.to_string());
+                        i += 1;
                     }
                     "--scale" => {
                         let v = parse_num(&mut i, "--scale")?;
@@ -1264,6 +1278,9 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
             }
             if let Some(s) = scale {
                 cmd["scale"] = json!(s);
+            }
+            if let Some(t) = tab {
+                cmd["tab"] = json!(t);
             }
             if let Some(ref fmt) = flags.screenshot_format {
                 cmd["format"] = json!(fmt);

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3659,8 +3659,23 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     // Without this, a screenshot resolves that stale scratch pin and captures
     // `about:blank` even though `snapshot`/`eval`/`tab list` see the real tab.
     // Best-effort: a stale pin still beats erroring the command.
+    //
+    // An explicit `--tab <ref>` (issue #88) switches to that tab first, so the
+    // shot targets it regardless of the active pin — resolved exactly like
+    // `tab <id>` (targetId, then `t<N>`/label).
     if let Some(mgr) = state.browser.as_mut() {
         mgr.resync_targets().await.ok();
+        if let Some(tab_ref_str) = cmd.get("tab").and_then(|v| v.as_str()) {
+            let tab_id = match mgr.tab_id_for_target(tab_ref_str) {
+                Some(id) => id,
+                None => {
+                    let tab_ref = super::browser::TabRef::parse(tab_ref_str)?;
+                    mgr.resolve_tab_ref(&tab_ref)?
+                }
+            };
+            mgr.tab_switch_by_id(tab_id).await?;
+            state.ref_map.clear();
+        }
     }
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3652,6 +3652,16 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
             return Ok(json!({ "path": tmp }));
         }
     }
+    // Re-sync with the live browser before resolving the active tab, mirroring
+    // `tab list` (issue #88). On relay auto-connect a background about:blank
+    // scratch tab can stay pinned as the active target; the read handlers share
+    // one resolver (`active_session_id`), but only `tab list` re-syncs the pin.
+    // Without this, a screenshot resolves that stale scratch pin and captures
+    // `about:blank` even though `snapshot`/`eval`/`tab list` see the real tab.
+    // Best-effort: a stale pin still beats erroring the command.
+    if let Some(mgr) = state.browser.as_mut() {
+        mgr.resync_targets().await.ok();
+    }
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -105,6 +105,7 @@ chrome-use is checked @e1      # Check if checked
 chrome-use screenshot          # Save to temporary directory
 chrome-use screenshot path.png # Save to specific path
 chrome-use screenshot --full   # Full page
+chrome-use screenshot --tab t2 shot.png  # Capture a specific tab (ref from `tab list`) instead of the active one
 chrome-use pdf output.pdf      # Save as PDF
 ```
 


### PR DESCRIPTION
Fixes #88 (the `screenshot @ about:blank` half).

## Root cause
All read handlers (`snapshot`, `eval`, `screenshot`, `tab list`) share **one** session resolver — `BrowserManager::active_session_id()`. On relay auto-connect, `connect_auto_with_fresh_tab()` opens a background `about:blank` scratch tab and **pins it as the active target**. Only `handle_tab_list` re-syncs that pin (`mgr.resync_targets()`); `handle_screenshot` did not, so it resolved the stale scratch pin — capturing `about:blank` (both the `screenshot @ <url>` origin and the pixels) while `snapshot`/`eval`/`tab list` showed the real tab.

Credit to the field investigation on #88 for pinpointing that this is a **pin-state/resync** gap, not a per-command resolver divergence.

## Fix
One change in `handle_screenshot` (cli/src/native/actions.rs): call `resync_targets()` before resolving `active_session_id()`, mirroring `handle_tab_list`. Best-effort (a stale pin still beats erroring).

## Verification (live)
Reproduced the original sequence with the built binary:

```
$ chrome-use open "https://drawstyle.leeguoo.com/en/me" --profile auto
$ chrome-use screenshot out.png
# before: screenshot @ about:blank        (blank image)
# after:  screenshot @ https://drawstyle.leeguoo.com/en/me   (fully-rendered page)
```

`cargo build`, `cargo fmt`, `cargo clippy` all clean.

## Not included (follow-ups from #88)
- A `--tab <ref>` / `@tN` selector on `screenshot` (parser is inline at commands.rs:1142-1290) — nice-to-have override, separate change.
- The `--isolated-login` / `--profile clone` competitiveness ask — larger feature.