### PR TITLE
feat(snapshot,diagnose): sharpen chrome-use on Element-Plus modal apps (#90)

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -52,6 +52,7 @@ const KNOWN_COMMANDS: &[&str] = &[
     "text",
     "html",
     "frames",
+    "diagnose",
     "find",
     "wait",
     "scroll",
@@ -1823,6 +1824,11 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         // frames + out-of-process iframes), with a text-length per frame so you
         // can see where a listing's description actually lives (issue #27).
         "frames" => Ok(json!({ "id": id, "action": "frames" })),
+
+        // `diagnose` — why is this page blank? Fetches each script/stylesheet to
+        // catch 404s + MIME mismatches (a .js served as text/html = wrong base
+        // path), checks the app root mounted, flags console-capture-off (#90.5).
+        "diagnose" => Ok(json!({ "id": id, "action": "diagnose" })),
 
         // Top-level shortcuts for `get <x>` status reads — users naturally type
         // `chrome-use url` / `cdp-url` / `title` without the `get` prefix

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1487,6 +1487,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             "wait" => handle_wait(cmd, state).await,
             "gettext" => handle_gettext(cmd, state).await,
             "frames" => handle_frames(cmd, state).await,
+            "diagnose" => handle_diagnose(cmd, state).await,
             "getattribute" => handle_getattribute(cmd, state).await,
             "isvisible" => handle_isvisible(cmd, state).await,
             "isenabled" => handle_isenabled(cmd, state).await,
@@ -5488,6 +5489,145 @@ fn console_capture_active(state: &DaemonState) -> bool {
 const CONSOLE_DISABLED_HINT: &str =
     "console/error capture is disabled for stealth (Runtime.enable is a detectable CDP \
      signal). Restart the session with AGENT_BROWSER_CAPTURE_CONSOLE=1 to capture page output.";
+
+/// `diagnose` — "why is this page blank?" (issue #90.5). For an SPA that renders
+/// nothing, the single most useful signal is *which* asset failed and *how*.
+/// Non-destructive: fetches every `<script src>` / stylesheet and checks its
+/// status + content-type — a `.js`/`.css` served as `text/html` is the classic
+/// wrong-base-path / SPA-fallback (server returned `index.html` for an asset
+/// request), which loads "6 scripts" yet never mounts. Also reports whether the
+/// app root actually populated, and flags that console capture is off by default
+/// (so the page's own mount-time errors weren't recorded — the reason
+/// `console --level error` came back empty).
+async fn handle_diagnose(_cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+
+    let js = r#"(async () => {
+    var out = { url: location.href, bodyTextLen: 0, rootSelector: null, rootEmpty: null,
+                scripts: 0, styles: 0, assets: [] };
+    out.bodyTextLen = ((document.body && document.body.innerText) || '').trim().length;
+    var root = document.querySelector('#app,#root,[data-reactroot],[data-v-app],main');
+    if (root) { out.rootSelector = root.id ? ('#'+root.id) : root.tagName.toLowerCase(); out.rootEmpty = root.children.length === 0; }
+    var srcs = [];
+    document.querySelectorAll('script[src]').forEach(function(s){ srcs.push({ url: s.src, kind: 'script' }); });
+    document.querySelectorAll('link[rel="stylesheet"][href]').forEach(function(l){ srcs.push({ url: l.href, kind: 'style' }); });
+    out.scripts = document.querySelectorAll('script[src]').length;
+    out.styles = document.querySelectorAll('link[rel="stylesheet"]').length;
+    var checks = await Promise.all(srcs.slice(0, 40).map(async function(s){
+        try {
+            var r = await fetch(s.url, { method: 'GET', cache: 'no-store' });
+            var ct = (r.headers.get('content-type') || '').split(';')[0].trim();
+            var isHtml = /text\/html/i.test(ct);
+            var mimeMismatch = (s.kind === 'script' && isHtml) || (s.kind === 'style' && isHtml);
+            if (!r.ok || mimeMismatch)
+                return { url: s.url, status: r.status, contentType: ct, kind: s.kind, mimeMismatch: mimeMismatch };
+            return null;
+        } catch (e) {
+            return { url: s.url, status: 0, contentType: '(fetch failed: ' + e.message + ')', kind: s.kind, mimeMismatch: false };
+        }
+    }));
+    out.assets = checks.filter(Boolean);
+    return out;
+})()"#
+        .to_string();
+
+    let resp = mgr
+        .client
+        .send_command_typed::<_, Value>(
+            "Runtime.evaluate",
+            &super::cdp::types::EvaluateParams {
+                expression: js,
+                return_by_value: Some(true),
+                await_promise: Some(true),
+            },
+            Some(&session_id),
+        )
+        .await?;
+
+    if let Some(ex) = resp.get("exceptionDetails") {
+        let text = ex
+            .get("exception")
+            .and_then(|e| e.get("description"))
+            .and_then(|d| d.as_str())
+            .or_else(|| ex.get("text").and_then(|t| t.as_str()))
+            .unwrap_or("evaluation failed");
+        return Err(format!("diagnose failed: {}", text));
+    }
+    let scan = resp
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let body_len = scan.get("bodyTextLen").and_then(|v| v.as_i64()).unwrap_or(0);
+    let root_empty = scan.get("rootEmpty").and_then(|v| v.as_bool());
+    let empty_assets = Vec::new();
+    let assets = scan
+        .get("assets")
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty_assets);
+    let mime_mismatch = assets
+        .iter()
+        .any(|a| a.get("mimeMismatch").and_then(|m| m.as_bool()) == Some(true));
+    let failed = assets.iter().any(|a| {
+        matches!(a.get("status").and_then(|s| s.as_i64()), Some(s) if s == 0 || s >= 400)
+    });
+    let blank = body_len < 16 && root_empty != Some(false);
+    let console_on = console_capture_active(state);
+
+    // Plain-language verdict, most-actionable first.
+    let mut verdict = Vec::new();
+    if mime_mismatch {
+        verdict.push(
+            "an asset (JS/CSS) was served as text/html — almost always a wrong base path or \
+             SPA fallback returning index.html for asset requests; fix the base path / deploy path."
+                .to_string(),
+        );
+    }
+    if failed && !mime_mismatch {
+        verdict.push(
+            "one or more scripts/stylesheets failed to load (see `assets` — status 0 = blocked/network, \
+             4xx/5xx = missing); the app can't mount without them."
+                .to_string(),
+        );
+    }
+    if blank && assets.is_empty() {
+        // Assets all loaded but nothing rendered → JS threw during mount.
+        verdict.push(if console_on {
+            "assets all loaded but the page is blank — the JS likely threw during mount; \
+             check `console --level error`."
+                .to_string()
+        } else {
+            "assets all loaded but the page is blank — the JS likely threw during mount, but \
+             console capture is OFF by default (that's why `console --level error` was empty). \
+             Re-run the session with AGENT_BROWSER_CAPTURE_CONSOLE=1 to see the throw."
+                .to_string()
+        });
+    }
+    if verdict.is_empty() {
+        verdict.push(if blank {
+            "page looks blank but assets and mount root are inconclusive — inspect `assets` and \
+             re-run with AGENT_BROWSER_CAPTURE_CONSOLE=1 for mount-time errors."
+                .to_string()
+        } else {
+            "page appears to have rendered content; no failed assets detected.".to_string()
+        });
+    }
+
+    Ok(json!({
+        "url": scan.get("url"),
+        "blank": blank,
+        "bodyTextLen": body_len,
+        "rootSelector": scan.get("rootSelector"),
+        "rootEmpty": root_empty,
+        "scripts": scan.get("scripts"),
+        "styles": scan.get("styles"),
+        "assets": assets,
+        "consoleCapture": console_on,
+        "diagnosis": verdict,
+    }))
+}
 
 /// `expect <condition>` — assertion verb. Polls the condition until it holds or
 /// the timeout elapses (unless --no-wait), then returns {pass, actual, ...}.

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -466,11 +466,118 @@ pub async fn resolve_element_object_id(
         ));
     }
 
