### PR TITLE
feat(install,silence): curl-install sets up the extension + handles the debugger banner

### DIFF
--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -382,7 +382,16 @@ fn run_install(args: &[String], json: bool) {
         run_install_windows(json, &host_paths);
     }
     #[cfg(not(target_os = "windows"))]
-    run_install_unix(args, json, host_paths);
+    {
+        run_install_unix(args, json, host_paths);
+        // With a real terminal (install.sh wires /dev/tty in), ask once whether
+        // chrome-use may auto-restart Chrome to remove the debugging banner and
+        // remember the answer for later agent-driven connects (#banner). No-op
+        // in --json / piped / CI installs.
+        if !json {
+            crate::silence::offer_install_time_consent();
+        }
+    }
 }
 
 /// Windows `extension install`: the native-messaging host is registered in the

--- a/cli/src/silence.rs
+++ b/cli/src/silence.rs
@@ -39,6 +39,37 @@ const RESTORE_FLAG: &str = "--restore-last-session";
 /// while to flush to disk, and quitting too eagerly would leave Chrome down.
 const QUIT_TIMEOUT: Duration = Duration::from_secs(45);
 
+/// Marker file recording the user's one-time consent for chrome-use to restart
+/// their Chrome to remove the debugging banner. Captured interactively at
+/// install time (real TTY), then honoured at runtime so agent-driven connects —
+/// which have no TTY to prompt on — can silence the banner without asking again.
+fn consent_path() -> PathBuf {
+    crate::connection::config_home().join("silence-consent")
+}
+
+/// Record (or clear) the install-time consent to auto-restart Chrome for the
+/// banner. Best-effort: a write failure just means we'll ask again next time.
+pub fn store_silence_consent(granted: bool) {
+    let path = consent_path();
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if granted {
+        let _ = std::fs::write(&path, "1\n");
+    } else {
+        // Persist an explicit denial so we don't re-prompt on every install.
+        let _ = std::fs::write(&path, "0\n");
+    }
+}
+
+/// Whether the user granted consent to auto-restart Chrome for the banner.
+pub fn has_silence_consent() -> bool {
+    match std::fs::read_to_string(consent_path()) {
+        Ok(s) => s.trim() == "1",
+        Err(_) => false,
+    }
+}
+
 /// How to treat the banner during `extension connect`.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SilenceMode {
