### PR TITLE
docs(compare): restructure — decision table up front, surpass feature gets its own h3

### DIFF
--- a/docs/compare.html
+++ b/docs/compare.html
@@ -174,6 +174,20 @@
         </div>
       </div>
 
+      <h2>怎么选</h2>
+      <div class="cmp-scroll">
+      <table class="cmp-table">
+        <thead><tr><th>你的情况</th><th>选</th></tr></thead>
+        <tbody>
+          <tr class="me"><th>要用你已登录的真账号、不想装新浏览器、要过反爬</th><td class="cmp-win">chrome-use</td></tr>
+          <tr><th>愿意换一个专为 agent 做的新浏览器、要最干净的隔离</th><td>ego-lite</td></tr>
+          <tr><th>写传统自动化脚本、跨语言、CI 里跑</th><td>Playwright / Puppeteer</td></tr>
+          <tr><th>无状态大规模云抓取</th><td>Browserbase / Steel</td></tr>
+          <tr><th>只是终端用户想让浏览器帮点忙</th><td>ChatGPT Atlas / Comet</td></tr>
+        </tbody>
+      </table>
+      </div>
+
       <h2>最接近的对手：chrome-use vs ego-lite（实测深挖）</h2>
       <p>
         ego-lite 的定位和我们最像（都用真登录、不抢用户标签），README 还<strong>直接点名 agent-browser</strong>。
@@ -259,6 +273,19 @@
       </table>
       </div>
 
+
+      <h3>反超的一项：单次成型脚本（chrome-use script）</h3>
+      <p>
+        ego 的核心卖点是 “code base, not CLI base”：写一段 JS 把整个任务一次跑完。这一项我们<span class="cmp-win">已 ship 并反超</span>：
+        <code>chrome-use script</code> 同样写一段 JS（ego 原样 idiom），用 <code>cu.snapshot/eval/click/fill/find/waitFor/extract</code>
+        直接驱动，带控制流，一次往返返回结构化结果；JSON op-list 形式亦可（可 dry-run、可机器生成）。
+      </p>
+      <p>
+        反超点在引擎位置：JS 引擎跑在<strong>守护进程里、不在页面里</strong>，<strong>扛得住硬跳转</strong>，
+        而多页翻页正是 ego 赢、页面内运行时输的地方。实测 HN 翻 3 页收集 ≥100 分故事 = <strong>一次 tool call</strong>（旧 per-verb 要 13+），
+        跑在你<strong>已登录的真 Chrome</strong> + 隐身传输，<strong>跨平台</strong>（ego 仅 macOS）。
+      </p>
+
       <h3>我们从 ego-lite 学到 &amp; 已搬的</h3>
       <p>逐项试用对比后，把真缺口用 chrome-use 原生的方式搬过来（进度在 <a href="https://github.com/leeguooooo/chrome-use/issues/89">issue #89</a>）：</p>
       <ul>
@@ -267,22 +294,7 @@
         <li><strong>登录继承 / 隔离上下文 / 按名复用 / token 经济</strong>（<span class="cmp-win">已具备</span>）：relay 天然带登录、每会话标签组隔离、<code>session list</code>、<code>--session-name</code>、更省 token。</li>
         <li><strong>定位（locating）</strong>（<span class="cmp-win">持平</span>）：<code>@ref</code>（backendNodeId 跨调用稳定）+ CSS + XPath + 坐标 + 语义 <code>find role button --name</code> + <code>box</code> 几何 + <code>-s</code> 作用域，对齐 ego 的 <code>loc=</code> / <code>@N</code>。</li>
         <li><strong>群组（groups）</strong>（<span class="cmp-win">持平</span>）：每个 <code>--session</code> 一个彩色 Chrome 标签组、group-scoped 隔离（<a href="https://github.com/leeguooooo/chrome-use/issues/40">#40</a>）、多 agent 互不串、只拥有自己建的标签。等价 ego 的 Task Space，只是发生在你的真 Chrome 里，不用换浏览器。</li>