-    let object_id = result
-        .result
-        .object_id
-        .ok_or_else(|| format!("Element not found: {}", selector_or_ref))?;
+    let Some(object_id) = result.result.object_id else {
+        // Element not found. If the selector carries a quoted text — most often a
+        // `[placeholder="…"]` — Element-Plus-style widgets render that text on an
+        // inner <span>, not the real <input>, so the CSS selector matches nothing
+        // and the generic "closed shadow root / cross-origin iframe" hint sends
+        // people down the wrong path (#90.4). Point at the closest textual match.
+        if let Some(hint) = suggest_textual_match(client, session_id, selector_or_ref).await {
+            return Err(format!("Element not found: {}. {}", selector_or_ref, hint));
+        }
+        return Err(format!("Element not found: {}", selector_or_ref));
+    };
     Ok((object_id, session_id.to_string()))
+}
+
+/// On a CSS-selector miss, if the selector carries a quoted string (usually a
+/// `placeholder`), scan the page for the closest textual match and describe it,
+/// so the error nudges toward `snapshot -i` + `@ref` instead of the misleading
+/// shadow/iframe explanation (#90.4). Best-effort: returns None on any failure
+/// or when the selector has no quoted text to look for.
+async fn suggest_textual_match(
+    client: &CdpClient,
+    session_id: &str,
+    selector: &str,
+) -> Option<String> {
+    // Pull the first quoted literal out of the selector (e.g. the value of a
+    // `placeholder="…"` clause). No quoted text → nothing to search for.
+    let want = extract_quoted(selector)?;
+    if want.chars().count() < 2 {
+        return None;
+    }
+
+    let js = format!(
+        r#"
+(function() {{
+    var want = {want};
+    function clean(s){{ return (s||'').replace(/\s+/g,' ').trim(); }}
+    function vis(el){{ var r = el.getBoundingClientRect(); return r.width>0 || r.height>0; }}
+    // 1. An element whose placeholder attribute holds the text (the common case:
+    //    Element Plus mirrors it onto an inner span, not the <input>).
+    var all = document.querySelectorAll('[placeholder]');
+    for (var i = 0; i < all.length; i++) {{
+        var p = all[i].getAttribute('placeholder') || '';
+        if (p.indexOf(want) >= 0 && vis(all[i]))
+            return {{ tag: all[i].tagName.toLowerCase(), via: 'placeholder', input: all[i].tagName === 'INPUT' || all[i].tagName === 'TEXTAREA' }};
+    }}
+    // 2. Any visible leaf element whose text equals/contains the wanted string.
+    var leaves = document.querySelectorAll('span, div, label, button, a, p');
+    for (var j = 0; j < leaves.length; j++) {{
+        var el = leaves[j];
+        if (el.children.length) continue;
+        if (clean(el.textContent).indexOf(want) >= 0 && vis(el))
+            return {{ tag: el.tagName.toLowerCase(), via: 'text', input: false }};
+    }}
+    return null;
+}})()
+"#,
+        want = serde_json::to_string(&want).unwrap_or_default(),
+    );
+
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &EvaluateParams {
+                expression: js,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(session_id),
+        )
+        .await
+        .ok()?;
+
+    let v = result.result.value?;
+    if v.is_null() {
+        return None;
+    }
+    let tag = v.get("tag").and_then(|t| t.as_str()).unwrap_or("element");
+    let via = v.get("via").and_then(|t| t.as_str()).unwrap_or("text");
+    let is_input = v.get("input").and_then(|b| b.as_bool()).unwrap_or(false);
+    if via == "placeholder" && !is_input {
+        Some(format!(
+            "No <input> matched, but a <{}> carries that placeholder \
+             (Element Plus and similar render the placeholder on an inner element, \
+             not the <input>). Run `snapshot -i` and act on the @ref instead of a CSS selector.",
+            tag
+        ))
+    } else {
+        Some(format!(
+            "No element matched that selector, but a <{}> contains that text. \
+             Run `snapshot -i` and act on the @ref (it names controls by placeholder/label).",
+            tag
+        ))
+    }
+}
+
+/// Extract the first single- or double-quoted literal from a selector string,
+/// e.g. `input[placeholder="请选择"]` → `请选择`. Returns None if unquoted.
+fn extract_quoted(selector: &str) -> Option<String> {
+    let bytes = selector.as_bytes();
+    for (i, &c) in bytes.iter().enumerate() {
+        if c == b'"' || c == b'\'' {
+            let rest = &selector[i + 1..];
+            if let Some(end) = rest.find(c as char) {
+                let inner = &rest[..end];
+                if !inner.is_empty() {
+                    return Some(inner.to_string());
+                }
+            }
+            return None;
+        }
+    }
+    None
 }
 
 /// Determine which CDP session and parameters to use for an AX tree query.
