### PR TITLE
docs(compare): mark #92 cross-origin iframe merge as fixed

### DIFF
--- a/docs/compare.html
+++ b/docs/compare.html
@@ -232,8 +232,8 @@
           </tr>
           <tr>
             <td>"not a JS shim on stock Chrome … reach into <strong>cross-origin iframes, shadow DOM, third-party SDK widgets</strong> like Stripe, Salesforce, Intercom, React portals … <strong>JS shims usually give up</strong> … burning tokens for nothing"</td>
-            <td>chrome-use 走 <strong>CDP</strong>（非 JS shim）。reCAPTCHA demo 实测：<code>frames</code> 列出全部 5 个跨域 frame；<code>eval --frame 1</code> 读到勾选框 <code>role=checkbox</code>「I'm not a robot」。<strong>但</strong>默认 <code>snapshot -i</code> 没把它并进顶层，ego 快照并了（已开 <a href="https://github.com/leeguooooo/chrome-use/issues/92">#92</a> 修）。</td>
-            <td><span class="cmp-mut">一半假一半真</span>——我们<strong>不是 JS shim、也能触达</strong> OOPIF/SDK widget；但默认快照确实漏并了 reCAPTCHA 这类，这点它对。</td>
+            <td>chrome-use 走 <strong>CDP</strong>（非 JS shim）。reCAPTCHA demo 实测：<code>frames</code> 列出全部 5 个跨域 frame；<code>eval --frame 1</code> 读到勾选框 <code>role=checkbox</code>「I'm not a robot」。默认 <code>snapshot -i</code> 此前没把它并进顶层——<strong>现已修复</strong>（<a href="https://github.com/leeguooooo/chrome-use/issues/92">#92</a> 已合并 presentation-role / AX-stripped 跨域 iframe）。</td>
+            <td><span class="cmp-win">已追平</span>——我们<strong>不是 JS shim、能触达</strong> OOPIF/SDK widget，且默认快照现在也把它们并入了（#92 已修）。ego 说的是通用 JS shim 的毛病，不适用于我们。</td>
           </tr>
           <tr>
             <td>"your AI agents will <strong>never get stuck on captchas, 2FA, and SSO redirects</strong>"（因为你登录态用它）</td>

--- a/docs/en/compare.html
+++ b/docs/en/compare.html
@@ -233,8 +233,8 @@
           </tr>
           <tr>
             <td>"not a JS shim on stock Chrome … reach into <strong>cross-origin iframes, shadow DOM, third-party SDK widgets</strong> like Stripe, Salesforce, Intercom, React portals … <strong>JS shims usually give up</strong> … burning tokens for nothing"</td>
-            <td>chrome-use uses <strong>CDP</strong> (not a JS shim). reCAPTCHA demo, measured: <code>frames</code> lists all 5 cross-origin frames; <code>eval --frame 1</code> read the checkbox <code>role=checkbox</code> "I'm not a robot". <strong>But</strong> the default <code>snapshot -i</code> didn't merge it while ego's did (fixing in <a href="https://github.com/leeguooooo/chrome-use/issues/92">#92</a>).</td>
-            <td><span class="cmp-mut">Half wrong, half right</span> — we're <strong>not a JS shim and do reach</strong> OOPIF/SDK widgets; but the default snapshot did miss this reCAPTCHA case — that part is fair.</td>
+            <td>chrome-use uses <strong>CDP</strong> (not a JS shim). reCAPTCHA demo, measured: <code>frames</code> lists all 5 cross-origin frames; <code>eval --frame 1</code> read the checkbox <code>role=checkbox</code> "I'm not a robot". The default <code>snapshot -i</code> previously didn't merge it — <strong>now fixed</strong> (<a href="https://github.com/leeguooooo/chrome-use/issues/92">#92</a> merges presentation-role / AX-stripped cross-origin iframes).</td>
+            <td><span class="cmp-win">Now closed</span> — we're <strong>not a JS shim and do reach</strong> OOPIF/SDK widgets, and the default snapshot now merges them too (#92 fixed). ego's dig is about generic JS shims — it doesn't apply to us.</td>
           </tr>
           <tr>
             <td>"your AI agents will <strong>never get stuck on captchas, 2FA, and SSO redirects</strong>" (because you're logged into it)</td>


### PR DESCRIPTION
#92 is CLOSED (fixed by 589fa51 — snapshot -i now merges presentation-role / AX-stripped cross-origin iframes). Updates the compare page's 'JS shim' row: evidence 'fixing in #92' -> 'now fixed'; verdict 'half wrong, half right' -> 'now closed'. zh + en.

https://claude.ai/code/session_016y1t4eQCT6abUVZCztLuvt