### PR TITLE
docs(compare): re-measure token table in matched login state (independent reproduction)

### DIFF
--- a/docs/compare.html
+++ b/docs/compare.html
@@ -185,15 +185,16 @@
       <table class="cmp-table">
         <thead><tr><th>页面</th><th>chrome-use <code>snapshot -i</code></th><th>ego <code>snapshotText</code></th><th>谁更省</th></tr></thead>
         <tbody>
-          <tr class="me"><th>example.com</th><td class="cmp-win">101 字节</td><td>456 字节</td><td>省 ~4.5×</td></tr>
-          <tr class="me"><th>Hacker News</th><td class="cmp-win">12.9 KB</td><td>46.7 KB</td><td>省 ~3.6×</td></tr>
-          <tr class="me"><th>GitHub 仓库页</th><td class="cmp-win">18.6 KB</td><td>33.6 KB</td><td>省 ~1.8×</td></tr>
+          <tr class="me"><th>example.com</th><td class="cmp-win">102 字节</td><td>438 字节</td><td>省 ~4.3×</td></tr>
+          <tr class="me"><th>Hacker News</th><td class="cmp-win">12.6 KB</td><td>46.7 KB</td><td>省 ~3.7×</td></tr>
+          <tr class="me"><th>GitHub 仓库页<br><span class="cmp-mut">（两边都登录态）</span></th><td class="cmp-win">26.6 KB</td><td>112 KB</td><td>省 ~4.2×</td></tr>
         </tbody>
       </table>
       </div>
+      <p class="cmp-mut" style="font-size:.82rem; margin-top:6px;">两边工具于同一时刻、同一登录态各自默认设置下实测（2026-07 复现）：example.com / HN 均为登出态，GitHub 两边都登录同一账号。此前的 456 / 33.6K 等数字为旧值或状态错配，已用独立复现值替换。</p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ "更省 token" 恰好说反了</div>
-        chrome-use 默认 <code>snapshot -i</code> 只列交互元素，比 ego 默认的全结构树 <strong>省 1.8–4.5×</strong>。token 是 agent 真正花钱的地方——是我们更省。
+        chrome-use 默认 <code>snapshot -i</code> 只列交互元素，比 ego 默认的全结构树 <strong>省 ~3.7–4.3×</strong>（同登录态独立复现）。token 是 agent 真正花钱的地方——是我们更省。
       </div>
 
       <h3>性能（墙钟时间）</h3>
@@ -226,8 +227,8 @@
           </tr>
           <tr class="me">
             <td>"<strong>Same automation, fewer tokens</strong>"</td>
-            <td>同页默认快照体量：chrome-use <code>snapshot -i</code> <strong>101 / 12.9K / 18.6K 字节</strong> vs ego <code>snapshotText</code> 456 / 46.7K / 33.6K。</td>
-            <td><span class="cmp-win">反了</span>——默认工作流下<strong>我们省 1.8–4.5×</strong>。</td>
+            <td>同页默认快照体量（同登录态独立复现）：chrome-use <code>snapshot -i</code> <strong>102 B / 12.6K / 26.6K</strong> vs ego <code>snapshotText</code> 438 B / 46.7K / 112K。</td>
+            <td><span class="cmp-win">反了</span>——默认工作流下<strong>我们省 ~3.7–4.3×</strong>。</td>
           </tr>
           <tr>
             <td>"not a JS shim on stock Chrome … reach into <strong>cross-origin iframes, shadow DOM, third-party SDK widgets</strong> like Stripe, Salesforce, Intercom, React portals … <strong>JS shims usually give up</strong> … burning tokens for nothing"</td>

--- a/docs/en/compare.html
+++ b/docs/en/compare.html
@@ -186,15 +186,16 @@
       <table class="cmp-table">
         <thead><tr><th>Page</th><th>chrome-use <code>snapshot -i</code></th><th>ego <code>snapshotText</code></th><th>Leaner</th></tr></thead>
         <tbody>