@@ -110,6 +141,10 @@ pub fn ensure_banner_silenced(mode: SilenceMode) -> SilenceOutcome {
         SilenceMode::Auto => {
             if interactive() {
                 confirm_restart()
+            } else if has_silence_consent() {
+                // No TTY to ask on (agent-driven), but the user already granted
+                // consent at install time — proceed to restart silently.
+                true
             } else {
                 eprintln!(
                     "{} Chrome will show a \"started debugging this browser\" banner. Run \
@@ -171,6 +206,55 @@ pub fn restart_chrome_preserving_session() -> Result<bool, String> {
     graceful_quit(&rc)?;
     relaunch(&rc)?;
     Ok(true)
+}
+
+/// Called at the tail of `extension install`. install.sh wires the real
+/// terminal in (`chrome-use extension install < /dev/tty > /dev/tty`), so this
+/// is the one moment a human is present to answer. Ask once whether chrome-use
+/// may restart Chrome to remove the debugging banner, persist the answer (so
+/// later agent-driven connects — which have no TTY — silence without asking),
+/// and if granted + Chrome is up, silence it right now. No-op without a TTY
+/// (piped/CI installs), leaving consent unset.
+pub fn offer_install_time_consent() {
+    if !interactive() {
+        return;
+    }
+    eprintln!(
+        "\n  Chrome shows a \"…started debugging this browser\" banner while chrome-use drives it."
+    );
+    eprintln!(
+        "  Removing it needs a one-time Chrome restart whenever chrome-use connects — your tabs \
+         and logins are restored automatically (~2s)."
+    );
+    eprint!("  Let chrome-use handle this for you from now on? [Y/n] ");
+    let _ = io::stderr().flush();
+
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_err() {
+        return;
+    }
+    let a = input.trim().to_lowercase();
+    let granted = a.is_empty() || a == "y" || a == "yes";
+    store_silence_consent(granted);
+
+    if !granted {
+        eprintln!(
+            "  ok — leaving the banner. Run `chrome-use extension connect --silent` anytime to remove it."
+        );
+        return;
+    }
+    eprintln!("  ✓ saved — chrome-use will silence the banner automatically from now on.");
+    // Consent is now stored; do the first silence immediately if Chrome is up.
+    // Use Force (not Auto) so we don't re-prompt — the user just said yes.
+    match ensure_banner_silenced(SilenceMode::Force) {
+        SilenceOutcome::Restarted => eprintln!("  ✓ Chrome restarted — banner removed."),
+        SilenceOutcome::Ambiguous(n) => eprintln!(
+            "  ({n} Chrome instances are running — will silence on a future single-instance connect.)"
+        ),
+        // NotRunning / AlreadySilent / Declined / Failed → nothing to show now;
+        // the stored consent takes effect on the next connect.
+        _ => {}
+    }
 }
 
 /// Both stdin and stderr are TTYs, so a confirm prompt is safe.

--- a/install.sh
+++ b/install.sh
@@ -99,6 +99,19 @@ mv "$tmp/${BIN_NAME}" "$bindir/${BIN_NAME}"
 info "installed -> ${bindir}/${BIN_NAME}"
 "$bindir/${BIN_NAME}" --version 2>/dev/null || true
 
+# --- guided setup: install the Chrome extension + banner preference -----------
+# When a real terminal is available (works even under `curl … | sh`, whose stdin
+# is the piped script — we borrow /dev/tty), run the guided native-host +
+# extension install and ask once whether chrome-use may auto-restart Chrome to
+# remove the "started debugging this browser" banner. Non-fatal: a declined or
+# failed setup never breaks the binary install. Skip with AGENT_BROWSER_NO_SETUP=1.
+if [ -e /dev/tty ] && [ -z "${AGENT_BROWSER_NO_SETUP:-}" ]; then
+  info "setting up the Chrome extension + debugging-banner preference..."
+  "$bindir/${BIN_NAME}" extension install < /dev/tty > /dev/tty 2>&1 || true
+else
+  info "skipped extension setup (no terminal). Run \`${BIN_NAME} extension install\` later."
+fi
+
 case ":$PATH:" in
   *":$bindir:"*) : ;;
   *) printf '\033[33mnote:\033[0m %s is not on your PATH. Add:\n  export PATH="%s:$PATH"\n' "$bindir" "$bindir" >&2 ;;


### PR DESCRIPTION
`curl … | sh` now does a complete setup, and the "chrome-use started debugging this browser" banner is handled without leaving agent-driven sessions stuck (the top support question).

**Constraint:** the banner is Chrome's `chrome.debugger` attach infobar — only shows in connect mode, can't be dismissed at runtime; the only suppressant is launching Chrome with `--silent-debugger-extension-api`, which can't be injected into a running Chrome → removing it needs a one-time restart. Agent-driven usage is non-interactive, so the old Auto mode just printed a hint and left the banner (the human was never asked). Fix: capture consent once at install time (real TTY), auto-silence at runtime using it.

| Piece | Change |
|---|---|
| install.sh | After the binary lands, run guided `extension install` wired to `/dev/tty` (works under `curl \| sh`), so extension setup + banner preference happen in one command. Non-fatal; skipped w/o a terminal or `AGENT_BROWSER_NO_SETUP=1`. |
| silence.rs | Consent marker at `~/.chrome-use/silence-consent` (`store_silence_consent`/`has_silence_consent`). Auto mode now proceeds when there's no TTY **but** install-time consent was granted — agent connects silence without re-asking. All safety preserved (single-instance-only, graceful quit, `--restore-last-session`). |
| offer_install_time_consent() | Tail of `extension install` asks once (TTY only) whether chrome-use may auto-restart Chrome for the banner, persists it, and if granted + Chrome up, silences now (Force → no double-prompt). |

Deliberately **not** broadened to implicit auto-connect: restarting the user's Chrome mid-session is more disruptive than the banner. Silence engages at install (Chrome running) and on explicit `extension connect`/`reconnect`.

Verified: cargo build + clippy -D warnings (CI cmd) clean, cargo test **1012 + 2 passed / 0 failed**, `sh -n install.sh` clean.

https://claude.ai/code/session_01UNBcDSncWtGDEfe89pFvUZ