### PR TITLE
docs: How It Works + Lineage & Upstream + Single-pass Scripting chapters

### DIFF
--- a/docs/assets/docs/docs.js
+++ b/docs/assets/docs/docs.js
@@ -83,6 +83,7 @@
       { slug: "overview",  ico: "🧭", zh: "概览",        en: "Overview",            kw: "intro start home 首页 介绍" },
       { slug: "install",   ico: "📦", zh: "安装",        en: "Installation",        kw: "install setup 安装 npm curl extension 扩展" },
       { slug: "core-loop", ico: "🔁", zh: "核心循环",    en: "The Core Loop",       kw: "loop snapshot act observe 循环 workflow" },
+      { slug: "how-it-works", ico: "⚙️", zh: "它怎么工作", en: "How It Works",       kw: "architecture daemon relay native messaging extension cdp pipeline 架构 原理 守护进程 中继 工作原理" },
     ]},
     { id: "core", label: { zh: "核心用法", en: "Core Usage" }, items: [
       { slug: "reading",     ico: "📖", zh: "读取页面",  en: "Reading Pages",       kw: "snapshot read dom accessibility 读取 快照" },
@@ -99,6 +100,7 @@
       { slug: "stealth",     ico: "🥷", zh: "反检测与隐身", en: "Stealth & Anti-detection", kw: "stealth anti-detection antibot cloudflare creepjs humanize 反检测 隐身 封号 指纹 bot" },
     ]},
     { id: "advanced", label: { zh: "进阶", en: "Advanced" }, items: [
+      { slug: "script",  ico: "⚡", zh: "单次成型脚本", en: "Single-pass Scripting", kw: "script batch op-list json js boa foreach waituntil assert dry-run cu 单次 脚本 一次往返 编排" },
       { slug: "canvas",  ico: "🎨", zh: "Canvas / WebGL / 游戏", en: "Canvas / WebGL / Games", kw: "canvas webgl game figma capture 游戏" },
       { slug: "network", ico: "🛰️", zh: "网络拦截与改写", en: "Network Interception", kw: "network mock rewrite fetch cdp 拦截 改写" },
       { slug: "react",   ico: "⚛️", zh: "React / Web Vitals", en: "React / Web Vitals", kw: "react vitals performance 性能" },
@@ -118,6 +120,7 @@
       { slug: "commands",        ico: "📚", zh: "命令参考",   en: "Command Reference",  kw: "commands cli flags reference 命令 参考" },
       { slug: "troubleshooting", ico: "🩹", zh: "故障排查",   en: "Troubleshooting",    kw: "troubleshoot debug relay error 故障 排查" },
       { slug: "family",          ico: "🧩", zh: "*-use 家族", en: "The *-use Family",   kw: "family iphone-use cookie-use bitwarden 家族" },
+      { slug: "lineage",         ico: "🌱", zh: "血统与上游", en: "Lineage & Upstream", kw: "fork upstream vercel agent-browser apache license attribution 上游 分叉 血统 许可证 出身" },
     ]},
   ];
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -211,7 +211,7 @@
       </ul>
 
       <h2>更早历史</h2>
-      <p>chrome-use 会定期把上游 <a href="https://github.com/AgentDesk/agent-browser">agent-browser</a> 的版本合并进来（<code>v0.27</code>–<code>v0.31</code>，比如 v0.30.0 的 <code>--wait</code> glob 支持、v0.29.0 的 sandbox 包发布元数据修复）；chrome-use 自己在这之上做了大量独立开发，两条版本号并不同步。</p>
+      <p>chrome-use 会定期把上游 <a href="https://github.com/vercel-labs/agent-browser">agent-browser</a> 的版本合并进来（<code>v0.27</code>–<code>v0.31</code>，比如 v0.30.0 的 <code>--wait</code> glob 支持、v0.29.0 的 sandbox 包发布元数据修复）；chrome-use 自己在这之上做了大量独立开发，两条版本号并不同步。</p>
       <p>更早的 v0.x 版本（v0.6.0 – v0.26.0，2026 年 1–4 月）继承自上游 agent-browser 基线，逐条列出意义不大，这里不再展开。</p>
 
       <hr class="du-divider" />

--- a/docs/compare.html
+++ b/docs/compare.html
@@ -284,6 +284,7 @@
         反超点在引擎位置：JS 引擎跑在<strong>守护进程里、不在页面里</strong>，<strong>扛得住硬跳转</strong>，
         而多页翻页正是 ego 赢、页面内运行时输的地方。实测 HN 翻 3 页收集 ≥100 分故事 = <strong>一次 tool call</strong>（旧 per-verb 要 13+），
         跑在你<strong>已登录的真 Chrome</strong> + 隐身传输，<strong>跨平台</strong>（ego 仅 macOS）。
+        用法与两种写法详见 <a href="/script.html">单次成型脚本</a>。
       </p>
 
       <h3>我们从 ego-lite 学到 &amp; 已搬的</h3>

--- a/docs/core-loop.html
+++ b/docs/core-loop.html
@@ -256,9 +256,13 @@
           <div class="du-card-title"><span class="du-card-ico">🔎</span> 定位元素</div>
           <p><code>find role/text/label</code> 与 <code>@ref</code> 精准锁定目标。</p>
         </a>
-        <a class="du-card" href="/install.html">
-          <div class="du-card-title"><span class="du-card-ico">📦</span> 安装</div>
-          <p>还没装好？装 CLI、装 Chrome 扩展、拉 agent 技能。</p>
+        <a class="du-card" href="/how-it-works.html">
+          <div class="du-card-title"><span class="du-card-ico">⚙️</span> 它怎么工作</div>
+          <p>这个循环背后：CLI、守护进程、扩展中继、@ref 从哪来。</p>
+        </a>
+        <a class="du-card" href="/script.html">
+          <div class="du-card-title"><span class="du-card-ico">⚡</span> 单次成型脚本</div>
+          <p>多步流程把整个循环一次跑完：<code>chrome-use script</code>，一次 tool call 拿回结果。</p>
         </a>
       </div>
 

--- a/docs/en/changelog.html
+++ b/docs/en/changelog.html
@@ -210,7 +210,7 @@
       </ul>
 
       <h2>Earlier history</h2>
-      <p>chrome-use periodically merges in upstream <a href="https://github.com/AgentDesk/agent-browser">agent-browser</a> releases (<code>v0.27</code>–<code>v0.31</code>, e.g. glob support in <code>--wait</code> from v0.30.0, a sandbox-package publish-metadata fix from v0.29.0). chrome-use's own development sits on top of these and diverges heavily, so the two version lines aren't in lockstep.</p>
+      <p>chrome-use periodically merges in upstream <a href="https://github.com/vercel-labs/agent-browser">agent-browser</a> releases (<code>v0.27</code>–<code>v0.31</code>, e.g. glob support in <code>--wait</code> from v0.30.0, a sandbox-package publish-metadata fix from v0.29.0). chrome-use's own development sits on top of these and diverges heavily, so the two version lines aren't in lockstep.</p>
       <p>Earlier v0.x releases (v0.6.0 – v0.26.0, January–April 2026) inherit from the upstream agent-browser base; they're not worth listing individually here.</p>
 
       <hr class="du-divider" />

--- a/docs/en/compare.html
+++ b/docs/en/compare.html
@@ -287,7 +287,7 @@
         <strong>survives hard navigations</strong> — the multi-page flows that are exactly where ego wins and a page-world
         runtime breaks. Measured: crawl 3 HN pages collecting every ≥100-point story = <strong>one tool call</strong>
         (the old per-verb way needs 13+), on your <strong>already-logged-in real Chrome</strong> over the stealth transport,
-        <strong>cross-platform</strong> (ego is macOS-only).
+        <strong>cross-platform</strong> (ego is macOS-only). Full usage and both forms on <a href="/en/script.html">Single-pass Scripting</a>.
       </p>
 
       <h3>What we learned from ego-lite &amp; ported</h3>