@@ -1743,6 +1850,27 @@ mod tests {
     fn test_parse_ref_at_prefix() {
         assert_eq!(parse_ref("@e1"), Some("e1".to_string()));
         assert_eq!(parse_ref("@e123"), Some("e123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_quoted() {
+        // double- and single-quoted placeholder values (the #90.4 case)
+        assert_eq!(
+            extract_quoted(r#"input[placeholder="请选择试听名字"]"#),
+            Some("请选择试听名字".to_string())
+        );
+        assert_eq!(
+            extract_quoted("input[placeholder='hello world']"),
+            Some("hello world".to_string())
+        );
+        // first literal wins when several are present
+        assert_eq!(
+            extract_quoted(r#"[data-x="a"][title="b"]"#),
+            Some("a".to_string())
+        );
+        // no quotes / empty literal → nothing to search for
+        assert_eq!(extract_quoted("div.foo > span"), None);
+        assert_eq!(extract_quoted(r#"input[value=""]"#), None);
     }
 
     #[test]

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -102,6 +102,10 @@ struct TreeNode {
     depth: usize,
     cursor_info: Option<CursorElementInfo>,
     url: Option<String>,
+    // True when this node lives inside the topmost open modal/drawer (issue #90):
+    // rendered as a `modal` attr so drawer controls are distinguishable from the
+    // still-present background page controls that `snapshot -i` also lists.
+    in_top_layer: bool,
 }
 
 impl TreeNode {
@@ -125,6 +129,7 @@ impl TreeNode {
             depth: 0,
             cursor_info: None,
             url: None,
+            in_top_layer: false,
         }
     }
 
@@ -573,6 +578,25 @@ async fn take_snapshot_at_depth(
                     {
                         node.name = label.clone();
                     }
+                }
+            }
+        }
+
+        // Tag nodes inside the topmost open modal/drawer (issue #90). When a drawer
+        // or dialog is open, `snapshot -i` otherwise lists its controls flat next to
+        // the still-present background page controls — identical `link "编辑"` lines
+        // from both, with no way to tell which is the drawer's. Marking the top-layer
+        // subtree with a `modal` attr makes the boundary greppable.
+        let top_layer = find_top_layer_backend_ids(client, session_id)
+            .await
+            .unwrap_or_default();
+        if !top_layer.is_empty() {
+            for node in tree_nodes.iter_mut() {
+                if node
+                    .backend_node_id
+                    .is_some_and(|bid| top_layer.contains(&bid))
+                {
+                    node.in_top_layer = true;
                 }
             }
         }
@@ -1486,6 +1510,88 @@ async fn find_control_label_fallbacks(
     Ok(out)
 }
 
+/// Find the `backendNodeId`s of every element inside the topmost open
+/// modal/drawer (issue #90), so `snapshot -i` can mark them with a `modal` attr.
+///
+/// Element-Plus / Ant / native `<dialog>` all leave the background page mounted
+/// and interactive underneath an open overlay, so the AX tree (and thus the flat
+/// snapshot) mixes drawer controls with background controls. We pick the topmost
+/// visible modal container by effective z-index (DOM order breaks ties — a later
+/// popup stacks on top), tag its whole subtree, and resolve the backend ids with
+/// the same batch dance the label/cursor scans use. Best-effort: any CDP failure
+/// yields an empty set (snapshot just omits the marker).
+async fn find_top_layer_backend_ids(
+    client: &CdpClient,
+    session_id: &str,
+) -> Result<std::collections::HashSet<i64>, String> {
+    let js = r#"
+(function() {
+    if (!document.body) return 0;
+    var SEL = '[role=dialog],[aria-modal="true"],dialog[open],' +
+              '.el-dialog,.el-drawer,.el-message-box,.ant-modal,.ant-drawer';
+    function vis(el){
+        var r = el.getBoundingClientRect();
+        if (r.width === 0 && r.height === 0) return false;
+        var cs = getComputedStyle(el);
+        return cs.visibility !== 'hidden' && cs.display !== 'none';
+    }
+    var cands = [].slice.call(document.querySelectorAll(SEL)).filter(vis);
+    try {
+        var modals = [].slice.call(document.querySelectorAll(':modal'));
+        for (var m = 0; m < modals.length; m++)
+            if (cands.indexOf(modals[m]) < 0 && vis(modals[m])) cands.push(modals[m]);
+    } catch (e) {}
+    if (!cands.length) return 0;
+    function zed(el){
+        var z = 0, n = el;
+        while (n && n !== document.body) {
+            var v = parseInt(getComputedStyle(n).zIndex, 10);
+            if (!isNaN(v)) z = Math.max(z, v);
+            n = n.parentElement;
+        }
+        return z;
+    }
+    // Topmost = highest effective z-index; ties resolve to the later candidate
+    // (DOM order ≈ stacking order for equal z-index), so a nested dialog opened
+    // inside a drawer wins over the drawer.
+    var top = cands[0], topZ = zed(cands[0]);
+    for (var i = 1; i < cands.length; i++) {
+        var z = zed(cands[i]);
+        if (z >= topZ) { topZ = z; top = cands[i]; }
+    }
+    var all = [top].concat([].slice.call(top.querySelectorAll('*')));
+    var n = 0;
+    for (var j = 0; j < all.length; j++) all[j].setAttribute('data-__ab-top', String(n++));
+    return n;
+})()
+"#
+    .to_string();
+
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &EvaluateParams {
+                expression: js,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(session_id),
+        )
+        .await?;
+
+    let count = result
+        .result
+        .value
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+    if count == 0 {
+        return Ok(std::collections::HashSet::new());
+    }
+
+    let idx_to_backend = resolve_tagged_backend_ids(client, session_id, "data-__ab-top").await;
+    Ok(idx_to_backend.into_values().collect())
+}
+
 /// Resolve the `backendNodeId` for every element previously tagged with a
 /// numeric-indexed data attribute (e.g. `data-__ab-err="3"`), then strip the
 /// attribute. Returns a map from that index to its `backendNodeId`.
@@ -1666,6 +1772,7 @@ fn build_tree(nodes: &[AXNode]) -> (Vec<TreeNode>, Vec<usize>) {
             depth: 0,
             cursor_info: None,
             url: None,
+            in_top_layer: false,
         });
         id_to_idx.insert(node.node_id.clone(), i);
     }
@@ -1860,6 +1967,12 @@ fn render_tree(
 
     if let Some(ref ref_id) = node.ref_id {
         attrs.push(format!("ref={}", ref_id));
+    }
+
+    // Top-layer marker (issue #90): distinguishes controls inside the open
+    // modal/drawer from the background page controls `snapshot -i` also lists.
+    if node.in_top_layer {
+        attrs.push("modal".to_string());
     }
 
     if let Some(ref url) = node.url {


### PR DESCRIPTION
Addresses the remaining friction from #90 (unlabeled-control naming #90.2 already shipped).

| # | Fix |
|---|-----|
| 90.1 | `snapshot -i` tags controls inside the topmost open modal/drawer with a `modal` attr (top container chosen by effective z-index), so drawer controls are distinguishable from the background page controls it also lists. |
| 90.4 | On a CSS-selector miss carrying a quoted string (usually `placeholder`), scan for the closest textual match and point at `snapshot -i` + @ref instead of the misleading closed-shadow/iframe hint (Element Plus renders placeholders on an inner span, not the input). |
| 90.5 | New `diagnose` verb — why is this page blank? Non-destructively fetches each script/stylesheet to catch 404s + MIME mismatches (a .js served as text/html = wrong base path / SPA fallback), checks the app root mounted, and flags that console capture is off by default (why `console --level error` was empty). |
| 90.3 | Already covered by the #105 `select` → portal-aware pick fallback (el-select detached poppers). |

Files: snapshot.rs (+top-layer scan), element.rs (+selector-miss hint + `extract_quoted` unit test), actions.rs/commands.rs (+`diagnose`).

Verified: cargo build clean, clippy -D warnings (CI cmd) clean, cargo test **1012 + 2 passed / 0 failed**.

https://claude.ai/code/session_01UNBcDSncWtGDEfe89pFvUZ