-          <tr class="me"><th>example.com</th><td class="cmp-win">101 bytes</td><td>456 bytes</td><td>~4.5×</td></tr>
-          <tr class="me"><th>Hacker News</th><td class="cmp-win">12.9 KB</td><td>46.7 KB</td><td>~3.6×</td></tr>
-          <tr class="me"><th>GitHub repo page</th><td class="cmp-win">18.6 KB</td><td>33.6 KB</td><td>~1.8×</td></tr>
+          <tr class="me"><th>example.com</th><td class="cmp-win">102 bytes</td><td>438 bytes</td><td>~4.3×</td></tr>
+          <tr class="me"><th>Hacker News</th><td class="cmp-win">12.6 KB</td><td>46.7 KB</td><td>~3.7×</td></tr>
+          <tr class="me"><th>GitHub repo page<br><span class="cmp-mut">(both logged in)</span></th><td class="cmp-win">26.6 KB</td><td>112 KB</td><td>~4.2×</td></tr>
         </tbody>
       </table>
       </div>
+      <p class="cmp-mut" style="font-size:.82rem; margin-top:6px;">Both tools measured back-to-back in the same login state, each on its own defaults (re-run 2026-07): example.com / HN logged out, GitHub logged into the same account on both. Earlier figures (456 / 33.6K, etc.) were stale or captured in a mismatched login state; replaced with independently reproduced values.</p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ "fewer tokens" is backwards</div>
-        chrome-use's default <code>snapshot -i</code> lists interactive elements only — <strong>1.8–4.5× leaner</strong> than ego's default full tree. Tokens are what an agent actually pays for, so we save more.
+        chrome-use's default <code>snapshot -i</code> lists interactive elements only — <strong>~3.7–4.3× leaner</strong> than ego's default full tree (independently reproduced, same login state). Tokens are what an agent actually pays for, so we save more.
       </div>
 
       <h3>Performance (wall-clock)</h3>
@@ -227,8 +228,8 @@
           </tr>
           <tr class="me">
             <td>"<strong>Same automation, fewer tokens</strong>"</td>
-            <td>Default snapshot size, same pages: chrome-use <code>snapshot -i</code> <strong>101 / 12.9K / 18.6K bytes</strong> vs ego <code>snapshotText</code> 456 / 46.7K / 33.6K.</td>
-            <td><span class="cmp-win">Backwards</span> — in the default workflow <strong>we're 1.8–4.5× leaner</strong>.</td>
+            <td>Default snapshot size, same pages (independently reproduced, same login state): chrome-use <code>snapshot -i</code> <strong>102 B / 12.6K / 26.6K</strong> vs ego <code>snapshotText</code> 438 B / 46.7K / 112K.</td>
+            <td><span class="cmp-win">Backwards</span> — in the default workflow <strong>we're ~3.7–4.3× leaner</strong>.</td>
           </tr>
           <tr>
             <td>"not a JS shim on stock Chrome … reach into <strong>cross-origin iframes, shadow DOM, third-party SDK widgets</strong> like Stripe, Salesforce, Intercom, React portals … <strong>JS shims usually give up</strong> … burning tokens for nothing"</td>


### PR DESCRIPTION
Closes the last 'unverifiable' gap from the compare-page fact-check: the chrome-use-vs-ego token numbers were ego's self-reported figures. I installed/drove ego-lite and re-ran both tools back-to-back, each on its own defaults, in the **same login state**.

| Page | state | chrome-use `snapshot -i` | ego `snapshotText` | leaner |
|---|---|---|---|---|
| example.com | logged out | 102 B | 438 B | ~4.3x |
| Hacker News | logged out | 12.6 KB | 46.7 KB | ~3.7x |
| GitHub repo | **both logged in** | 26.6 KB | 112 KB | ~4.2x |

- Old GitHub 18.6K/33.6K was a login-state mismatch that **understated** the real saving. Corrected range 1.8-4.5x -> ~3.7-4.3x.
- Perf numbers re-measured cleanly (0.169s/op median, 1.01s for 6 separate procs, batch 0.186s ~ 0.19s) — they hold, left unchanged.

https://claude.ai/code/session_016y1t4eQCT6abUVZCztLuvt