-        <li><strong>单次成型的复杂脚本</strong>（ego 的 “code base, not CLI base” 优势，<span class="cmp-win">已 ship，反超</span>）：<code>chrome-use script</code> 写一段 JS（ego 原样 idiom），用 <code>cu.snapshot/eval/click/fill/find/waitFor/extract</code> 直接驱动，带控制流，一次往返返回结构化结果。反超点在引擎位置：JS 引擎跑在<strong>守护进程里、不在页面里</strong>，<strong>扛得住硬跳转</strong>，而多页翻页正是 ego 赢、页面内运行时输的地方。实测 HN 翻 3 页收集 ≥100 分故事 = <strong>一次 tool call</strong>（旧 per-verb 要 13+），跑在你<strong>已登录的真 Chrome</strong> + 隐身传输，<strong>跨平台</strong>（ego 仅 macOS）。JSON op-list 形式亦可（可 dry-run、可机器生成）。</li>
       </ul>
-
-      <h2>怎么选</h2>
-      <div class="cmp-scroll">
-      <table class="cmp-table">
-        <thead><tr><th>你的情况</th><th>选</th></tr></thead>
-        <tbody>
-          <tr class="me"><th>要用你已登录的真账号、不想装新浏览器、要过反爬</th><td class="cmp-win">chrome-use</td></tr>
-          <tr><th>愿意换一个专为 agent 做的新浏览器、要最干净的隔离</th><td>ego-lite</td></tr>
-          <tr><th>写传统自动化脚本、跨语言、CI 里跑</th><td>Playwright / Puppeteer</td></tr>
-          <tr><th>无状态大规模云抓取</th><td>Browserbase / Steel</td></tr>
-          <tr><th>只是终端用户想让浏览器帮点忙</th><td>ChatGPT Atlas / Comet</td></tr>
-        </tbody>
-      </table>
-      </div>
 
       <h2>对比 workflow</h2>
       <p>这一页是活文档。每评估一个方案，走同一套流程，保证对比诚实、可复现：</p>

--- a/docs/en/compare.html
+++ b/docs/en/compare.html
@@ -175,6 +175,20 @@
         </div>
       </div>
 
+      <h2>Which to pick</h2>
+      <div class="cmp-scroll">
+      <table class="cmp-table">
+        <thead><tr><th>Your situation</th><th>Pick</th></tr></thead>
+        <tbody>
+          <tr class="me"><th>Use your real logged-in accounts, install no new browser, beat anti-bot</th><td class="cmp-win">chrome-use</td></tr>
+          <tr><th>Willing to switch to an agent-native browser, want the cleanest isolation</th><td>ego-lite</td></tr>
+          <tr><th>Write classic automation scripts, cross-language, run in CI</th><td>Playwright / Puppeteer</td></tr>
+          <tr><th>Stateless large-scale cloud scraping</th><td>Browserbase / Steel</td></tr>
+          <tr><th>Just an end user who wants the browser to help</th><td>ChatGPT Atlas / Comet</td></tr>
+        </tbody>
+      </table>
+      </div>
+
       <h2>The closest rival: chrome-use vs ego-lite (measured)</h2>
       <p>
         ego-lite is positioned closest to us (both "use real logins, don't fight for the user's tabs"), and its README <strong>names agent-browser directly</strong>.
@@ -260,6 +274,22 @@
       </table>
       </div>
 
