### PR TITLE
docs(compare): don't quote ego 'Take over / Stop' as verbatim UI (unverified)

### DIFF
--- a/docs/compare.html
+++ b/docs/compare.html
@@ -246,8 +246,8 @@
             <td><span class="cmp-mut">持平</span>——都免费；它要你下一个新浏览器，我们用你现有的。</td>
           </tr>
           <tr>
-            <td>"<strong>Take over</strong> / Stop"（它的交接 UI）</td>
-            <td>chrome-use 已实现 <code>session handoff</code> / <code>resume</code> / <code>status</code> / <code>list</code>。</td>
+            <td>交接 / 接管 UI（用户可随时从 agent 手里接管 Space）</td>
+            <td>chrome-use 已实现 <code>session handoff</code> / <code>resume</code> / <code>status</code> / <code>list</code>。<span class="cmp-mut">（注：ego 该功能确有，但未见 "Take over/Stop" 逐字标签，故不作原文引用。）</span></td>
             <td><span class="cmp-mut">持平</span>——已对齐。</td>
           </tr>
           <tr>

--- a/docs/en/compare.html
+++ b/docs/en/compare.html
@@ -247,8 +247,8 @@
             <td><span class="cmp-mut">Parity</span> — both free; they have you download a new browser, we use yours.</td>
           </tr>
           <tr>
-            <td>"<strong>Take over</strong> / Stop" (their handoff UI)</td>
-            <td>chrome-use ships <code>session handoff</code> / <code>resume</code> / <code>status</code> / <code>list</code>.</td>
+            <td>Handoff / take-over UI (the user can reclaim a Space from the agent anytime)</td>
+            <td>chrome-use ships <code>session handoff</code> / <code>resume</code> / <code>status</code> / <code>list</code>. <span class="cmp-mut">(Note: ego has this feature, but we couldn't verify the literal "Take over/Stop" labels, so we don't quote them.)</span></td>
             <td><span class="cmp-mut">Parity</span> — matched.</td>
           </tr>
           <tr>


### PR DESCRIPTION
Couldn't confirm the literal 'Take over'/'Stop' labels in ego's GUI (window captures) or app-bundle strings — they only appear in ego's SKILL.md + generic Chromium locale packs. Feature exists (color-coded agent tabs), so reword to a generic handoff description + note. Parity verdict unchanged. zh + en.

https://claude.ai/code/session_016y1t4eQCT6abUVZCztLuvt