### PR TITLE
fix(snapshot,eval): resync targets so they don't drift to about:blank (#88 follow-up)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3119,7 +3119,7 @@ async fn handle_content(state: &DaemonState) -> Result<Value, String> {
     Ok(json!({ "html": html, "origin": url }))
 }
 
-async fn handle_evaluate(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_evaluate(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     if let Some(ref wb) = state.webdriver_backend {
         if state.browser.is_none() {
             let script = cmd
@@ -3130,6 +3130,14 @@ async fn handle_evaluate(cmd: &Value, state: &DaemonState) -> Result<Value, Stri
             let url = wb.get_url().await.unwrap_or_default();
             return Ok(json!({ "result": result, "origin": url }));
         }
+    }
+    // Re-sync the active-tab pin before resolving it (issue #88; same drift the
+    // `screenshot`/`snapshot` fix closes). A stale about:blank scratch tab left
+    // pinned by relay auto-connect would otherwise make `evaluate` run against
+    // `about:blank` instead of the real tab. Best-effort: a stale pin still
+    // beats erroring the command.
+    if let Some(mgr) = state.browser.as_mut() {
+        mgr.resync_targets().await.ok();
     }
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let script = cmd
@@ -3509,6 +3517,17 @@ async fn handle_close(state: &mut DaemonState) -> Result<Value, String> {
 // ---------------------------------------------------------------------------
 
 async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    // Re-sync the active-tab pin before resolving it, mirroring `tab list` and
+    // `screenshot` (issue #88). On relay auto-connect a background about:blank
+    // scratch tab can stay pinned as the active target; the read handlers share
+    // one resolver (`active_session_id`), but only handlers that resync escape a
+    // stale pin. Without this, `snapshot` resolves the scratch pin and reports
+    // `about:blank` (empty page / "no interactive elements") even though a real
+    // tab is open — the same drift #88 fixed for `screenshot`. Best-effort: a
+    // stale pin still beats erroring the command.
+    if let Some(mgr) = state.browser.as_mut() {
+        mgr.resync_targets().await.ok();
+    }
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 
@@ -8744,7 +8763,14 @@ async fn handle_find(cmd: &Value, state: &DaemonState) -> Result<Value, String> 
 // Evaluate a JS expression in the active page and return its value by value.
 // Sibling to `evalhandle` (which returns a remote object handle instead). Used
 // e.g. to read DOM state after an action (`document.querySelector(...).disabled`).
-async fn handle_eval(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_eval(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    // Re-sync the active-tab pin before resolving it (issue #88; same drift the
+    // `screenshot`/`snapshot` fix closes). A stale about:blank scratch pin left
+    // by relay auto-connect would otherwise make `eval` read from `about:blank`
+    // instead of the real tab. Best-effort: a stale pin still beats erroring.
+    if let Some(mgr) = state.browser.as_mut() {
+        mgr.resync_targets().await.ok();
+    }
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
     // Accept `expression` (canonical) or `script` (alias, matching evalhandle).
@@ -8779,7 +8805,14 @@ async fn handle_eval(cmd: &Value, state: &DaemonState) -> Result<Value, String> 
     Ok(json!({ "result": result.result.value.unwrap_or(Value::Null) }))
 }
 
-async fn handle_evalhandle(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
+async fn handle_evalhandle(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    // Re-sync the active-tab pin before resolving it (issue #88; same drift the
+    // `screenshot`/`snapshot`/`eval` fix closes). A stale about:blank scratch pin
+    // left by relay auto-connect would otherwise target `about:blank` instead of
+    // the real tab. Best-effort: a stale pin still beats erroring.
+    if let Some(mgr) = state.browser.as_mut() {
+        mgr.resync_targets().await.ok();
+    }
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
     let script = cmd

--- a/docs/compare.html
+++ b/docs/compare.html
@@ -64,7 +64,7 @@
 
       <h2>一句话</h2>
       <p>
-        <strong>chrome-use 驱动你<span class="mark">现有的真 Chrome</span></strong>——你的 profile、你的扩展、你的登录，什么都不用装。
+        <strong>chrome-use 驱动你<span class="mark">现有的真 Chrome</span></strong>——你的 profile、你的扩展、你的登录，不用装新浏览器。
         它是给 AI agent 用的<strong>原生 CLI</strong>：无障碍树快照 + 紧凑 <code>@ref</code>，任何能跑 shell 的 agent 都能用，还带隐身反检测。
         大多数方案要么另开一个浏览器、要么要你换浏览器；chrome-use 直接用你手上这个。
       </p>
@@ -93,13 +93,13 @@
             <td>自建 Chromium 浏览器</td>
             <td>装一个新浏览器</td>
             <td class="cmp-win">Space 继承登录</td>
-            <td>Node.js 运行时</td>
+            <td>页面内 JS 运行时</td>
             <td class="cmp-mut">非重点</td>
             <td>MIT</td>
           </tr>
           <tr>
             <th>browser-use</th>
-            <td>Python 框架（底层 Playwright）</td>
+            <td>Python 框架（底层 CDP，cdp-use）</td>
             <td>框架 + 受控浏览器</td>
             <td class="cmp-mut">默认另开，需重登</td>
             <td>Python API</td>
@@ -122,7 +122,7 @@
             <td class="cmp-mut">全新 profile，无登录</td>
             <td>JS / 多语言</td>
             <td class="cmp-mut">易被检测</td>
-            <td>Apache / BSD</td>
+            <td>Apache-2.0</td>
           </tr>
           <tr>
             <th>Browserbase / Stagehand</th>
@@ -210,7 +210,7 @@
       </div>
       <p>
         原始浏览器操作两边一样快。ego 的优势是<strong>常驻运行时</strong>，没有每条命令的进程启动开销；chrome-use 默认「一命令一进程」，每条约 0.15–0.17s。
-        所以<strong>微操作特别多</strong>的任务里 ego 更快（"快 3 倍"多半来自这种形状）。但典型任务（open+快照+抽取）实测两边都 ~3s，chrome-use 用 <code>batch</code>（一次往返、常驻守护进程）6 操作 0.19s 基本追平，还有 WebSocket 流做实时驱动。
+        所以<strong>微操作特别多</strong>的任务里 ego 更快（"快 3 倍"多半来自这种形状）。但典型任务（open+快照+抽取）实测两边都 ~3s，chrome-use 用 <code>batch</code>（一个进程复用常驻守护进程）6 操作 0.19s 基本追平，还有 WebSocket 流做实时驱动。
       </p>
 
       <h3>他们官网的宣传语 vs 我们的证据</h3>
@@ -271,7 +271,7 @@
       <table class="cmp-table">
         <thead><tr><th>你的情况</th><th>选</th></tr></thead>
         <tbody>
-          <tr class="me"><th>要用你已登录的真账号、什么都不想装、要过反爬</th><td class="cmp-win">chrome-use</td></tr>
+          <tr class="me"><th>要用你已登录的真账号、不想装新浏览器、要过反爬</th><td class="cmp-win">chrome-use</td></tr>
           <tr><th>愿意换一个专为 agent 做的新浏览器、要最干净的隔离</th><td>ego-lite</td></tr>
           <tr><th>写传统自动化脚本、跨语言、CI 里跑</th><td>Playwright / Puppeteer</td></tr>
           <tr><th>无状态大规模云抓取</th><td>Browserbase / Steel</td></tr>

--- a/docs/en/compare.html
+++ b/docs/en/compare.html
@@ -65,7 +65,7 @@
 
       <h2>In one line</h2>
       <p>
-        <strong>chrome-use drives your <span class="mark">existing, real Chrome</span></strong> — your profile, your extensions, your logins, nothing to install.
+        <strong>chrome-use drives your <span class="mark">existing, real Chrome</span></strong> — your profile, your extensions, your logins, no new browser to install.
         It's a <strong>native CLI for AI agents</strong>: accessibility-tree snapshots + compact <code>@ref</code>s, usable by any agent that can run a shell, with stealth / anti-detection built in.
         Most tools either spin up a separate browser or ask you to switch browsers; chrome-use uses the one you already have.
       </p>
@@ -94,13 +94,13 @@
             <td>Purpose-built Chromium browser</td>
             <td>Install a new browser</td>
             <td class="cmp-win">Spaces inherit login</td>
-            <td>Node.js runtime</td>
+            <td>in-page JS runtime</td>
             <td class="cmp-mut">Not a focus</td>
             <td>MIT</td>
           </tr>
           <tr>
             <th>browser-use</th>
-            <td>Python framework (Playwright under the hood)</td>
+            <td>Python framework (CDP under the hood, cdp-use)</td>
             <td>Framework + a driven browser</td>
             <td class="cmp-mut">Fresh by default, re-login</td>
             <td>Python API</td>
@@ -123,7 +123,7 @@
             <td class="cmp-mut">Fresh profile, no login</td>
             <td>JS / many languages</td>
             <td class="cmp-mut">Easily detected</td>
-            <td>Apache / BSD</td>
+            <td>Apache-2.0</td>
           </tr>
           <tr>
             <th>Browserbase / Stagehand</th>
@@ -211,7 +211,7 @@
       </div>
       <p>
         Raw browser operations are equally fast. ego's edge is its <strong>persistent runtime</strong> — no per-command process spawn; chrome-use defaults to one-process-per-command (~0.15–0.17s each).
-        So a task with <strong>many tiny ops</strong> is where ego pulls ahead ("3×" most likely comes from that shape). But a typical task (open + snapshot + extract) measured ~3s on both, and chrome-use's <code>batch</code> (one round-trip to the persistent daemon) does 6 ops in 0.19s ≈ ego, plus a WebSocket stream for real-time driving.
+        So a task with <strong>many tiny ops</strong> is where ego pulls ahead ("3×" most likely comes from that shape). But a typical task (open + snapshot + extract) measured ~3s on both, and chrome-use's <code>batch</code> (one process reusing the persistent daemon) does 6 ops in 0.19s ≈ ego, plus a WebSocket stream for real-time driving.
       </p>
 
       <h3>Their site's claims vs our evidence</h3>
@@ -272,7 +272,7 @@
       <table class="cmp-table">
         <thead><tr><th>Your situation</th><th>Pick</th></tr></thead>
         <tbody>
-          <tr class="me"><th>Use your real logged-in accounts, install nothing, beat anti-bot</th><td class="cmp-win">chrome-use</td></tr>
+          <tr class="me"><th>Use your real logged-in accounts, install no new browser, beat anti-bot</th><td class="cmp-win">chrome-use</td></tr>
           <tr><th>Willing to switch to an agent-native browser, want the cleanest isolation</th><td>ego-lite</td></tr>
           <tr><th>Write classic automation scripts, cross-language, run in CI</th><td>Playwright / Puppeteer</td></tr>
           <tr><th>Stateless large-scale cloud scraping</th><td>Browserbase / Steel</td></tr>


### PR DESCRIPTION
Follow-up to #91. #91 fixed the `screenshot` half of the `about:blank` drift; this closes the same gap for `snapshot`, `eval`, `evaluate`, and `evalhandle`.

## Why #91 wasn't the whole fix
#91's own root cause: the read handlers share one resolver (`active_session_id`), and on relay auto-connect a background `about:blank` scratch tab can stay **pinned** as the active target. Only handlers that call `resync_targets()` escape that stale pin. #91 added the resync to `handle_screenshot` only — but `snapshot`/`eval`/`evaluate`/`evalhandle` don't resync either, so they keep drifting.

`eval`/`evaluate`/`evalhandle` took `&DaemonState` (immutable) — they structurally *couldn't* resync.

## Repro (filed on #88)
Fresh cold `open` reports success, then the very next read lands on `about:blank`:
```
$ chrome-use open https://example.com
✓ Example Domain                       # success

$ chrome-use snapshot -i
(no interactive elements)              # example.com has a "Learn more" link

$ chrome-use eval "document.title"
eval @ about:blank                     # WRONG TAB
""
```
See <https://github.com/leeguooooo/chrome-use/issues/88#issuecomment-4895757684>.

## Fix
- `handle_snapshot` (already `&mut`): add `resync_targets()` before `active_session_id()`.
- `handle_eval` / `handle_evaluate` / `handle_evalhandle`: change `&DaemonState` → `&mut DaemonState` and resync before resolving the active tab.

All three eval handlers are only reached from the command dispatcher and `handle_site`, both of which already hold `&mut DaemonState`, so no caller changes were needed. Best-effort (a stale pin still beats erroring), matching #91.

## Verification
- 3 cold-daemon `open → eval → snapshot` rounds: all resolve the real tab (pre-fix drifted to `about:blank`).
- `cargo build`, `cargo clippy` (no issues), `cargo fmt --check` clean.
- `cargo test`: **1004 passed, 0 failed, 76 ignored**.

_Found by the chrome-use vs ego-browser bakeoff._