+
+      <h3>Where we're ahead: single-pass scripting (chrome-use script)</h3>
+      <p>
+        ego's core pitch is “code base, not CLI base”: write one JS program that runs the whole task in one pass.
+        This one is <span class="cmp-win">shipped and ahead</span>: <code>chrome-use script</code> runs a real JS program
+        (ego's exact idiom) driving the page via <code>cu.snapshot/eval/click/fill/find/waitFor/extract</code>, with control
+        flow, returning structured results in one round-trip; a JSON op-list form is also available (dry-runnable, machine-generatable).
+      </p>
+      <p>
+        The decisive edge is where the engine lives: in the <strong>daemon, not the page</strong>, so it
+        <strong>survives hard navigations</strong> — the multi-page flows that are exactly where ego wins and a page-world
+        runtime breaks. Measured: crawl 3 HN pages collecting every ≥100-point story = <strong>one tool call</strong>
+        (the old per-verb way needs 13+), on your <strong>already-logged-in real Chrome</strong> over the stealth transport,
+        <strong>cross-platform</strong> (ego is macOS-only).
+      </p>
+
       <h3>What we learned from ego-lite &amp; ported</h3>
       <p>After trialing each item, we ported the real gaps the chrome-use way (progress in <a href="https://github.com/leeguooooo/chrome-use/issues/89">issue #89</a>):</p>
       <ul>
@@ -268,22 +298,7 @@
         <li><strong>Login inheritance / isolated contexts / reuse-by-name / token economy</strong> — <span class="cmp-win">already covered</span> (relay carries logins, per-session tab groups, <code>session list</code>, <code>--session-name</code>, leaner tokens).</li>
         <li><strong>Locating</strong> — <span class="cmp-win">covered · parity</span>: <code>@ref</code> (backendNodeId-stable across calls) + CSS + XPath + coordinates + semantic <code>find role button --name</code> + <code>box</code> geometry + <code>-s</code> scoping, matching ego's <code>loc=</code> / <code>@N</code>.</li>
         <li><strong>Groups</strong> — <span class="cmp-win">covered · parity</span>: each <code>--session</code> maps to a colored Chrome tab group, group-scoped isolation (<a href="https://github.com/leeguooooo/chrome-use/issues/40">#40</a>), agents never cross tabs, a session owns only the tabs it created — equivalent to ego's Task Space, except it happens in your real Chrome instead of a separate browser.</li>
-        <li><strong>Single-pass complex scripting</strong> (ego's “code base, not CLI base” edge) — <span class="cmp-win">shipped, ahead</span>: <code>chrome-use script</code> runs a real JS program (ego's exact idiom) that drives the page via <code>cu.snapshot/eval/click/fill/find/waitFor/extract</code>, with control flow, returning structured results in one round-trip. <strong>The decisive edge</strong>: the JS engine lives in the <strong>daemon, not the page</strong>, so it <strong>survives hard navigations</strong> — the multi-page flows that are exactly where ego wins and a page-world runtime breaks. Measured: crawl 3 HN pages collecting every ≥100-point story = <strong>one tool call</strong> (the old per-verb way needs 13+), on your <strong>already-logged-in real Chrome</strong> over the stealth transport, <strong>cross-platform</strong> (ego is macOS-only). A JSON op-list form is also available (dry-runnable, machine-generatable).</li>
       </ul>
-
-      <h2>Which to pick</h2>
-      <div class="cmp-scroll">
-      <table class="cmp-table">
-        <thead><tr><th>Your situation</th><th>Pick</th></tr></thead>
-        <tbody>
-          <tr class="me"><th>Use your real logged-in accounts, install no new browser, beat anti-bot</th><td class="cmp-win">chrome-use</td></tr>
-          <tr><th>Willing to switch to an agent-native browser, want the cleanest isolation</th><td>ego-lite</td></tr>
-          <tr><th>Write classic automation scripts, cross-language, run in CI</th><td>Playwright / Puppeteer</td></tr>
-          <tr><th>Stateless large-scale cloud scraping</th><td>Browserbase / Steel</td></tr>
-          <tr><th>Just an end user who wants the browser to help</th><td>ChatGPT Atlas / Comet</td></tr>
-        </tbody>
-      </table>
-      </div>
 
       <h2>The comparison workflow</h2>
       <p>This page is a living document. For every tool we evaluate, the same loop keeps the comparison honest and reproducible:</p>


### PR DESCRIPTION
Structure-only pass (zh+en mirrored, zero content removed): 'Which to pick' now sits next to 'Pick by category' instead of after the ego deep-dive; the shipped single-pass-scripting surpass is promoted from a buried bullet under 'learned & ported' to its own h3. Facts spot-checked intact.

https://claude.ai/code/session_016y1t4eQCT6abUVZCztLuvt