--- a/docs/en/how-it-works.html
+++ b/docs/en/how-it-works.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>How It Works · chrome-use docs</title>
+  <meta name="description" content="One chrome-use command crosses four processes before it touches the page: the CLI, a per-session daemon, a relay Chrome launches for the extension, and the ab-connect extension. Each hop, its protocol, where state lives, and why an extension instead of a debug port." />
+
+  <meta name="theme-color" content="#fcfbf4" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="chrome-use docs" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=ZCOOL+KuaiLe&family=Permanent+Marker&family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="/assets/docs/docs.css" />
+</head>
+
+<body data-page="how-it-works" data-lang="en">
+
+  <div id="du-topbar"></div>
+
+  <div class="du-shell">
+
+    <nav id="du-sidebar"></nav>
+
+    <!-- ============================ PAGE CONTENT ============================ -->
+    <main class="du-main">
+
+      <span class="du-doodle" style="top:40px; right:8px; width:46px; height:46px;">
+        <svg viewBox="0 0 60 60" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="30" cy="30" r="10"/><path d="M30 4v8M30 48v8M4 30h8M48 30h8M11 11l6 6M43 43l6 6M49 11l-6 6M17 43l-6 6"/>
+        </svg>
+      </span>
+
+      <p class="du-eyebrow">Getting Started</p>
+
+      <div class="du-title-row">
+        <h1>How It Works</h1>
+        <button class="du-copy-page" type="button" aria-label="Copy page">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
+          <span class="du-copy-page-label">Copy page</span>
+        </button>
+      </div>
+
+      <p class="du-lede">
+        One chrome-use command leaves the terminal and crosses <span class="mark">four processes</span> before it touches a page: the CLI itself, a per-session daemon,
+        a relay process Chrome launches for the extension, and the ab-connect extension inside the browser. This page takes the chain apart: which process each hop lives in,
+        what protocol it speaks, and who holds the state. By the end you can explain what the <code>relay-cdp-url</code> file is, why an <code>@ref</code> goes stale,
+        and why it's an extension rather than a debug port.
+      </p>
+
+      <h2>The four hops of one command</h2>
+      <p>Take <code>chrome-use open https://example.com</code>. The full chain:</p>
+<pre><code>chrome-use open &lt;url&gt;                    the CLI, exits when done
+        │  one JSON request line, one JSON response line
+        │  Unix domain socket ~/.chrome-use/&lt;session&gt;.sock
+        ▼
+daemon                                   one per --session, stays resident
+holds the CDP connection, @ref map, script engine
+        │  standard CDP over WebSocket
+        │  ws://127.0.0.1:&lt;random port&gt;/&lt;random guid&gt;
+        ▼
+relay (chrome-use __nm-host)             a process Chrome launches for the extension
+answers Target.* discovery locally, forwards the rest
+        │  Chrome native messaging (stdio, 4-byte length prefix + JSON frame)
+        ▼
+ab-connect extension                     MV3, installed once
+        │  chrome.debugger, attached per tab
+        ▼
+your already-logged-in real Chrome tab</code></pre>
+      <p>
+        Every hop is a standard protocol, no private magic: CLI to daemon is a local socket, daemon to relay is plain CDP,
+        relay to extension is Chrome native messaging, extension to page is <code>chrome.debugger</code> (the same one DevTools uses).
+      </p>
+
+      <h2>The CLI is thin; state lives in the daemon</h2>
+      <p>
+        In CLI mode the <code>chrome-use</code> binary holds no browser state. It serializes the command to one JSON line, writes it to a Unix domain socket,
+        reads one JSON line back, prints it, and exits. The socket path is <code>~/.chrome-use/&lt;session&gt;.sock</code>
+        (with <code>XDG_RUNTIME_DIR</code> set it uses <code>$XDG_RUNTIME_DIR/chrome-use/</code>, see <code>get_daemon_socket_dir</code> in <code>cli/src/native/daemon.rs</code>).
+        Windows has no Unix sockets, so it uses a TCP port on 127.0.0.1 hashed from the session name.
+      </p>
+      <p>
+        The first command to a session finds no socket, so the CLI forks the daemon and retries. Beside the daemon sit a few sidecar files:
+        <code>&lt;session&gt;.pid</code>, <code>&lt;session&gt;.version</code>, <code>&lt;session&gt;.stream</code> (the real-time stream server's port).
+      </p>
+      <p>The daemon holds three things across commands:</p>
+      <ol>
+        <li>the CDP connection to the browser (<code>CdpClient</code>)</li>
+        <li>the @ref → DOM-node map (<code>RefMap</code>, see the snapshot section below)</li>
+        <li>the JS engine for <code>chrome-use script</code> (boa, pure Rust). It runs in the daemon, not the page, so script state survives a hard navigation — see <a href="/en/script.html">Single-pass Scripting</a>.</li>
+      </ol>
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ Why the daemon stays resident</div>
+        The CDP connection and @ref map are built once and reused, saving a reconnect and re-snapshot per command. This is also the base that lets
+        <code>batch</code> and <code>script</code> "run many steps in one round-trip." The daemon exits after ~10 minutes idle, cleaning up the tabs it opened.
+      </div>
+
+      <h2>The relay is a process Chrome launches</h2>
+      <p>The third hop is the confusing one: you don't start the relay — Chrome does.</p>
+      <p>
+        At install time, <code>chrome-use extension install</code> writes a manifest into Chrome's native-messaging host directory
+        (host name <code>com.leeguoo.chrome_use</code>, compatible with the old <code>com.agent_browser.connect</code>) that registers the chrome-use binary's path and the extension ids allowed to talk to it.
+        When the ab-connect extension calls <code>connectNative</code>, Chrome launches chrome-use in a hidden <code>__nm-host</code> mode (<code>run_nm_host</code> in <code>cli/src/connect.rs</code>),
+        and the two speak the native-messaging protocol over stdio: a 4-byte little-endian length prefix plus one JSON frame.
+      </p>
+      <p>This nm-host process does two things:</p>
+      <ol>
+        <li>binds a random port on 127.0.0.1, opens a WebSocket endpoint <code>ws://127.0.0.1:&lt;port&gt;/&lt;guid&gt;</code>, and writes the URL into <code>~/.chrome-use/relay-cdp-url</code> at mode 0600. The guid is unguessable and the file is readable only by the current user, so no other local process gets the entry point. The daemon reads this file and connects to it as if it were an ordinary Chrome CDP endpoint.</li>
+        <li>translates between the extension protocol and standard CDP, answering discovery commands like <code>Target.getTargets</code> locally instead of round-tripping to the extension every time (<code>cli/src/native/relay.rs</code>).</li>
+      </ol>
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ Debug anchors</div>
+        A missing <code>~/.chrome-use/relay-cdp-url</code> usually means the relay never came up (the extension didn't connect);
+        <code>stdin EOF</code> in <code>nm-host.log</code> usually means Chrome reclaimed the MV3 background worker. Details on <a href="/en/troubleshooting.html">Troubleshooting</a>.
+      </div>
+
+      <h2>The extension does one thing</h2>
+      <p>
+        ab-connect is an MV3 extension whose core job is to run CDP commands per tab via <code>chrome.debugger</code> and hand results back to the relay over native messaging.
+        Its permission footprint is 7 items, with no <code>&lt;all_urls&gt;</code>. Two properties that matter for fingerprinting:
+      </p>
+      <ol>
+        <li>it <strong>attaches only to the agent's own tabs</strong>. The page you're looking at is never attached, so you never see the "chrome-use has started debugging this browser" banner (since extension 0.5.5, it attaches only agent-owned tabs).</li>
+        <li>this path <strong>injects no JS patches</strong>. The page sees your real Chrome, real cookies, real fingerprint, so CreepJS reads 0% bot. The anti-detection isn't disguise; there's simply nothing to disguise (see <a href="/en/stealth.html">Stealth &amp; Anti-detection</a>).</li>
+      </ol>
+      <p>In other words, the extension is the only process in the chain that touches the page, and it touches it with the same protocol as DevTools.</p>
+
+      <h2>Why an extension, not --remote-debugging-port</h2>
+      <p>
+        The classic way to drive a real Chrome is <code>--remote-debugging-port=9222</code> and a direct CDP connection. Chrome 136 broke half of that:
+        every time a client connects, Chrome pops a blocking "Allow remote debugging?" dialog. One click per connection means no automation.
+        The port also has to be opened before Chrome starts, which asks the user to launch their daily browser a different way.
+      </p>
+      <p>
+        Native messaging avoids this because the trust runs the other way: an outside process doesn't knock on Chrome's port — Chrome launches and authenticates the host
+        by the extension id registered in the host manifest. You click "Add to Chrome" once, then zero confirmations forever. Local safety rests on two things:
+        only extensions listed in the manifest can start the host; and the relay's WebSocket URL carries an unguessable guid written to a 0600 file.
+      </p>
+
+      <h2>Two modes</h2>
+      <p>The four-hop chain above is the default mode: connect to your real, logged-in Chrome. There's a second path, <code>--launch</code>:</p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code><span class="du-cmt"># default: extension relay, your real Chrome</span>
+$ chrome-use open https://example.com
+<span class="du-cmt"># launch a separate isolated stealth Chromium</span>
+$ chrome-use --launch open https://example.com</code></pre>
+      </div>
+      <div class="cmp-scroll" style="overflow-x:auto; margin:14px 0;">
+      <table>
+        <thead><tr><th></th><th>extension relay (default)</th><th><code>--launch</code></th></tr></thead>
+        <tbody>
+          <tr><th>browser</th><td>the Chrome you're already using</td><td>a separate Chromium the daemon launches</td></tr>
+          <tr><th>logins</th><td>all already there</td><td>an empty temp profile (<code>--profile</code> for a persistent one)</td></tr>
+          <tr><th>chain</th><td>daemon → relay → extension → chrome.debugger</td><td>daemon connects CDP directly, no relay or extension</td></tr>
+          <tr><th>anti-detection</th><td>not needed: it's a real browser, zero injection</td><td>native overrides (UA, timezone, webdriver, etc., see <code>stealth.rs</code>), no JS patches</td></tr>
+          <tr><th>fits</th><td>need logins, need to beat anti-bot, user takes over anytime</td><td>clean-environment testing, parallel one-off tasks</td></tr>
+        </tbody>
+      </table>
+      </div>
+      <p>Both modes share the same daemon architecture and the same commands; the only difference is who the daemon connects to.</p>
+
+      <h2>One colored tab group per --session</h2>
+      <p>When several agents share one real Chrome, isolation is by tab group:</p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code>$ chrome-use --session research open https://a.com   <span class="du-cmt"># research group</span>
+$ chrome-use --session shopping open https://b.com   <span class="du-cmt"># shopping group, mutually invisible</span></code></pre>
+      </div>
+      <p>
+        When the daemon starts it records the session name in <code>DAEMON_SESSION</code>, and every tab it opens lands in that session's own colored Chrome tab group.
+        Isolation is enforced at the relay layer (<code>client_groups</code> in <code>relay.rs</code>): after connecting, the daemon declares its group, and from then on its
+        <code>Target.getTargets</code> returns only tabs in that group. It can't see your tabs or other agents' tabs, so it can't click them either.
+      </p>
+      <p>
+        Ownership rules cover the details: a new tab is tagged with its creator's group; a pop-up inherits the opener's group, so cross-process jumps (an OAuth pop-up) don't get lost;
+        <code>chrome-use adopt</code> is the only cross-group channel — after adoption that one tab is re-tagged into the adopter's group, the rest stay invisible. Session details on <a href="/en/sessions.html">Sessions &amp; Persistence</a>.
+      </p>
+
+      <h2>Where snapshot and @ref come from</h2>
+      <p>
+        The text tree that <code>chrome-use snapshot -i</code> prints isn't HTML — it's the accessibility tree. The daemon pulls the full AX tree via CDP's
+        <code>Accessibility.getFullAXTree</code> (<code>cli/src/native/snapshot.rs</code>), filters for interactive roles like button, link, textbox, and renders indented text:
+      </p>
+<pre><code>button "Submit" [ref=e12]
+textbox "Email" [ref=e13]</code></pre>
+      <p>
+        Each <code>[ref=eN]</code> is a number the daemon assigns while building the snapshot, backed by the <code>RefMap</code> (<code>cli/src/native/element.rs</code>):
+        a ref maps to CDP's <code>backend_node_id</code>, the stable handle for that DOM node in the browser process. On <code>chrome-use click @e12</code>,
+        the daemon looks up the node id and acts on the node directly — no CSS selector, no coordinates. Two usage rules follow:
+      </p>
+      <ol>
+        <li>a ref is daemon memory state. After the daemon restarts (e.g. an idle exit) all old refs are void; just <code>snapshot</code> again.</li>
+        <li>after a big page change a ref may point at a node that's gone. The <code>RefMap</code> stores each ref's role, name, and other fingerprints, and <code>--heal</code> relocates the ref to the closest node. Locating details on <a href="/en/finding.html">Finding Elements</a>.</li>
+      </ol>
+
+      <h2>Lineage</h2>
+      <p>
+        chrome-use is originally based on vercel-labs/agent-browser (Apache-2.0). The CLI skeleton and some command semantics come from upstream, but the stealth and
+        extension-relay architecture, anti-detection, humanize, multi-agent isolation, and the whole nm-host chain on this page grew here. It's a standalone project now.
+        The full fork story is on <a href="/en/lineage.html">Lineage &amp; Upstream</a>.
+      </p>
+      <div class="du-callout tip">
+        <div class="du-callout-title">🔧 See it yourself</div>
+        <code>AGENT_BROWSER_DEBUG=1</code> makes the daemon log to <code>~/.chrome-use/&lt;session&gt;.log</code>;
+        <code>cat ~/.chrome-use/relay-cdp-url</code> shows the relay's live endpoint; <code>chrome-use doctor</code> reports the health of every hop.
+        Troubleshooting on <a href="/en/troubleshooting.html">Troubleshooting</a>, extension install on <a href="/en/real-chrome.html">Real Chrome</a>, anti-detection data on <a href="/en/stealth.html">Stealth &amp; Anti-detection</a>.
+      </div>
+
+    </main>
+    <!-- ========================== /PAGE CONTENT =========================== -->
+
+    <aside id="du-toc"></aside>
+
+  </div>
+
+  <script src="/assets/docs/docs.js" defer></script>
+</body>
+</html>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -231,6 +231,9 @@
         Apache-2.0 · <a href="https://github.com/leeguooooo/chrome-use" target="_blank" rel="noopener">GitHub</a>
         · part of the <a href="https://leeguoo.com" target="_blank" rel="noopener">leeguoo.com</a> *-use family.
       </p>
+      <p class="du-small" style="margin-top:6px; color:var(--ink-faint); font-size:.85rem;">
+        Originally based on <a href="https://github.com/vercel-labs/agent-browser" target="_blank" rel="noopener">vercel-labs/agent-browser</a> (Apache-2.0), now standalone · <a href="/en/lineage.html">Lineage &amp; Upstream</a>
+      </p>
 
     </main>
 

--- a/docs/en/lineage.html
+++ b/docs/en/lineage.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>Lineage &amp; Upstream · chrome-use docs</title>
+  <meta name="description" content="chrome-use started as a fork of vercel-labs/agent-browser (Apache-2.0) and is now a standalone project. Who the upstream is, what diverged after the fork, how to think about the relationship, version pinning, and Apache-2.0 obligations." />
+
+  <meta name="theme-color" content="#fcfbf4" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="chrome-use docs" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=ZCOOL+KuaiLe&family=Permanent+Marker&family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="/assets/docs/docs.css" />
+</head>
+
+<body data-page="lineage" data-lang="en">
+
+  <div id="du-topbar"></div>
+
+  <div class="du-shell">
+
+    <nav id="du-sidebar"></nav>
+
+    <!-- ============================ PAGE CONTENT ============================ -->
+    <main class="du-main">
+
+      <span class="du-doodle" style="top:40px; right:8px; width:46px; height:46px;">
+        <svg viewBox="0 0 60 60" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M30 54V30M30 30C30 20 22 16 14 14M30 30c0-8 8-12 16-14M30 22c0-6 4-10 10-12"/>
+        </svg>
+      </span>
+
+      <p class="du-eyebrow">Reference</p>
+
+      <div class="du-title-row">
+        <h1>Lineage &amp; Upstream</h1>
+        <button class="du-copy-page" type="button" aria-label="Copy page">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
+          <span class="du-copy-page-label">Copy page</span>
+        </button>
+      </div>
+
+      <p class="du-lede">
+        chrome-use started from <a href="https://github.com/vercel-labs/agent-browser" target="_blank" rel="noopener">vercel-labs/agent-browser</a> (Apache-2.0)
+        and is now a standalone project. This page covers who the upstream is, what path each took after the fork, and how to think about the relationship:
+        it's <span class="mark">not a variant of upstream</span> — it's a different product, built to drive your already-logged-in real Chrome.
+      </p>
+
+      <h2>Upstream: vercel-labs/agent-browser</h2>
+      <p>
+        chrome-use's first line of code came from Vercel Labs' agent-browser: a Rust browser-automation CLI for AI agents.
+        The daemon model, the snapshot-plus-<code>@ref</code> interaction paradigm, and the overall Rust CLI skeleton are inherited from it.
+        There'd be no chrome-use without that upstream, and the credit belongs here.
+      </p>
+      <p>The lineage is still visible in the repo:</p>
+      <ul>
+        <li><code>git remote</code>'s <code>upstream</code> still points at <code>vercel-labs/agent-browser</code>;</li>
+        <li>the environment-variable prefix is still <code>AGENT_BROWSER_*</code>;</li>
+        <li>the <code>abs</code> command alias comes from the old repo name agent-browser-stealth;</li>
+        <li>early Release tags carried a <code>-fork.N</code> suffix (like <code>v0.27.0-fork.12</code>); current tags are an independent <code>v1.x.y</code> series.</li>
+      </ul>
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ From the README</div>
+        “Originally based on vercel-labs/agent-browser (Apache-2.0); now a standalone project — the stealth/extension-relay
+        architecture, anti-detection, humanize, multi-agent isolation, and CLI have diverged substantially.”
+      </div>
+
+      <h2>What changed after the fork</h2>
+      <p>
+        The core divergence is the connection method. Upstream's classic path launches a browser instance for the agent; chrome-use's default path takes over the real Chrome
+        where you're already logged into everything, and the whole chain was rebuilt for that:
+      </p>
+      <p>
+        <strong>Extension-relay architecture.</strong> The CLI talks to a per-session background daemon over a Unix domain socket; the daemon connects to the ab-connect browser
+        extension over Chrome native messaging; the extension drives target tabs with CDP via <code>chrome.debugger</code>. No <code>--remote-debugging-port</code> anywhere,
+        so it never trips the "Allow remote debugging?" dialog Chrome 136+ pops on every connection. Install is one <code>curl … | sh</code> plus a one-time extension install.
+        The full pipeline is on <a href="/en/how-it-works.html">How It Works</a>.
+      </p>
+      <p>
+        <strong>Anti-detection.</strong> On the extension path to real Chrome, nothing is JS-injected — it is your real browser, and CreepJS reads 0% bot.
+        The <code>--launch</code> path opens a separate stealth Chromium disguised with native CDP- and flag-level overrides, not leak-prone JS patches.
+        See <a href="/en/stealth.html">Stealth &amp; Anti-detection</a> and <a href="/en/real-chrome.html">Real Chrome</a>.
+      </p>
+      <p>
+        <strong>Also brought in:</strong> <code>--humanize</code> behavioral evasion, multi-agent isolation via per-session colored tab groups,
+        <code>session handoff</code> ownership and human takeover, <a href="/en/script.html">single-pass scripting</a>, and a whole command surface built around real Chrome.
+      </p>
+
+      <h2>Not a drop-in replacement</h2>
+      <p>
+        The two projects answer different questions. Upstream gives the agent a clean browser; chrome-use lets the agent use the browser you're already logged into,
+        sharing your sessions, so sites read it as a real person. So don't treat chrome-use as a re-skin of upstream: the command surface, connection method, and default
+        behavior have evolved apart, and this site documents chrome-use only — it can't be applied back to agent-browser.
+      </p>
+      <ul>
+        <li>Need an isolated, brand-new browser instance for the agent and don't care about logins → upstream agent-browser is the clean choice.</li>
+        <li>Need to reuse real logins, dodge anti-bot prompts, run several agents concurrently in one Chrome → that's what chrome-use is for.</li>
+      </ul>
+      <p>The two ship independently and promise no compatibility. Item-by-item comparison on <a href="/en/compare.html">how chrome-use compares</a>.</p>
+
+      <h2>Pinning a version</h2>
+      <p>
+        The default install pulls the latest GitHub Release. For production or CI, pin a specific tag with <code>AGENT_BROWSER_VERSION</code>
+        (the variable name is itself part of the lineage):
+      </p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code><span class="du-cmt"># latest</span>
+$ curl -fsSL https://raw.githubusercontent.com/leeguooooo/chrome-use/main/install.sh | sh
+
+<span class="du-cmt"># pin a version</span>
+$ AGENT_BROWSER_VERSION=v1.5.70 \
+    curl -fsSL https://raw.githubusercontent.com/leeguooooo/chrome-use/main/install.sh | sh</code></pre>
+      </div>
+      <div class="du-callout tip">
+        <div class="du-callout-title">💡 Old tags</div>
+        <code>v0.27.0-fork.12</code>-style tags with a <code>-fork.N</code> suffix in old docs or scripts belong to the early fork series;
+        the same variable pins them too. New projects should just use <code>v1.x.y</code>.
+      </div>
+
+      <h2>License</h2>
+      <p>Upstream agent-browser is Apache-2.0, and chrome-use ships under Apache-2.0 as well; the full text is in <code>LICENSE</code> at the repo root.</p>
+      <p>
+        Apache-2.0 permits free use, modification, and distribution (commercial included), on the condition that you keep the copyright and license notices.
+        chrome-use credits upstream in the README. If you redistribute based on chrome-use, keep the <code>LICENSE</code> and carry forward the attribution chain to vercel-labs/agent-browser.
+      </p>
+
+      <hr class="du-divider" />
+
+      <div class="du-cards">
+        <a class="du-card" href="/en/how-it-works.html">
+          <div class="du-card-title"><span class="du-card-ico">⚙️</span> How It Works</div>
+          <p>The extension-relay chain rebuilt after the fork, hop by hop.</p>
+        </a>
+        <a class="du-card" href="/en/compare.html">
+          <div class="du-card-title"><span class="du-card-ico">⚖️</span> How chrome-use compares</div>
+          <p>chrome-use vs agent-browser, ego-lite, Playwright and more, measured.</p>
+        </a>
+        <a class="du-card" href="https://github.com/vercel-labs/agent-browser" target="_blank" rel="noopener">
+          <div class="du-card-title"><span class="du-card-ico">🌱</span> Upstream repo</div>
+          <p>vercel-labs/agent-browser (Apache-2.0).</p>
+        </a>
+      </div>
+
+    </main>
+    <!-- ========================== /PAGE CONTENT =========================== -->
+
+    <aside id="du-toc"></aside>
+
+  </div>
+
+  <script src="/assets/docs/docs.js" defer></script>
+</body>
+</html>

--- a/docs/en/script.html
+++ b/docs/en/script.html
@@ -1,0 +1,221 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>Single-pass Scripting · chrome-use docs</title>
+  <meta name="description" content="chrome-use script runs a whole observe→decide→act→verify flow in one round-trip over the daemon, returning structured results in one tool call. JSON op-list (value bus + loops + asserts) or synchronous JS (cu.* helpers); the engine runs in the daemon, so it survives hard navigations." />
+
+  <meta name="theme-color" content="#fcfbf4" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="chrome-use docs" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=ZCOOL+KuaiLe&family=Permanent+Marker&family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="/assets/docs/docs.css" />
+</head>
+
+<body data-page="script" data-lang="en">
+
+  <div id="du-topbar"></div>
+
+  <div class="du-shell">
+
+    <nav id="du-sidebar"></nav>
+
+    <!-- ============================ PAGE CONTENT ============================ -->
+    <main class="du-main">
+
+      <span class="du-doodle" style="top:40px; right:8px; width:46px; height:46px;">
+        <svg viewBox="0 0 60 60" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M32 6 L14 34 h14 l-4 20 20-30 h-14 z"/>
+        </svg>
+      </span>
+
+      <p class="du-eyebrow">Advanced</p>
+
+      <div class="du-title-row">
+        <h1>Single-pass Scripting</h1>
+        <button class="du-copy-page" type="button" aria-label="Copy page">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
+          <span class="du-copy-page-label">Copy page</span>
+        </button>
+      </div>
+
+      <p class="du-lede">
+        When you drive the browser one verb at a time, the model is stuck in the loop: every step means read the result, decide the next move, send another command.
+        <code>chrome-use script</code> hands the whole <span class="mark">observe / decide / act / verify</span> flow to the daemon at once,
+        so the decision logic runs next to the browser and you get structured results back in one tool call. Two forms:
+        a <strong>JSON op-list</strong> (machine-generatable, dry-runnable) and a real <strong>synchronous JS</strong> program (<code>cu.*</code> helpers).
+        Measured: crawling 3 HN pages for high-score stories drops from 13+ calls to one.
+      </p>
+
+      <h2>How expensive the per-verb loop is</h2>
+      <p>
+        chrome-use is one-command-one-action by default: <code>snapshot</code> to see the page, <code>click @e8</code> to press a button,
+        <code>eval</code> to read data. Each command is a full round-trip: process spawn, Unix socket to the daemon, extension relay to the browser,
+        result back the same way, then the agent's model reads the output and decides the next step. Fine for a single step; the cost shows up in multi-step flows:
+        pagination, conditional retries, using a prior result to pick the next action. The model is forced to stay in the loop, <strong>one inference and one tool call per step</strong>.
+      </p>
+      <p>
+        A fixed sequence of actions already runs in one round-trip with <code>batch</code> (<code>press --hold</code> and <code>wait</code> block inside the daemon, so timing is precise),
+        but batch steps can't pass values between them, and there are no loops or conditions. <code>script</code> is the layer that adds them.
+      </p>
+      <div class="du-callout note">
+        <div class="du-callout-title">🪜 Four-rung ladder</div>
+        single verb (one step, one round-trip) → <code>batch</code> (fixed sequence, one round-trip) → <code>script</code> (values between steps +
+        loops + conditions + asserts, one round-trip) → <code>stream</code> WebSocket (continuous real-time driving). Each rung down expresses more logic
+        with fewer round-trips and tool calls; pick the lowest one that's enough.
+      </div>
+
+      <h2>JSON op-list form</h2>
+      <p>
+        The first form is a JSON array of statements — good for a model to emit directly and for a program to assemble.
+        A later op reads an earlier op's result through the <code>{{name.path}}</code> value bus:
+      </p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code>chrome-use script - &lt;&lt;'JSON'
+[
+  {"do":"navigate","url":"https://example.com"},
+  {"do":"evaluate","script":"document.title","bind":"t"},
+  {"assert":{"contains":["{{t.result}}","Example"]},"msg":"wrong page"},
+  {"return":"{{t.result}}"}
+]
+JSON</code></pre>
+      </div>
+      <p>There are eight statements (<code>cli/src/native/script.rs</code>):</p>
+<pre><code>{ "do": "&lt;action&gt;", ...params, "bind"?: "name", "optional"?: bool }   // run a command, store its result
+{ "waitUntil": &lt;cond&gt;, "timeoutMs"?: n, "pollMs"?: n }                 // poll until a condition holds
+{ "forEach": "{{list}}", "as"?: "item", "max": n, "body": [ ... ] }   // loop (max is required, a hard cap)
+{ "assert": &lt;cond&gt;, "msg"?: "..." }                                   // assert, stop on failure (exit 1)
+{ "set": "name", "value": &lt;v|"{{expr}}"&gt; }                            // assign
+{ "push": "name", "value": &lt;v|"{{expr}}"&gt; }                           // append to an array
+{ "return": &lt;v|"{{expr}}"&gt; }                                          // return and end
+{ "log": &lt;v|"...{{expr}}..."&gt; }                                       // record a progress line</code></pre>
+      <p>
+        Conditions (<code>&lt;cond&gt;</code>): <code>{"eq":[a,b]}</code>, <code>{"ne"}</code>, <code>{"contains"}</code>,
+        <code>{"matches":[a,rx]}</code>, <code>{"exists":"&lt;selector&gt;"}</code>, <code>{"gone"}</code>.
+        The <code>{{expr}}</code> value bus: a string that is exactly <code>{{x}}</code> yields the value at its real type (a number stays a number);
+        embedded <code>...{{x}}...</code> does string interpolation; paths take indices, e.g. <code>rows.0.ref</code>, <code>rows[0].url</code>.
+      </p>
+      <div class="du-callout tip">
+        <div class="du-callout-title">💡 Tip</div>
+        <code>evaluate</code>'s return value is wrapped under <code>.result</code>, so reference a page value as <code>{{t.result}}</code>, not <code>{{t}}</code>.
+        <code>--dry-run</code> validates the program's shape without touching the browser; <code>--arg k=v</code> seeds a variable. Exit codes: 0 ok, 1 runtime failure or failed assert, 2 invalid program.
+      </div>
+
+      <h2>JS program form</h2>
+      <p>
+        The second form is a real JavaScript program that drives your already-logged-in Chrome through <code>cu.*</code> helpers.
+        This is ego-lite's "code base" idiom; control flow is just JS's own <code>for</code> / <code>if</code> / <code>break</code>.
+        <strong>No <code>await</code></strong>: every <code>cu.*</code> call blocks until the browser returns, so the script is synchronous.
+      </p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code>chrome-use script --timeout 120000 &lt;&lt;'JS'
+  cu.open('https://news.ycombinator.com');
+  const out = [];
+  for (let page = 0; page &lt; 3; page++) {
+    const rows = cu.eval("[...document.querySelectorAll('.athing')].map(r=&gt;({id:r.id,title:r.querySelector('.titleline a')?.innerText}))");
+    for (const r of rows) {
+      const pts = cu.eval(`+(document.querySelector('#score_${r.id}')?.innerText.match(/\\d+/)?.[0] ?? 0)`);
+      if (pts &gt;= 100) out.push({ title: r.title, points: pts });
+    }
+    if (!cu.visible('a.morelink')) break;
+    cu.click('a.morelink');       // full-page navigation, script state kept
+    cu.waitFor('.athing', 8000);
+  }
+  return { count: out.length, top: out.slice(0, 5) };
+JS</code></pre>
+      </div>
+      <p>
+        The helpers: <code>cu.snapshot</code> / <code>cu.eval</code> / <code>cu.open</code> / <code>cu.click</code> /
+        <code>cu.fill</code> / <code>cu.type</code> / <code>cu.press</code> / <code>cu.hover</code> / <code>cu.select</code> /
+        <code>cu.check</code> / <code>cu.scroll</code> / <code>cu.find</code> / <code>cu.visible</code> / <code>cu.waitFor</code> /
+        <code>cu.wait</code> / <code>cu.extract</code> / <code>cu.text</code> / <code>cu.log</code>. <code>cu.eval</code> returns the page value directly;
+        the rest throw on failure so the script fails fast. The program's return value is the command's result; <code>cu.log(...)</code> collects progress lines.
+      </p>
+
+      <h2>The engine runs in the daemon</h2>
+      <p>ego can also write one JS program that runs a whole task; where chrome-use script pulls ahead is <strong>where the engine lives</strong>.</p>
+      <p>
+        <strong>It survives hard navigations.</strong> A runtime injected into the page world dies the moment the page navigates — the whole execution context is gone, and multi-page flows die exactly at the page turn.
+        chrome-use's JS engine runs in the daemon, outside the page: in the example above <code>cu.click('a.morelink')</code> triggers a full navigation, the script state
+        (the <code>out</code> array, the loop counter) stays put, and <code>cu.waitFor</code> confirms the new page loaded before continuing.
+      </p>
+      <p>
+        <strong>Pure-Rust engine, every platform.</strong> The JS engine is boa, a pure-Rust implementation compiled into the chrome-use binary itself — no Node, no system V8.
+        macOS / Linux / Windows all run it; ego is macOS-only.
+      </p>
+      <p>
+        <strong>Every op goes through the same front door.</strong> Each step of a script (both forms) re-enters the daemon's <code>execute_command</code>,
+        the identical path a hand-typed single command takes: policy checks, the stealth transport, <code>--humanize</code>, <code>@ref</code> healing, cross-process session recovery.
+        Nothing is reimplemented, so behavior inside a script matches the command line exactly. The full pipeline is on <a href="/en/how-it-works.html">How It Works</a>.
+      </p>
+
+      <h2>Measured: 3 HN pages</h2>
+      <p>
+        Benchmark task: paginate 3 pages of Hacker News, collect every story with ≥100 points, output JSON. The JS program above is the complete solution,
+        verified on real Chrome (3 pages, 34 stories, ~4.8s).
+      </p>
+      <div class="cmp-scroll" style="overflow-x:auto; margin:14px 0;">
+      <table>
+        <thead><tr><th></th><th>per-verb</th><th>chrome-use script</th></tr></thead>
+        <tbody>
+          <tr><th>tool calls</th><td>13+</td><td><strong>1</strong></td></tr>
+          <tr><th>model inferences</th><td>one per step; every page turn and per-story score check goes back to the model</td><td>2: write the program + read the result</td></tr>
+          <tr><th>intermediate output</th><td>every snapshot / eval result enters the context</td><td>only the final <code>return</code> JSON</td></tr>
+          <tr><th>pagination (hard nav)</th><td>fine (each step is independent)</td><td>fine, engine is in the daemon</td></tr>
+        </tbody>
+      </table>
+      </div>
+      <p>
+        The "≥100 points" decision is one <code>if</code> in the script; the old way carries every story's score back to the model to judge.
+        The more steps and the denser the decisions, the wider the gap. Full landscape and the item-by-item ego-lite measurements are on <a href="/en/compare.html">how chrome-use compares</a>.
+      </p>
+
+      <h2>Which layer to use</h2>
+      <p>script doesn't replace single commands; it's the layer above for multi-step flows. How to choose:</p>
+      <ul>
+        <li><strong>One or two steps</strong>: a single verb, closed with <a href="/en/waiting.html"><code>expect</code></a> or <code>--observe</code>.</li>
+        <li><strong>Fixed sequence, no values passed between steps</strong>: <code>batch</code> — precise timing, minimal overhead.</li>
+        <li><strong>Need a prior result, a loop or condition, an assert to bail mid-way</strong>: <code>script</code>. Let the model emit the JSON form (dry-runnable); hand-write or complex logic → the JS form.</li>
+        <li><strong>Continuous real-time driving</strong> (games, frame-by-frame): the <code>stream</code> WebSocket, see <a href="/en/canvas.html">Canvas / WebGL</a>.</li>
+      </ul>
+      <div class="du-callout tip">
+        <div class="du-callout-title">✅ Start here</div>
+        For pure data-scraping, look at <a href="/en/extract.html"><code>extract --schema</code></a> first (one call structures the page into JSON);
+        to accumulate across pages or filter conditionally, wrap extract in a <code>script</code> loop.
+      </div>
+
+      <hr class="du-divider" />
+
+      <div class="du-cards">
+        <a class="du-card" href="/en/how-it-works.html">
+          <div class="du-card-title"><span class="du-card-ico">⚙️</span> How It Works</div>
+          <p>Daemon, relay, and where the boa engine runs — the reason script survives hard navigations is in this pipeline.</p>
+        </a>
+        <a class="du-card" href="/en/compare.html">
+          <div class="du-card-title"><span class="du-card-ico">⚖️</span> How chrome-use compares</div>
+          <p>chrome-use script vs ego-lite's code-base idiom, measured item by item.</p>
+        </a>
+        <a class="du-card" href="/en/waiting.html">
+          <div class="du-card-title"><span class="du-card-ico">⏳</span> Waiting &amp; Asserting</div>
+          <p><code>expect</code> / <code>--observe</code>: the single-command verification that maps to <code>assert</code> / <code>waitUntil</code> in a script.</p>
+        </a>
+      </div>
+
+    </main>
+    <!-- ========================== /PAGE CONTENT =========================== -->
+
+    <aside id="du-toc"></aside>
+
+  </div>
+
+  <script src="/assets/docs/docs.js" defer></script>
+</body>
+</html>

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>它怎么工作 · chrome-use 文档</title>
+  <meta name="description" content="一条 chrome-use 命令从终端到页面要经过四个进程：CLI、每会话一个的守护进程、Chrome 拉起的中继、ab-connect 扩展。拆开讲每一站在哪个进程、说什么协议、状态放在谁手上，以及为什么装扩展而不是开调试端口。" />
+
+  <meta name="theme-color" content="#fcfbf4" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="chrome-use 文档" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=ZCOOL+KuaiLe&family=Permanent+Marker&family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="/assets/docs/docs.css" />
+</head>
+
+<body data-page="how-it-works" data-lang="zh">
+
+  <div id="du-topbar"></div>
+
+  <div class="du-shell">
+
+    <nav id="du-sidebar"></nav>
+
+    <!-- ============================ PAGE CONTENT ============================ -->
+    <main class="du-main">
+
+      <span class="du-doodle" style="top:40px; right:8px; width:46px; height:46px;">
+        <svg viewBox="0 0 60 60" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="30" cy="30" r="10"/><path d="M30 4v8M30 48v8M4 30h8M48 30h8M11 11l6 6M43 43l6 6M49 11l-6 6M17 43l-6 6"/>
+        </svg>
+      </span>
+
+      <p class="du-eyebrow">开始 / Getting Started</p>
+
+      <div class="du-title-row">
+        <h1>它怎么工作</h1>
+        <button class="du-copy-page" type="button" aria-label="复制页面">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
+          <span class="du-copy-page-label">复制页面</span>
+        </button>
+      </div>
+
+      <p class="du-lede">
+        一条 chrome-use 命令从终端出发，要经过<span class="mark">四个进程</span>才碰到页面：CLI 本身、每个会话一个的守护进程、
+        Chrome 为扩展拉起的中继进程、浏览器里的 ab-connect 扩展。这一页把整条链路拆开：每一站在哪个进程里、说什么协议、
+        状态放在谁手上。读完你就能解释 <code>relay-cdp-url</code> 是什么文件、<code>@ref</code> 为什么会失效、
+        以及为什么装一个扩展而不是开调试端口。
+      </p>
+
+      <h2>一条命令走过的四站</h2>
+      <p>以 <code>chrome-use open https://example.com</code> 为例，完整链路是：</p>
+<pre><code>chrome-use open &lt;url&gt;                    CLI，执行完即退出
+        │  一行 JSON 请求，一行 JSON 响应
+        │  Unix 域套接字 ~/.chrome-use/&lt;session&gt;.sock
+        ▼
+守护进程 (daemon)                         每个 --session 一个，常驻后台
+持有 CDP 连接、@ref 映射、脚本引擎
+        │  标准 CDP over WebSocket
+        │  ws://127.0.0.1:&lt;随机端口&gt;/&lt;随机 guid&gt;
+        ▼
+中继 (chrome-use __nm-host)               Chrome 为扩展拉起的进程
+本地应答 Target.* 发现命令，其余转发
+        │  Chrome 原生消息 (stdio，4 字节长度前缀 + JSON 帧)
+        ▼
+ab-connect 扩展                           MV3，装一次
+        │  chrome.debugger，按标签页附加
+        ▼
+你已登录的真实 Chrome 标签页</code></pre>
+      <p>
+        每一段都是标准协议，没有私有魔法：CLI 到守护进程是本机套接字，守护进程到中继是普通 CDP，
+        中继到扩展是 Chrome 原生消息，扩展到页面是 <code>chrome.debugger</code>（和 DevTools 同一套）。
+      </p>
+
+      <h2>CLI 很薄，状态都在守护进程里</h2>
+      <p>
+        <code>chrome-use</code> 这个二进制在 CLI 模式下不持有任何浏览器状态。它把命令序列化成一行 JSON，
+        写进 Unix 域套接字，读回一行 JSON，打印，退出。套接字路径是 <code>~/.chrome-use/&lt;session&gt;.sock</code>
+        （有 <code>XDG_RUNTIME_DIR</code> 时用 <code>$XDG_RUNTIME_DIR/chrome-use/</code>，见 <code>cli/src/native/daemon.rs</code>
+        的 <code>get_daemon_socket_dir</code>）。Windows 没有 Unix 套接字，改用 127.0.0.1 上按会话名哈希出的 TCP 端口。
+      </p>
+      <p>
+        第一次对某个会话发命令时，CLI 发现套接字不存在，就先 fork 出守护进程再重试。守护进程旁边还有几个
+        sidecar 文件：<code>&lt;session&gt;.pid</code>、<code>&lt;session&gt;.version</code>、<code>&lt;session&gt;.stream</code>（实时流服务的端口）。
+      </p>
+      <p>守护进程持有三样跨命令的东西：</p>
+      <ol>
+        <li>到浏览器的 CDP 连接（<code>CdpClient</code>）</li>
+        <li>@ref 到 DOM 节点的映射表（<code>RefMap</code>，见下文 snapshot 一节）</li>
+        <li><code>chrome-use script</code> 的 JS 引擎（boa，纯 Rust）。引擎跑在守护进程里而不是页面里，所以页面硬跳转时脚本状态不丢，详见 <a href="/script.html">单次成型脚本</a>。</li>
+      </ol>
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ 为什么守护进程常驻</div>
+        CDP 连接和 @ref 映射建立一次就复用，省掉每条命令重新连、重新快照的开销。这也是 <code>batch</code>
+        和 <code>script</code> 能「一次往返跑完多步」的底座。守护进程闲置约 10 分钟自动退出，清掉它开的临时标签。
+      </div>
+
+      <h2>中继进程是 Chrome 自己拉起来的</h2>
+      <p>第三站最容易让人迷糊：中继不是你启动的，是 Chrome 启动的。</p>
+      <p>
+        装扩展时，<code>chrome-use extension install</code> 往 Chrome 的原生消息宿主目录写一份 manifest
+        （宿主名 <code>com.leeguoo.chrome_use</code>，兼容旧名 <code>com.agent_browser.connect</code>），里面登记了
+        chrome-use 二进制的路径和允许对话的扩展 id。之后 ab-connect 扩展一调用 <code>connectNative</code>，
+        Chrome 就以隐藏的 <code>__nm-host</code> 模式拉起 chrome-use（<code>cli/src/connect.rs</code> 的 <code>run_nm_host</code>），
+        两边用 stdio 说原生消息协议：4 字节小端长度前缀加一个 JSON 帧。
+      </p>
+      <p>这个 nm-host 进程做两件事：</p>
+      <ol>
+        <li>在 127.0.0.1 上随机绑一个端口，开一个 WebSocket 端点 <code>ws://127.0.0.1:&lt;port&gt;/&lt;guid&gt;</code>，把 URL 写进 <code>~/.chrome-use/relay-cdp-url</code>，文件权限 0600。guid 不可猜、文件只有当前用户可读，所以本机其他进程拿不到入口。守护进程读这个文件，把它当成一个普通 Chrome 的 CDP 端点去连。</li>
+        <li>在扩展协议和标准 CDP 之间做翻译，并本地应答 <code>Target.getTargets</code> 这类发现命令，避免每次都往扩展绕一圈（<code>cli/src/native/relay.rs</code>）。</li>
+      </ol>
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ 排障锚点</div>
+        <code>~/.chrome-use/relay-cdp-url</code> 不存在，多半是中继没起来（扩展没连上）；
+        <code>nm-host.log</code> 里 <code>stdin EOF</code> 一般是 MV3 后台 worker 被 Chrome 回收了。
+        细节见 <a href="/troubleshooting.html">故障排查</a>。
+      </div>
+
+      <h2>扩展端只做一件事</h2>
+      <p>
+        ab-connect 是个 MV3 扩展，核心就是拿 <code>chrome.debugger</code> 按标签页执行 CDP 命令，把结果通过原生消息交回中继。
+        权限足迹是 7 项，没有 <code>&lt;all_urls&gt;</code>。两条对指纹重要的性质：
+      </p>
+      <ol>
+        <li>它<strong>只附加 agent 自己的标签</strong>。你正在看的页面不会被 attach，也就不会出现「chrome-use 已开始调试此浏览器」的横幅（扩展 0.5.5 起，只 attach agent 拥有的标签）。</li>
+        <li>这条路径<strong>不注入任何 JS 补丁</strong>。页面看到的就是你真实的 Chrome、真实的 cookie、真实的指纹，所以 CreepJS 测出来是 0% bot。反检测靠的不是伪装，是根本没有东西需要伪装（见 <a href="/stealth.html">反检测与隐身</a>）。</li>
+      </ol>
+      <p>换句话说，扩展是整条链路里唯一碰得到页面的进程，而它碰页面的方式和 DevTools 是同一套协议。</p>
+
+      <h2>为什么装扩展，而不是开 --remote-debugging-port</h2>
+      <p>
+        驱动真实 Chrome 的传统做法是加 <code>--remote-debugging-port=9222</code> 然后直连 CDP。这条路从 Chrome 136 起废了一半：
+        每次有客户端连上来，Chrome 都弹一个阻塞式的「Allow remote debugging?」确认框。agent 每连一次你点一次，自动化无从谈起。
+        而且端口要在启动 Chrome 前就开好，等于要求用户换一种方式启动日常浏览器。
+      </p>
+      <p>
+        原生消息没有这个问题，因为信任关系是反过来的：不是外部进程去敲 Chrome 的端口，而是 Chrome 根据宿主 manifest 里
+        登记的扩展 id，主动拉起并认证这个宿主。装扩展点一次「添加至 Chrome」，之后每次使用零确认。本机安全性由两层兜住：
+        只有 manifest 里登记的扩展能启动宿主；中继的 WebSocket URL 带不可猜的 guid，写在 0600 权限的文件里。
+      </p>
+
+      <h2>两种模式</h2>
+      <p>上面讲的四站链路是默认模式：连你真实的、已登录的 Chrome。还有第二条路，<code>--launch</code>：</p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code><span class="du-cmt"># 默认：走扩展中继，用你的真实 Chrome</span>
+$ chrome-use open https://example.com
+<span class="du-cmt"># 另开一个隔离的隐身 Chromium</span>
+$ chrome-use --launch open https://example.com</code></pre>
+      </div>
+      <div class="cmp-scroll" style="overflow-x:auto; margin:14px 0;">
+      <table>
+        <thead><tr><th></th><th>扩展中继（默认）</th><th><code>--launch</code></th></tr></thead>
+        <tbody>
+          <tr><th>浏览器</th><td>你正在用的那个 Chrome</td><td>守护进程自己拉起的独立 Chromium</td></tr>
+          <tr><th>登录态</th><td>全部现成</td><td>空的临时 profile（<code>--profile</code> 可指定持久 profile）</td></tr>
+          <tr><th>链路</th><td>daemon → 中继 → 扩展 → chrome.debugger</td><td>daemon 直连 CDP，没有中继和扩展</td></tr>
+          <tr><th>反检测</th><td>不需要：本来就是真浏览器，零注入</td><td>原生覆盖（改 UA、时区、webdriver 等，见 <code>stealth.rs</code>），不打 JS 补丁</td></tr>
+          <tr><th>适用</th><td>需要登录态、过反爬、用户随时接管</td><td>干净环境测试、并行跑一次性任务</td></tr>
+        </tbody>
+      </table>
+      </div>
+      <p>两种模式共用同一个守护进程架构和同一套命令，区别只在守护进程连的是谁。</p>
+
+      <h2>每个 --session 一个彩色标签组</h2>
+      <p>多个 agent 共用一个真实 Chrome 时，隔离靠标签组：</p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code>$ chrome-use --session research open https://a.com   <span class="du-cmt"># research 组</span>
+$ chrome-use --session shopping open https://b.com   <span class="du-cmt"># shopping 组，互不可见</span></code></pre>
+      </div>
+      <p>
+        守护进程启动时把会话名记进 <code>DAEMON_SESSION</code>，它开的每个标签都落进这个会话专属的彩色 Chrome 标签组。
+        隔离在中继层强制执行（<code>relay.rs</code> 的 <code>client_groups</code>）：守护进程连上中继后先声明自己的组，
+        此后它的 <code>Target.getTargets</code> 只返回本组的标签。它看不见你的标签，也看不见其他 agent 的标签，自然也就点不到。
+      </p>
+      <p>
+        细节都有归属规则：新标签打上创建者的组标签；页面弹出的 pop-up 继承 opener 的组，跨进程跳转（比如 OAuth 弹窗）不会跑丢；
+        <code>chrome-use adopt</code> 是唯一的跨组通道，收养后那一个标签被重新打进收养者的组，其余照旧不可见。会话与持久化细节见
+        <a href="/sessions.html">会话与持久化</a>。
+      </p>
+
+      <h2>snapshot 和 @ref 从哪里来</h2>
+      <p>
+        <code>chrome-use snapshot -i</code> 输出的那棵文本树不是 HTML，是无障碍树（accessibility tree）。守护进程通过 CDP 的
+        <code>Accessibility.getFullAXTree</code> 拿到整棵 AX 树（<code>cli/src/native/snapshot.rs</code>），过滤出 button、link、
+        textbox 等可交互角色，渲染成带缩进的文本：
+      </p>
+<pre><code>button "提交" [ref=e12]
+textbox "邮箱" [ref=e13]</code></pre>
+      <p>
+        每个 <code>[ref=eN]</code> 是守护进程在生成快照时分配的编号，背后是 <code>RefMap</code>（<code>cli/src/native/element.rs</code>）：
+        ref 映射到 CDP 的 <code>backend_node_id</code>，也就是那个 DOM 节点在浏览器进程里的稳定句柄。<code>chrome-use click @e12</code>
+        时，守护进程查表拿到节点 id，直接对节点发操作，不需要 CSS 选择器，也不需要坐标。由此推出两条使用规则：
+      </p>
+      <ol>
+        <li>ref 是守护进程的内存状态。守护进程重启（比如闲置退出）后旧 ref 全部作废，重新 <code>snapshot</code> 即可。</li>
+        <li>页面大改后 ref 可能指向已不存在的节点。<code>RefMap</code> 存了每个 ref 的角色、名称等指纹，<code>--heal</code> 能据此把 ref 重新定位到最接近的节点。定位细节见 <a href="/finding.html">定位元素</a>。</li>
+      </ol>
+
+      <h2>出身</h2>
+      <p>
+        chrome-use 最初基于 vercel-labs/agent-browser（Apache-2.0）。CLI 骨架和部分命令语义来自上游，
+        但隐身与扩展中继架构、反检测、humanize、多 agent 隔离、以及本页讲的整条 nm-host 链路都是本项目自己长出来的，
+        现在是独立项目。完整的分叉说明见 <a href="/lineage.html">血统与上游</a>。
+      </p>
+      <div class="du-callout tip">
+        <div class="du-callout-title">🔧 想动手验证</div>
+        <code>AGENT_BROWSER_DEBUG=1</code> 让守护进程把日志写到 <code>~/.chrome-use/&lt;session&gt;.log</code>；
+        <code>cat ~/.chrome-use/relay-cdp-url</code> 看中继的实时端点；<code>chrome-use doctor</code> 把每一站的健康状况报一遍。
+        排障见 <a href="/troubleshooting.html">故障排查</a>，扩展安装见 <a href="/real-chrome.html">驱动真实 Chrome</a>，反检测数据见 <a href="/stealth.html">反检测与隐身</a>。
+      </div>
+
+    </main>
+    <!-- ========================== /PAGE CONTENT =========================== -->
+
+    <aside id="du-toc"></aside>
+
+  </div>
+
+  <script src="/assets/docs/docs.js" defer></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,6 +242,9 @@
         Apache-2.0 · <a href="https://github.com/leeguooooo/chrome-use" target="_blank" rel="noopener">GitHub</a>
         · 属于 <a href="https://leeguoo.com" target="_blank" rel="noopener">leeguoo.com</a> *-use 家族。
       </p>
+      <p class="du-small" style="margin-top:6px; color:var(--ink-faint); font-size:.85rem;">
+        最初基于 <a href="https://github.com/vercel-labs/agent-browser" target="_blank" rel="noopener">vercel-labs/agent-browser</a>（Apache-2.0），现已独立演进 · <a href="/lineage.html">血统与上游</a>
+      </p>
 
     </main>
     <!-- ========================== /PAGE CONTENT =========================== -->

--- a/docs/lineage.html
+++ b/docs/lineage.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>血统与上游 · chrome-use 文档</title>
+  <meta name="description" content="chrome-use 起源于 vercel-labs/agent-browser（Apache-2.0），现在是独立项目。上游是谁、分叉之后各自走了哪条路、该怎么理解这层关系，以及版本锁定和 Apache-2.0 许可证义务。" />
+
+  <meta name="theme-color" content="#fcfbf4" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="chrome-use 文档" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=ZCOOL+KuaiLe&family=Permanent+Marker&family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="/assets/docs/docs.css" />
+</head>
+
+<body data-page="lineage" data-lang="zh">
+
+  <div id="du-topbar"></div>
+
+  <div class="du-shell">
+
+    <nav id="du-sidebar"></nav>
+
+    <!-- ============================ PAGE CONTENT ============================ -->
+    <main class="du-main">
+
+      <span class="du-doodle" style="top:40px; right:8px; width:46px; height:46px;">
+        <svg viewBox="0 0 60 60" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M30 54V30M30 30C30 20 22 16 14 14M30 30c0-8 8-12 16-14M30 22c0-6 4-10 10-12"/>
+        </svg>
+      </span>
+
+      <p class="du-eyebrow">参考 / Reference</p>
+
+      <div class="du-title-row">
+        <h1>血统与上游</h1>
+        <button class="du-copy-page" type="button" aria-label="复制页面">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
+          <span class="du-copy-page-label">复制页面</span>
+        </button>
+      </div>
+
+      <p class="du-lede">
+        chrome-use 起源于 <a href="https://github.com/vercel-labs/agent-browser" target="_blank" rel="noopener">vercel-labs/agent-browser</a>（Apache-2.0），
+        现在是独立项目。这一页交代上游是谁、分叉之后各自走了哪条路、以及该怎么理解这层关系：它<span class="mark">不是上游的替代版本</span>，
+        是一个目标不同的产品，专门驱动你已登录的真实 Chrome。
+      </p>
+
+      <h2>上游：vercel-labs/agent-browser</h2>
+      <p>
+        chrome-use 的第一行代码来自 Vercel Labs 的 agent-browser：一个用 Rust 写的、给 AI agent 用的浏览器自动化 CLI。
+        守护进程模型、快照加 <code>@ref</code> 引用的交互范式、Rust CLI 的整体骨架都继承自它。没有这个上游就没有 chrome-use，
+        这份功劳记在这里。
+      </p>
+      <p>仓库里的血统痕迹至今可查：</p>
+      <ul>
+        <li><code>git remote</code> 的 <code>upstream</code> 仍指向 <code>vercel-labs/agent-browser</code>；</li>
+        <li>环境变量前缀沿用 <code>AGENT_BROWSER_*</code>；</li>
+        <li><code>abs</code> 命令别名来自仓库旧名 agent-browser-stealth；</li>
+        <li>早期 Release tag 带 <code>-fork.N</code> 后缀（如 <code>v0.27.0-fork.12</code>），现行 tag 已是独立的 <code>v1.x.y</code> 序列。</li>
+      </ul>
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ README 原话</div>
+        “Originally based on vercel-labs/agent-browser (Apache-2.0); now a standalone project — the stealth/extension-relay
+        architecture, anti-detection, humanize, multi-agent isolation, and CLI have diverged substantially.”
+      </div>
+
+      <h2>分叉之后加了什么</h2>
+      <p>
+        分歧的核心是连接方式。上游的经典路径是为 agent 启动一个浏览器实例；chrome-use 的默认路径是接管你已经登录一切的
+        那个真实 Chrome，整条链路为此重造：
+      </p>
+      <p>
+        <strong>扩展中继架构。</strong>CLI 与每个会话的后台守护进程之间走 Unix domain socket；守护进程经 Chrome 原生消息连接
+        ab-connect 浏览器扩展；扩展再用 <code>chrome.debugger</code> 发 CDP 命令驱动目标标签页。全程没有
+        <code>--remote-debugging-port</code>，因此不会触发 Chrome 136+ 每次连接都弹的「Allow remote debugging?」对话框。
+        安装只需一条 <code>curl … | sh</code> 加一次性的扩展安装。整条链路见 <a href="/how-it-works.html">它怎么工作</a>。
+      </p>
+      <p>
+        <strong>反检测。</strong>走扩展连真实 Chrome 时不注入任何 JS 补丁，因为它就是你的真实浏览器，CreepJS 实测 0% bot。
+        <code>--launch</code> 路径另开一个隔离的隐身 Chromium，用 CDP 与启动参数级的原生覆盖做伪装，不靠容易泄漏的 JS 打补丁。
+        详见 <a href="/stealth.html">反检测与隐身</a> 与 <a href="/real-chrome.html">驱动真实 Chrome</a>。
+      </p>
+      <p>
+        <strong>还搬进来的：</strong><code>--humanize</code> 行为级过检测、每会话彩色标签组的多 agent 隔离、
+        <code>session handoff</code> 所有权与人工接管、<a href="/script.html">单次成型脚本</a>、以及围绕真实 Chrome 的一整套命令面。
+      </p>
+
+      <h2>这不是替代品</h2>
+      <p>
+        两个项目回答的问题不同。上游给 agent 一个干净的浏览器；chrome-use 让 agent 用你已登录的那个浏览器，
+        共享你的会话，站点把它读成真人。所以别把 chrome-use 当上游的换壳：命令面、连接方式、默认行为都已分开演进，
+        本站文档只描述 chrome-use，不能反过来套用到 agent-browser 上。
+      </p>
+      <ul>
+        <li>需要给 agent 起一个隔离的全新浏览器实例、且不在意登录态 → 上游 agent-browser 是干净的选择。</li>
+        <li>需要复用真实登录、绕开反爬弹窗、多个 agent 在同一个 Chrome 里并发干活 → 这是 chrome-use 存在的理由。</li>
+      </ul>
+      <p>两边独立发版，互不承诺兼容。逐项能力对比见 <a href="/compare.html">对比其他方案</a>。</p>
+
+      <h2>锁定版本</h2>
+      <p>
+        默认安装拉取最新 GitHub Release。生产环境或 CI 建议用 <code>AGENT_BROWSER_VERSION</code> 锁定具体 tag
+        （这个变量名本身就是血统的一部分）：
+      </p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code><span class="du-cmt"># 装最新版</span>
+$ curl -fsSL https://raw.githubusercontent.com/leeguooooo/chrome-use/main/install.sh | sh
+
+<span class="du-cmt"># 锁定到指定版本</span>
+$ AGENT_BROWSER_VERSION=v1.5.70 \
+    curl -fsSL https://raw.githubusercontent.com/leeguooooo/chrome-use/main/install.sh | sh</code></pre>
+      </div>
+      <div class="du-callout tip">
+        <div class="du-callout-title">💡 老 tag</div>
+        旧文档或旧脚本里出现的 <code>v0.27.0-fork.12</code> 这类带 <code>-fork.N</code> 后缀的 tag 属于分叉早期的版本序列，
+        同一个变量照样能锁定；新项目直接用 <code>v1.x.y</code>。
+      </div>
+
+      <h2>许可证</h2>
+      <p>
+        上游 agent-browser 采用 Apache-2.0，chrome-use 同样以 Apache-2.0 发布，许可证全文见仓库根目录 <code>LICENSE</code>。
+      </p>
+      <p>
+        Apache-2.0 允许自由使用、修改、分发（含商用），条件是保留版权与许可声明。chrome-use 在 README 中署名上游。
+        如果你基于 chrome-use 再分发，需要保留 <code>LICENSE</code>，并延续对 vercel-labs/agent-browser 的署名链。
+      </p>
+
+      <hr class="du-divider" />
+
+      <div class="du-cards">
+        <a class="du-card" href="/how-it-works.html">
+          <div class="du-card-title"><span class="du-card-ico">⚙️</span> 它怎么工作</div>
+          <p>分叉后重造的那条扩展中继链路，一站一站拆开讲。</p>
+        </a>
+        <a class="du-card" href="/compare.html">
+          <div class="du-card-title"><span class="du-card-ico">⚖️</span> 对比其他方案</div>
+          <p>chrome-use vs agent-browser、ego-lite、Playwright 等，逐项实测。</p>
+        </a>
+        <a class="du-card" href="https://github.com/vercel-labs/agent-browser" target="_blank" rel="noopener">
+          <div class="du-card-title"><span class="du-card-ico">🌱</span> 上游仓库</div>
+          <p>vercel-labs/agent-browser（Apache-2.0）。</p>
+        </a>
+      </div>
+
+    </main>
+    <!-- ========================== /PAGE CONTENT =========================== -->
+
+    <aside id="du-toc"></aside>
+
+  </div>
+
+  <script src="/assets/docs/docs.js" defer></script>
+</body>
+</html>

--- a/docs/script.html
+++ b/docs/script.html
@@ -1,0 +1,221 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>单次成型脚本 · chrome-use 文档</title>
+  <meta name="description" content="chrome-use script：把整个观察→判断→动作→验证流程一次交给守护进程执行，一次 tool call 拿回结构化结果。JSON op-list（值总线 + 循环 + 断言）和同步 JS（cu.* 助手）两种写法，引擎跑在守护进程里，扛得住硬跳转。" />
+
+  <meta name="theme-color" content="#fcfbf4" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="chrome-use 文档" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=ZCOOL+KuaiLe&family=Permanent+Marker&family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="/assets/docs/docs.css" />
+</head>
+
+<body data-page="script" data-lang="zh">
+
+  <div id="du-topbar"></div>
+
+  <div class="du-shell">
+
+    <nav id="du-sidebar"></nav>
+
+    <!-- ============================ PAGE CONTENT ============================ -->
+    <main class="du-main">
+
+      <span class="du-doodle" style="top:40px; right:8px; width:46px; height:46px;">
+        <svg viewBox="0 0 60 60" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M32 6 L14 34 h14 l-4 20 20-30 h-14 z"/>
+        </svg>
+      </span>
+
+      <p class="du-eyebrow">进阶 / Advanced</p>
+
+      <div class="du-title-row">
+        <h1>单次成型脚本</h1>
+        <button class="du-copy-page" type="button" aria-label="复制页面">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
+          <span class="du-copy-page-label">复制页面</span>
+        </button>
+      </div>
+
+      <p class="du-lede">
+        逐条命令驱动浏览器时，模型卡在循环里：每走一步都要读结果、想下一步、再发一条命令。
+        <code>chrome-use script</code> 把整个<span class="mark">观察、判断、动作、验证</span>流程一次交给守护进程执行，
+        决策逻辑贴着浏览器跑，一次 tool call 拿回结构化结果。两种写法：<strong>JSON op-list</strong>（可机器生成、可 dry-run）
+        和真正的<strong>同步 JS</strong>（<code>cu.*</code> 助手函数）。实测 HN 翻 3 页采集高分故事，从 13+ 次调用降到 1 次。
+      </p>
+
+      <h2>逐条命令的循环有多贵</h2>
+      <p>
+        chrome-use 的基本用法是一条命令一个动作：<code>snapshot</code> 看页面，<code>click @e8</code> 点按钮，
+        <code>eval</code> 读数据。每条命令都是一次完整往返：进程启动、Unix socket 到守护进程、扩展 relay 到浏览器、
+        结果原路返回，然后 agent 的模型读输出、决定下一步。单步任务这样没问题，代价在多步流程上：翻页采集、
+        按条件重试、拿上一步结果决定下一步，模型被迫留在循环里，<strong>每一步花一次推理，每一步一次 tool call</strong>。
+      </p>
+      <p>
+        固定的动作序列已经有 <code>batch</code> 可以一次往返跑完（<code>press --hold</code> 和 <code>wait</code>
+        在守护进程内阻塞，时序精确），但 batch 的步骤之间不能传值，也没有循环和条件。<code>script</code> 补的就是这一层。
+      </p>
+      <div class="du-callout note">
+        <div class="du-callout-title">🪜 四层阶梯</div>
+        单条 verb（一步一往返）→ <code>batch</code>（固定序列，一次往返）→ <code>script</code>（步骤间传值 +
+        循环 + 条件 + 断言，一次往返）→ <code>stream</code> WebSocket（持续实时驱动）。往下每一层能表达的逻辑更多，
+        往返和 tool call 更少；选到刚好够用的那层就行。
+      </div>
+
+      <h2>JSON op-list 形式</h2>
+      <p>
+        第一种写法是 JSON 语句数组，适合让模型直接生成、让程序拼装。后面的 op 通过 <code>{{name.path}}</code>
+        值总线读前面 op 的结果：
+      </p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code>chrome-use script - &lt;&lt;'JSON'
+[
+  {"do":"navigate","url":"https://example.com"},
+  {"do":"evaluate","script":"document.title","bind":"t"},
+  {"assert":{"contains":["{{t.result}}","Example"]},"msg":"wrong page"},
+  {"return":"{{t.result}}"}
+]
+JSON</code></pre>
+      </div>
+      <p>语句一共八种（<code>cli/src/native/script.rs</code>）：</p>
+<pre><code>{ "do": "&lt;action&gt;", ...params, "bind"?: "name", "optional"?: bool }   // 跑一个命令，结果存进变量
+{ "waitUntil": &lt;cond&gt;, "timeoutMs"?: n, "pollMs"?: n }                 // 轮询到条件成立
+{ "forEach": "{{list}}", "as"?: "item", "max": n, "body": [ ... ] }   // 循环（max 必填，硬上限）
+{ "assert": &lt;cond&gt;, "msg"?: "..." }                                   // 断言，失败即止损（退出码 1）
+{ "set": "name", "value": &lt;v|"{{expr}}"&gt; }                            // 赋值
+{ "push": "name", "value": &lt;v|"{{expr}}"&gt; }                           // 往数组追加
+{ "return": &lt;v|"{{expr}}"&gt; }                                          // 返回并结束
+{ "log": &lt;v|"...{{expr}}..."&gt; }                                       // 记一行进度</code></pre>
+      <p>
+        条件（<code>&lt;cond&gt;</code>）有 <code>{"eq":[a,b]}</code>、<code>{"ne"}</code>、<code>{"contains"}</code>、
+        <code>{"matches":[a,rx]}</code>、<code>{"exists":"&lt;selector&gt;"}</code>、<code>{"gone"}</code>。
+        <code>{{expr}}</code> 值总线：整串就是 <code>{{x}}</code> 时取到原类型的值（数字还是数字），嵌在文本里
+        <code>...{{x}}...</code> 时做字符串插值；路径带下标，如 <code>rows.0.ref</code>、<code>rows[0].url</code>。
+      </p>
+      <div class="du-callout tip">
+        <div class="du-callout-title">💡 提示</div>
+        <code>evaluate</code> 的返回值裹在 <code>.result</code> 里，所以引用页面求值结果写 <code>{{t.result}}</code> 而不是 <code>{{t}}</code>。
+        用 <code>--dry-run</code> 只校验程序结构、不碰浏览器；用 <code>--arg k=v</code> 预置变量。退出码：0 成功、1 运行失败或断言不过、2 程序非法。
+      </div>
+
+      <h2>JS 程序形式</h2>
+      <p>
+        第二种写法是一段真正的 JavaScript，用 <code>cu.*</code> 助手函数直接驱动你已登录的真 Chrome。
+        这是 ego-lite 的 code base 写法，控制流就是 JS 本身的 <code>for</code> / <code>if</code> / <code>break</code>。
+        <strong>不用 <code>await</code></strong>：每个 <code>cu.*</code> 调用会阻塞到浏览器返回，脚本是同步的。
+      </p>
+      <div class="du-code">
+        <div class="du-code-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="du-code-name">bash</span></div>
+<pre><code>chrome-use script --timeout 120000 &lt;&lt;'JS'
+  cu.open('https://news.ycombinator.com');
+  const out = [];
+  for (let page = 0; page &lt; 3; page++) {
+    const rows = cu.eval("[...document.querySelectorAll('.athing')].map(r=&gt;({id:r.id,title:r.querySelector('.titleline a')?.innerText}))");
+    for (const r of rows) {
+      const pts = cu.eval(`+(document.querySelector('#score_${r.id}')?.innerText.match(/\\d+/)?.[0] ?? 0)`);
+      if (pts &gt;= 100) out.push({ title: r.title, points: pts });
+    }
+    if (!cu.visible('a.morelink')) break;
+    cu.click('a.morelink');       // 整页硬跳转，脚本状态不丢
+    cu.waitFor('.athing', 8000);
+  }
+  return { count: out.length, top: out.slice(0, 5) };
+JS</code></pre>
+      </div>
+      <p>
+        助手函数一览：<code>cu.snapshot</code> / <code>cu.eval</code> / <code>cu.open</code> / <code>cu.click</code> /
+        <code>cu.fill</code> / <code>cu.type</code> / <code>cu.press</code> / <code>cu.hover</code> / <code>cu.select</code> /
+        <code>cu.check</code> / <code>cu.scroll</code> / <code>cu.find</code> / <code>cu.visible</code> / <code>cu.waitFor</code> /
+        <code>cu.wait</code> / <code>cu.extract</code> / <code>cu.text</code> / <code>cu.log</code>。<code>cu.eval</code>
+        直接返回页面里的值；其余失败即抛异常，脚本快速失败。程序的返回值就是命令的返回值，<code>cu.log(...)</code> 收集进度行。
+      </p>
+
+      <h2>引擎跑在守护进程里</h2>
+      <p>ego 也能写一段 JS 跑完整个任务，chrome-use script 反超它的点在<strong>引擎的位置</strong>。</p>
+      <p>
+        <strong>扛得住硬跳转。</strong>注入到页面世界的运行时，页面一跳转整个执行环境就没了，多页流程正好死在翻页那一下。
+        chrome-use 的 JS 引擎跑在守护进程里、页面外面：上面例子里 <code>cu.click('a.morelink')</code> 触发整页导航，
+        脚本状态（<code>out</code> 数组、循环计数）原地不动，等 <code>cu.waitFor</code> 确认新页加载完继续跑。
+      </p>
+      <p>
+        <strong>纯 Rust 引擎，全平台。</strong>JS 引擎是 boa，纯 Rust 实现，编译进 chrome-use 二进制本体，
+        不依赖 Node 也不依赖系统 V8。macOS / Linux / Windows 都能跑；ego 只有 macOS。
+      </p>
+      <p>
+        <strong>每个 op 走同一条正门。</strong>script 的每一步（两种形式都是）重新进入守护进程的
+        <code>execute_command</code>，和你手敲单条命令走完全相同的路径：策略检查、隐身传输、<code>--humanize</code>、
+        <code>@ref</code> 自愈、跨进程会话恢复。没有任何东西被重新实现，所以脚本里的行为和命令行里一模一样。
+        整条链路怎么走见 <a href="/how-it-works.html">它怎么工作</a>。
+      </p>
+
+      <h2>实测：HN 翻 3 页</h2>
+      <p>
+        基准任务：Hacker News 翻 3 页，收集所有 ≥100 分的故事，输出 JSON。上一节的 JS 程序就是完整题解，
+        已在真 Chrome 上跑通（3 页、34 条、约 4.8 秒）。
+      </p>
+      <div class="cmp-scroll" style="overflow-x:auto; margin:14px 0;">
+      <table>
+        <thead><tr><th></th><th>逐条 verb</th><th>chrome-use script</th></tr></thead>
+        <tbody>
+          <tr><th>tool call 次数</th><td>13+</td><td><strong>1</strong></td></tr>
+          <tr><th>模型推理次数</th><td>每步一次，翻页、逐条判分都要回模型</td><td>2 次：写程序 + 读结果</td></tr>
+          <tr><th>中间输出</th><td>每步的 snapshot / eval 结果都进上下文</td><td>只有 <code>return</code> 的最终 JSON</td></tr>
+          <tr><th>翻页（硬跳转）</th><td>天然没问题（每步独立）</td><td>没问题，引擎在守护进程里</td></tr>
+        </tbody>
+      </table>
+      </div>
+      <p>
+        「≥100 分」这类判断在脚本里用一行 <code>if</code> 解决，旧写法里每条故事都要把分数带回模型判一次。
+        步数越多、判断越密，差距越大。全景对比和 ego-lite 逐项实测见 <a href="/compare.html">对比其他方案</a>。
+      </p>
+
+      <h2>该用哪一层</h2>
+      <p>script 不取代单条命令，它是多步流程的上层。选择标准：</p>
+      <ul>
+        <li><strong>一两步的任务</strong>：单条 verb 就好，加 <a href="/waiting.html"><code>expect</code></a> 或 <code>--observe</code> 收尾验证。</li>
+        <li><strong>固定序列、步骤间不传值</strong>：<code>batch</code>，时序精确、开销最小。</li>
+        <li><strong>要用上一步的结果、要循环或条件、要断言中途止损</strong>：<code>script</code>。模型来生成程序就用 JSON 形式（可 <code>--dry-run</code> 预验）；人写或逻辑复杂就用 JS 形式。</li>
+        <li><strong>持续实时驱动</strong>（游戏、逐帧交互）：<code>stream</code> WebSocket，见 <a href="/canvas.html">Canvas / WebGL</a>。</li>
+      </ul>
+      <div class="du-callout tip">
+        <div class="du-callout-title">✅ 先看这些</div>
+        纯抓数据的任务先看 <a href="/extract.html"><code>extract --schema</code></a>（一次调用把页面结构化成 JSON）；
+        要在多页之间累积、按条件筛选，再用 <code>script</code> 把 extract 包进循环。
+      </div>
+
+      <hr class="du-divider" />
+
+      <div class="du-cards">
+        <a class="du-card" href="/how-it-works.html">
+          <div class="du-card-title"><span class="du-card-ico">⚙️</span> 它怎么工作</div>
+          <p>守护进程、relay、boa 引擎跑在哪一站；script 扛硬跳转的原因就在这条链路上。</p>
+        </a>
+        <a class="du-card" href="/compare.html">
+          <div class="du-card-title"><span class="du-card-ico">⚖️</span> 对比其他方案</div>
+          <p>chrome-use script vs ego-lite 的 code base 写法，逐项实测。</p>
+        </a>
+        <a class="du-card" href="/waiting.html">
+          <div class="du-card-title"><span class="du-card-ico">⏳</span> 等待与断言</div>
+          <p><code>expect</code> / <code>--observe</code>：单条命令的收尾验证，script 里对应 <code>assert</code> / <code>waitUntil</code>。</p>
+        </a>
+      </div>
+
+    </main>
+    <!-- ========================== /PAGE CONTENT =========================== -->
+
+    <aside id="du-toc"></aside>
+
+  </div>
+
+  <script src="/assets/docs/docs.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
Adds the three missing chapters (bilingual) the doc site lacked: **How It Works** (architecture pipeline), **Lineage & Upstream** (vercel-labs/agent-browser fork story + Apache-2.0 attribution), **Single-pass Scripting** (the shipped chrome-use script feature). Wires them into NAV, fixes the compare→script dead end + index upstream attribution + core-loop next-steps, and corrects changelog's wrong upstream link (AgentDesk→vercel-labs).

From a 10-agent audit of all 29 doc pages; the broader per-page slop/factual-fix sweep is a planned follow-up.

https://claude.ai/code/session_016y1t4eQCT6abUVZCztLuvt