### PR TITLE
feat(console): console --limit N tails the last N entries (#110)

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2342,7 +2342,17 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
         }
         "console" => {
             let clear = rest.contains(&"--clear");
-            Ok(json!({ "id": id, "action": "console", "clear": clear }))
+            // `--limit N` tails the last N console entries (#110).
+            let limit = rest
+                .iter()
+                .position(|a| *a == "--limit")
+                .and_then(|i| rest.get(i + 1))
+                .and_then(|v| v.parse::<usize>().ok());
+            let mut cmd = json!({ "id": id, "action": "console", "clear": clear });
+            if let Some(n) = limit {
+                cmd["limit"] = json!(n);
+            }
+            Ok(cmd)
         }
         "errors" => {
             let clear = rest.contains(&"--clear");

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -5466,7 +5466,11 @@ async fn handle_console(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
         state.event_tracker.clear_console();
         Ok(json!({ "cleared": true }))
     } else {
-        let mut result = state.event_tracker.get_console_json();
+        let limit = cmd
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as usize);
+        let mut result = state.event_tracker.get_console_json(limit);
         if !console_capture_active(state) {
             if let Some(obj) = result.as_object_mut() {
                 obj.insert("hint".to_string(), json!(CONSOLE_DISABLED_HINT));

--- a/cli/src/native/network.rs
+++ b/cli/src/native/network.rs
@@ -418,10 +418,17 @@ impl EventTracker {
         self.console_entries.clear();
     }
 
-    pub fn get_console_json(&self) -> Value {
+    pub fn get_console_json(&self, limit: Option<usize>) -> Value {
+        // `--limit N` tails the last N entries (newest kept), for a quick peek at
+        // what just happened without dumping a long session (#110).
+        let start = match limit {
+            Some(n) => self.console_entries.len().saturating_sub(n),
+            None => 0,
+        };
         let messages: Vec<Value> = self
             .console_entries
             .iter()
+            .skip(start)
             .map(|e| {
                 let mut msg = json!({ "type": e.level, "text": e.text });
                 if !e.args.is_empty() {
@@ -512,7 +519,7 @@ mod tests {
         ];
         tracker.add_console("log", "hello 42", raw_args);
 
-        let result = tracker.get_console_json();
+        let result = tracker.get_console_json(None);
         let messages = result.get("messages").unwrap().as_array().unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].get("text").unwrap(), "hello 42");
@@ -527,9 +534,45 @@ mod tests {
         let mut tracker = EventTracker::new();
         tracker.add_console("log", "text only", vec![]);
 
-        let result = tracker.get_console_json();
+        let result = tracker.get_console_json(None);
         let messages = result.get("messages").unwrap().as_array().unwrap();
         assert!(messages[0].get("args").is_none());
+    }
+
+    #[test]
+    fn test_console_json_limit_tails_newest() {
+        let mut tracker = EventTracker::new();
+        for i in 0..5 {
+            tracker.add_console("log", &format!("m{i}"), vec![]);
+        }
+        // limit keeps the last N (newest), in order
+        let msgs = tracker.get_console_json(Some(2));
+        let arr = msgs.get("messages").unwrap().as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].get("text").unwrap(), "m3");
+        assert_eq!(arr[1].get("text").unwrap(), "m4");
+        // limit larger than the buffer returns everything
+        assert_eq!(
+            tracker
+                .get_console_json(Some(99))
+                .get("messages")
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .len(),
+            5
+        );
+        // None returns everything
+        assert_eq!(
+            tracker
+                .get_console_json(None)
+                .get("messages")
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .len(),
+            5
+        );
     }
 
     // -- format_console_arg: primitives --

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2887,12 +2887,13 @@ Examples:
             r##"
 chrome-use console - View console logs
 
-Usage: chrome-use console [--clear]
+Usage: chrome-use console [--clear] [--limit N]
 
 View browser console output (log, warn, error, info).
 
 Options:
   --clear              Clear console log buffer
+  --limit N            Show only the last N entries (newest kept)
 
 Global Options:
   --json               Output as JSON
@@ -2900,6 +2901,7 @@ Global Options:
 
 Examples:
   chrome-use console
+  chrome-use console --limit 20
   chrome-use console --clear
 "##
         }
@@ -3670,7 +3672,7 @@ Debug:
   profiler start|stop [path] Record Chrome DevTools profile
   record start <path> [url]  Start video recording (WebM)
   record stop                Stop and save video
-  console [--clear]          View console logs
+  console [--clear] [--limit N]  View console logs (--limit tails last N)
   errors [--clear]           View page errors
   highlight <sel>            Highlight element
   inspect                    Open Chrome DevTools for the active page


### PR DESCRIPTION
Addresses the `console --limit` item from #110 (ported from browser-relay). `console` had `--clear` only; `--limit N` keeps the last N entries (newest). `get_console_json(limit)` slices to the last N; help text updated. Other #110 items (HTTP REST API; URL downloads needing the ext `downloads` permission) stay tracked. Verified: build + clippy -D clean, test 1015+2 / 0 failed.

https://claude.ai/code/session_01UNBcDSncWtGDEfe89pFvUZ