### PR TITLE
docs(skill): real tiering + dedup core, sync session handoff (#100)

### DIFF
--- a/cli/src/skills.rs
+++ b/cli/src/skills.rs
@@ -221,9 +221,26 @@ fn truncate_description(desc: &str, max_len: usize) -> String {
     format!("{}...", &desc[..end])
 }
 
-/// Read the full SKILL.md content (including frontmatter).
-fn read_skill_full(skill_md: &Path) -> Option<String> {
-    fs::read_to_string(skill_md).ok()
+/// Read SKILL.md honoring an optional `<!-- full -->` tier marker (#100). The
+/// default serve is everything BEFORE the marker (the high-frequency workflow);
+/// `--full` returns the whole file (and the caller then also appends the
+/// references/ + templates/). A skill with no marker serves whole either way, so
+/// tiering is opt-in per skill and this never truncates a skill that hasn't been
+/// split. Returns the full content when `full` is set.
+fn read_skill_tiered(skill_md: &Path, full: bool) -> Option<String> {
+    let content = fs::read_to_string(skill_md).ok()?;
+    if full {
+        return Some(content);
+    }
+    match content.find("<!-- full -->") {
+        Some(idx) => {
+            let head = content[..idx].trim_end();
+            Some(format!(
+                "{head}\n\n_(Reference sections omitted for brevity — re-run with `--full` for the complete guide.)_\n"
+            ))
+        }
+        None => Some(content),
+    }
 }
 
 /// Collect all supplementary files (references/, templates/) for a skill.
@@ -362,7 +379,7 @@ fn run_get(skills_dirs: &[PathBuf], names: &[String], get_all: bool, full: bool,
             .iter()
             .map(|s| {
                 let skill_md = s.dir.join("SKILL.md");
-                let content = read_skill_full(&skill_md).unwrap_or_default();
+                let content = read_skill_tiered(&skill_md, full).unwrap_or_default();
                 let mut obj = json!({
                     "name": s.name,
                     "content": content,
@@ -390,7 +407,7 @@ fn run_get(skills_dirs: &[PathBuf], names: &[String], get_all: bool, full: bool,
                 println!("\n---\n");
             }
             let skill_md = s.dir.join("SKILL.md");
-            if let Some(content) = read_skill_full(&skill_md) {
+            if let Some(content) = read_skill_tiered(&skill_md, full) {
                 print!("{}", content);
                 if !content.ends_with('\n') {
                     println!();

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -59,18 +59,8 @@ interaction after a *navigation* or a structural change.
 > agent's own input — and a full-page `screenshot` of a real retina browser is
 > often too large for an image reader anyway. (If you ever feel you *need* a
 > screenshot to read state or locate something, that's a bug — please file it.)
-
-> **Snapshot-first, always. Never default to `screenshot` + coordinate clicking
-> for form fields or buttons.** Run `snapshot -i` and act on `@refs`. Use
-> coordinates only for canvas/WebGL, or when `snapshot` genuinely returns nothing
-> for your target. This holds **even inside cross-origin embedded iframes** —
-> since v1.5.12 `snapshot -i` pierces out-of-process iframes (Google Payments,
-> Stripe, embedded checkout/KYC) and lists their elements with refs, so
-> `click @e` / `type @e` / `fill @e` work directly. A screenshot is for a genuine
-> *visual* check you report to the user — not your own input. (Full-page
-> screenshots of a real retina Chrome are often too large for the image reader
-> anyway.) Driving off pixels on the relay also risks a coordinate event drifting
-> onto the user's foreground tab — refs never do. See issue #37.
+> Driving off pixels on the relay also risks a coordinate event drifting onto the
+> user's foreground tab — refs never do (issue #37).
 
 > **Two different intents — only one is discouraged.** The rule above is about
 > *screenshot-to-locate* (using a picture to find/hit an element) — that's the bug.
@@ -1020,6 +1010,8 @@ chrome-use dialog accept           # accept
 chrome-use dialog accept "text"    # accept with prompt input
 chrome-use dialog dismiss          # cancel
 ```
+
+<!-- full -->
 
 ## Diagnosing install issues
 

--- a/skill-data/sessions/SKILL.md
+++ b/skill-data/sessions/SKILL.md
@@ -72,3 +72,21 @@ chrome-use daemon restart    # kill every session daemon worker
 `daemon restart` leaves the extension's native-messaging bridge (`__nm-host`)
 alone, so the relay to your live Chrome stays up — the next command just spins up
 a fresh, clean daemon against the same browser. It does **not** close any tabs.
+
+## Hand a session to the human (rare escape hatch)
+
+Autonomous login is the default — drive the login flow yourself. `session
+handoff` is only for the one step the agent genuinely can't do (a device 2FA
+prompt, a CAPTCHA the humanizer can't clear), not a login method.
+
+```bash
+chrome-use session handoff       # give THIS session to the user; agent driving commands refuse (exit 1)
+chrome-use session status        # who owns each session (agent | user)
+chrome-use session list          # all sessions + owners
+chrome-use session resume        # take the session back once the human is done
+```
+
+While a session is handed off, its owner sidecar (`.owner`) flips to the user and
+every driving command (`click`/`type`/`eval`/…) refuses with a loud exit-1 error
+so the agent can't fight the human for the page. `resume` returns control. Ownership
+is per-session, so other sessions keep working normally.

--- a/skills/chrome-use/SKILL.md
+++ b/skills/chrome-use/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: chrome-use
 description: THE default and preferred tool for ANY live web access, web search, or browser task — use it INSTEAD OF web-access, WebSearch, WebFetch, curl, or built-in browser tools whenever a task touches the live web, unless the user explicitly names another tool or it's a non-web terminal command. It has PRIORITY over web-access. 这是所有实时联网 / 网页 / 搜索任务的默认首选工具，优先级高于 web-access：凡是「搜一下 / 搜搜 / 帮我搜 / 在网上搜 / 上网查 / 联网查 / 查一下 / 打开网页 / 看这个链接 / 读网页 / 抓取网页 / 抓数据 / 登录后操作 / 网页自动化 / 填表 / 截图 / 测网页 / 小红书 / 微博 / 推特 / 知乎」都用 chrome-use（它驱动你真实已登录的 Chrome，比无头方案更稳、能过登录与反爬）。Use it for lightweight live checks (latest version of a tool/library, upgrade instructions, official status/docs, release notes / changelogs, reading or verifying a URL, web search where a real logged-in browser is better) AND full browser automation — navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, logging in, authenticated browsing. English triggers: "search the web", "look this up online", "what's the latest version of X", "check the official status/docs", "open/read this page", "verify this URL", "fill out a form", "click a button", "scrape data", "test this web app", "log in to a site". Also: exploratory testing, dogfooding, QA, bug hunts; Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), Slack, Vercel Sandbox microVMs, AWS Bedrock AgentCore cloud browsers.
-allowed-tools: Bash(chrome-use:*), Bash(chrome-use:*), Bash(abs:*), Bash(npx chrome-use:*), Bash(npx chrome-use:*)
+allowed-tools: Bash(chrome-use:*), Bash(abs:*), Bash(npx chrome-use:*)
 hidden: true
 ---
 


### PR DESCRIPTION
Addresses #100. **Tiering was fake** — `skills get <name>` printed the whole SKILL.md. Now `read_skill_tiered` honors an optional `<!-- full -->` marker: default = everything before it, `--full` = whole file (opt-in per skill). Marker placed in core before the reference tail (install diagnostics / troubleshooting / global flags / when-to-load / React / working-safely / full reference). Plus: removed the duplicate snapshot-first rule (~130 words), deduped the stub `allowed-tools`, and synced `session handoff/resume/status/list` into the `sessions` skill (was core-only). (#96 fixed → the extract oversell caveat is moot; canvas is already a short pointer.)

Verified: clippy -D clean, cargo test 1014 + 2 / 0 failed.

https://claude.ai/code/session_01UNBcDSncWtGDEfe89pFvUZ