### PR TITLE
feat(tabs): add native tab duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,17 @@ chrome-use click "Post"
 chrome-use click 449 320            # …or click a raw viewport coordinate
 chrome-use fill "Title" "Hello World"
 chrome-use screenshot ./page.png
+
+# Native Duplicate tab on extension-connected real Chrome. The copy stays in
+# the background and becomes chrome-use's internal active tab.
+chrome-use tab duplicate --label working-copy
 ```
+
+`tab duplicate [ref] [--label <name>]` uses Chrome's native Duplicate tab
+operation and preserves its navigation history. It requires the browser
+extension path and never falls back to opening the same URL on launched Chrome,
+raw CDP, Lightpanda, or cloud providers. Chrome controls whether a background
+duplicate starts loading.
 
 The agent operates in your Chrome — you'll see tabs opening, pages loading, clicks happening in real time. You can take over at any point (e.g. solve a CAPTCHA), then let the agent continue.
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2134,6 +2134,37 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     }
                     Ok(cmd)
                 }
+                Some("duplicate") => {
+                    // Accepted forms:
+                    //   tab duplicate [ref]
+                    //   tab duplicate --label <name> [ref]
+                    //   tab duplicate [ref] --label <name>
+                    let mut cmd = json!({ "id": id, "action": "tab_duplicate" });
+                    let mut i = 1;
+                    while i < rest.len() {
+                        match rest[i] {
+                            "--label" => {
+                                let name = rest.get(i + 1).ok_or(ParseError::MissingArguments {
+                                    context: "tab duplicate --label".to_string(),
+                                    usage: "tab duplicate [ref] --label <name>",
+                                })?;
+                                cmd["label"] = json!(name);
+                                i += 2;
+                            }
+                            other if !other.starts_with("--") && cmd.get("tabId").is_none() => {
+                                cmd["tabId"] = json!(other);
+                                i += 1;
+                            }
+                            other => {
+                                return Err(ParseError::UnknownSubcommand {
+                                    subcommand: other.to_string(),
+                                    valid_options: &["--label", "<ref>"],
+                                });
+                            }
+                        }
+                    }
+                    Ok(cmd)
+                }
                 Some("list") => {
                     let mut cmd = json!({ "id": id, "action": "tab_list" });
                     if full {
@@ -5571,6 +5602,34 @@ mod tests {
         let cmd = parse_command(&args("tab new https://example.com"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "tab_new");
         assert_eq!(cmd["url"], "https://example.com");
+    }
+
+    #[test]
+    fn test_tab_duplicate_current() {
+        let cmd = parse_command(&args("tab duplicate"), &default_flags()).unwrap();
+        assert_eq!(cmd["action"], "tab_duplicate");
+        assert!(cmd.get("tabId").is_none());
+        assert!(cmd.get("label").is_none());
+    }
+
+    #[test]
+    fn test_tab_duplicate_by_ref_with_label() {
+        let cmd = parse_command(
+            &args("tab duplicate docs --label docs-copy"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "tab_duplicate");
+        assert_eq!(cmd["tabId"], "docs");
+        assert_eq!(cmd["label"], "docs-copy");
+
+        let target = parse_command(
+            &args("tab duplicate 0123456789ABCDEF --label target-copy"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(target["tabId"], "0123456789ABCDEF");
+        assert_eq!(target["label"], "target-copy");
     }
 
     #[test]

--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -2441,6 +2441,13 @@ async fn nm_host_main() {
         // `doctor` can report which extension build is live (and whether it's
         // behind). Best-effort; the message carries no CDP payload.
         if v.get("method").and_then(|m| m.as_str()) == Some("hello") {
+            let capabilities = v
+                .get("capabilities")
+                .and_then(|x| x.as_array())
+                .into_iter()
+                .flatten()
+                .filter_map(|x| x.as_str().map(ToString::to_string));
+            state.lock().await.set_extension_capabilities(capabilities);
             if let Some(ver) = v.get("version").and_then(|x| x.as_str()) {
                 let _ = std::fs::write(relay_ext_version_path(), ver);
             }

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -475,12 +475,12 @@ fn extended_tools() -> Vec<Value> {
         }),
         json!({
             "name": TOOL_TABS,
-            "description": "List, open, close, or switch browser tabs.",
+            "description": "List, open, duplicate, close, or switch browser tabs.",
             "inputSchema": build_schema(obj(&[
-                ("action", json!({ "type": "string", "enum": ["list", "new", "close", "switch"], "description": "Tab operation to perform." })),
+                ("action", json!({ "type": "string", "enum": ["list", "new", "duplicate", "close", "switch"], "description": "Tab operation to perform." })),
                 ("url", json!({ "type": "string", "description": "With action=new: URL to open in the new tab." })),
-                ("label", json!({ "type": "string", "description": "With action=new: assign this label to the tab (--label)." })),
-                ("tabId", json!({ "type": "string", "description": "Tab id or label (e.g. t1, docs). Required for action=switch; optional for action=close (defaults to current tab)." })),
+                ("label", json!({ "type": "string", "description": "With action=new or duplicate: assign this label to the new tab (--label)." })),
+                ("tabId", json!({ "type": "string", "description": "Tab id, label, or stable target ID. Required for action=switch; optional for action=close or duplicate (defaults to current tab)." })),
                 ("activate", json!({ "type": "boolean", "description": "With action=switch: also raise the tab to the foreground (--activate)." })),
                 ("full", json!({ "type": "boolean", "description": "With action=list: emit untruncated tab URLs (--full)." })),
             ]), &["action"]),
@@ -969,9 +969,13 @@ fn call_scroll(arguments: &Value) -> Result<Value, ProtocolError> {
     run_tool(arguments, args)
 }
 
-/// `tab list [--full]` | `tab new [url] [--label <name>]` | `tab close
-/// [tabId]` | `tab <tabId> [--activate]`.
+/// `tab list [--full]` | `tab new [url] [--label <name>]` | `tab duplicate
+/// [tabId] [--label <name>]` | `tab close [tabId]` | `tab <tabId> [--activate]`.
 fn call_tabs(arguments: &Value) -> Result<Value, ProtocolError> {
+    run_tool(arguments, tabs_args(arguments)?)
+}
+
+fn tabs_args(arguments: &Value) -> Result<Vec<String>, ProtocolError> {
     let action = required_string(arguments, "action")?;
     let mut args = vec!["tab".to_string()];
     match action.as_str() {
@@ -991,6 +995,16 @@ fn call_tabs(arguments: &Value) -> Result<Value, ProtocolError> {
                 args.push(url);
             }
         }
+        "duplicate" => {
+            args.push("duplicate".to_string());
+            if let Some(tab_id) = optional_string(arguments, "tabId")? {
+                args.push(tab_id);
+            }
+            if let Some(label) = optional_string(arguments, "label")? {
+                args.push("--label".to_string());
+                args.push(label);
+            }
+        }
         "close" => {
             args.push("close".to_string());
             if let Some(tab_id) = optional_string(arguments, "tabId")? {
@@ -1006,12 +1020,12 @@ fn call_tabs(arguments: &Value) -> Result<Value, ProtocolError> {
         }
         other => {
             return Err(ProtocolError::invalid_params(format!(
-                "chrome_use_tabs: unknown action '{}' (use list, new, close, or switch)",
+                "chrome_use_tabs: unknown action '{}' (use list, new, duplicate, close, or switch)",
                 other
             )))
         }
     }
-    run_tool(arguments, args)
+    Ok(args)
 }
 
 /// `extract [--frame <f>] --schema <json>`.
@@ -1625,6 +1639,26 @@ fn write_json_line(stdout: &mut io::Stdout, value: &Value) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tabs_duplicate_maps_to_cli_contract() {
+        let current = tabs_args(&json!({ "action": "duplicate" }))
+            .ok()
+            .expect("duplicate action should map to the CLI");
+        assert_eq!(current, vec!["tab", "duplicate"]);
+
+        let selected = tabs_args(&json!({
+            "action": "duplicate",
+            "tabId": "docs",
+            "label": "docs-copy"
+        }))
+        .ok()
+        .expect("duplicate action with ref and label should map to the CLI");
+        assert_eq!(
+            selected,
+            vec!["tab", "duplicate", "docs", "--label", "docs-copy"]
+        );
+    }
 
     const CORE_TOOL_NAMES: &[&str] = &[
         TOOL_OPEN,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1523,6 +1523,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             "pdf" => handle_pdf(cmd, state).await,
             "tab_list" => handle_tab_list(cmd, state).await,
             "tab_new" => handle_tab_new(cmd, state).await,
+            "tab_duplicate" => handle_tab_duplicate(cmd, state).await,
             "tab_switch" => handle_tab_switch(cmd, state).await,
             "tab_close" => handle_tab_close(cmd, state).await,
             "viewport" => handle_viewport(cmd, state).await,
@@ -1776,7 +1777,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             // so screencasting always targets the correct page.
             if matches!(
                 action,
-                "tab_new" | "tab_switch" | "tab_close" | "open" | "navigate"
+                "tab_new" | "tab_duplicate" | "tab_switch" | "tab_close" | "open" | "navigate"
             ) {
                 let session_id = mgr.active_session_id().ok().map(|s| s.to_string());
                 server.set_cdp_session_id(session_id).await;
@@ -6539,6 +6540,27 @@ async fn handle_tab_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
         .as_ref()
         .and_then(|m| m.active_session_id().ok())
         .map(|s| s.to_string())
+    {
+        apply_stealth_to_session(state, &sid).await;
+    }
+    Ok(result)
+}
+
+async fn handle_tab_duplicate(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let source_ref = cmd.get("tabId").and_then(|v| v.as_str());
+    let label = cmd.get("label").and_then(|v| v.as_str());
+    state.ref_map.clear();
+    state.iframe_sessions.clear();
+    state.active_frame_id = None;
+    let result = {
+        let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
+        mgr.tab_duplicate(source_ref, label).await?
+    };
+    if let Some(sid) = state
+        .browser
+        .as_ref()
+        .and_then(|m| m.active_session_id().ok())
+        .map(ToString::to_string)
     {
         apply_stealth_to_session(state, &sid).await;
     }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -6549,13 +6549,13 @@ async fn handle_tab_new(cmd: &Value, state: &mut DaemonState) -> Result<Value, S
 async fn handle_tab_duplicate(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let source_ref = cmd.get("tabId").and_then(|v| v.as_str());
     let label = cmd.get("label").and_then(|v| v.as_str());
-    state.ref_map.clear();
-    state.iframe_sessions.clear();
-    state.active_frame_id = None;
     let result = {
         let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
         mgr.tab_duplicate(source_ref, label).await?
     };
+    state.ref_map.clear();
+    state.iframe_sessions.clear();
+    state.active_frame_id = None;
     if let Some(sid) = state
         .browser
         .as_ref()
@@ -11919,6 +11919,32 @@ fn error_response(id: &str, error: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn tab_duplicate_failure_preserves_active_tab_context() {
+        let mut state = DaemonState::new();
+        state
+            .ref_map
+            .add("e1".to_string(), Some(42), "button", "Keep", None);
+        state
+            .iframe_sessions
+            .insert("frame-1".to_string(), "session-1".to_string());
+        state.active_frame_id = Some("frame-1".to_string());
+
+        let response = execute_command(
+            &json!({ "id": "duplicate-failure", "action": "tab_duplicate" }),
+            &mut state,
+        )
+        .await;
+
+        assert_eq!(response["success"], false);
+        assert!(state.ref_map.get("e1").is_some());
+        assert_eq!(
+            state.iframe_sessions.get("frame-1").map(String::as_str),
+            Some("session-1")
+        );
+        assert_eq!(state.active_frame_id.as_deref(), Some("frame-1"));
+    }
     use crate::test_utils::EnvGuard;
     use std::fs;
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -429,7 +429,8 @@ pub fn to_ai_friendly_error(error: &str) -> String {
 pub struct PageInfo {
     pub tab_id: u32,
     /// Optional user-assigned label (e.g. "docs", "app"). Set via
-    /// `tab new --label <name>`. Labels are agent-assigned and never
+    /// `tab new --label <name>` or `tab duplicate --label <name>`. Labels are
+    /// agent-assigned and never
     /// auto-generated, never rewritten on navigation, and unique within a
     /// session. Agents use labels instead of `t<N>` for readable multi-tab
     /// workflows.
@@ -1781,8 +1782,9 @@ impl BrowserManager {
             // they don't pile up in the user's window (in their per-session tab
             // group) every time a session ends, idles out, or the daemon shuts
             // down. `created_targets` only holds tabs we made via
-            // Target.createTarget — never the user's existing tabs or other
-            // sessions' — so this is always safe. Best-effort per tab.
+            // Target.createTarget or native duplicate — never the user's
+            // existing tabs or other sessions' — so this is always safe.
+            // Best-effort per tab.
             for target_id in self.created_targets.drain() {
                 let _ = self
                     .client
@@ -2377,6 +2379,22 @@ impl BrowserManager {
         }
     }
 
+    /// Best-effort rollback for a tab that Chrome created but the daemon could
+    /// not finish registering. The extension owns the underlying Chrome tab,
+    /// so closing the stable target also clears its persisted ownership entry.
+    async fn discard_created_target(&self, target_id: &str) {
+        let _ = self
+            .client
+            .send_command_typed::<_, Value>(
+                "Target.closeTarget",
+                &CloseTargetParams {
+                    target_id: target_id.to_string(),
+                },
+                None,
+            )
+            .await;
+    }
+
     pub async fn tab_new(
         &mut self,
         url: Option<&str>,
@@ -2460,6 +2478,165 @@ impl BrowserManager {
             "tabId": format_tab_id(tab_id),
             "label": label,
             "url": target_url,
+            "total": self.pages.len(),
+        }))
+    }
+
+    /// Duplicate a tab with Chrome's native duplicate primitive exposed by the
+    /// `ab-connect` extension. URL-based recreation is deliberately unsupported:
+    /// it does not preserve Chrome's duplicate-tab semantics.
+    pub async fn tab_duplicate(
+        &mut self,
+        source_ref: Option<&str>,
+        label: Option<&str>,
+    ) -> Result<Value, String> {
+        if !self.via_relay() || !self.relay_scoped {
+            return Err(
+                "Native tab duplication requires extension-connected real Chrome; it is not \
+                 available for launched Chrome, raw CDP, Lightpanda, or providers without the \
+                 ab-connect duplicate capability"
+                    .to_string(),
+            );
+        }
+        // The relay endpoint can become discoverable just before the extension's
+        // asynchronous hello reaches it. Retry briefly so a command issued at
+        // startup does not misclassify a capable extension as unsupported.
+        let mut supports_duplicate = false;
+        for attempt in 0..10 {
+            let capabilities: Value = self
+                .client
+                .send_command_typed("ABRelay.getCapabilities", &json!({}), None)
+                .await
+                .map_err(|_| {
+                    "Native tab duplication is unavailable because the connected relay does not \
+                     advertise extension capabilities"
+                        .to_string()
+                })?;
+            supports_duplicate = capabilities
+                .get("capabilities")
+                .and_then(Value::as_array)
+                .is_some_and(|items| items.iter().any(|item| item == "nativeTabDuplicate"));
+            if supports_duplicate || attempt == 9 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        if !supports_duplicate {
+            return Err(
+                "Native tab duplication is unavailable in the connected extension; update the \
+                 chrome-use extension to a build that advertises `nativeTabDuplicate`"
+                    .to_string(),
+            );
+        }
+        self.resync_targets().await.ok();
+        if let Some(label) = label {
+            if !is_valid_label(label) {
+                return Err(format!(
+                    "Invalid tab label `{}`; labels must start with a letter and contain only \
+                     letters, digits, `-`, and `_`",
+                    label
+                ));
+            }
+            if self.has_label(label) {
+                return Err(format!(
+                    "Label `{}` is already used by another tab; labels must be unique within a \
+                     session",
+                    label
+                ));
+            }
+        }
+
+        let source_index = match source_ref {
+            Some(value) => match self.pages.iter().position(|p| p.target_id == value) {
+                Some(index) => index,
+                None => {
+                    let tab_ref = TabRef::parse(value)?;
+                    let tab_id = self.resolve_tab_ref(&tab_ref)?;
+                    self.pages
+                        .iter()
+                        .position(|p| p.tab_id == tab_id)
+                        .ok_or_else(|| format!("Tab ID {} not found", tab_id))?
+                }
+            },
+            None => self.resolved_active_index(),
+        };
+        let source = self
+            .pages
+            .get(source_index)
+            .cloned()
+            .ok_or_else(|| "No active tab to duplicate".to_string())?;
+        let agent_group = self.agent_group().ok_or_else(|| {
+            "Native tab duplication requires an extension session group".to_string()
+        })?;
+
+        let duplicate: CreateTargetResult = self
+            .client
+            .send_command_typed(
+                "ABExt.duplicateTab",
+                &json!({
+                    "sourceTargetId": source.target_id,
+                    "agentGroup": agent_group,
+                }),
+                None,
+            )
+            .await?;
+
+        let attach: AttachToTargetResult = match self
+            .client
+            .send_command_typed(
+                "Target.attachToTarget",
+                &AttachToTargetParams {
+                    target_id: duplicate.target_id.clone(),
+                    flatten: true,
+                },
+                None,
+            )
+            .await
+        {
+            Ok(attach) => attach,
+            Err(error) => {
+                self.discard_created_target(&duplicate.target_id).await;
+                return Err(format!(
+                    "Native duplicate was created but debugger attachment failed: {}",
+                    error
+                ));
+            }
+        };
+
+        if let Err(error) = self.enable_domains(&attach.session_id).await {
+            self.discard_created_target(&duplicate.target_id).await;
+            return Err(format!(
+                "Native duplicate was created but debugger setup failed: {}",
+                error
+            ));
+        }
+
+        self.created_targets.insert(duplicate.target_id.clone());
+        let source_target_id = source.target_id.clone();
+        let tab_id = self.next_tab_id;
+        self.next_tab_id += 1;
+        let label = label.map(ToString::to_string);
+        let index = self.pages.len();
+        self.pages.push(PageInfo {
+            tab_id,
+            label: label.clone(),
+            target_id: duplicate.target_id.clone(),
+            session_id: attach.session_id,
+            url: source.url,
+            title: source.title,
+            target_type: source.target_type,
+        });
+        self.active_page_index = index;
+        self.pin_active_target();
+
+        Ok(json!({
+            "sourceTabId": format_tab_id(source.tab_id),
+            "sourceTargetId": source_target_id,
+            "tabId": format_tab_id(tab_id),
+            "targetId": duplicate.target_id,
+            "label": label,
+            "duplicated": true,
+            "native": true,
             "total": self.pages.len(),
         }))
     }

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1191,6 +1191,205 @@ async fn e2e_tabs() {
 
 #[tokio::test]
 #[ignore]
+async fn e2e_tab_duplicate_rejects_launched_chrome_without_native_extension_capability() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "2", "action": "tab_duplicate" }), &mut state).await;
+    assert_eq!(resp["success"], false);
+    assert!(
+        resp["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("extension-connected real Chrome"),
+        "unexpected error: {resp}"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Native duplication is extension-only and therefore cannot run in the normal
+/// isolated-launch E2E suite. Set `CHROME_USE_EXTENSION_E2E=1` after loading the
+/// extension from this checkout to exercise the real Chrome path explicitly.
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_duplicate_preserves_native_history_on_extension_connected_chrome() {
+    if std::env::var("CHROME_USE_EXTENSION_E2E").as_deref() != Ok("1") {
+        return;
+    }
+
+    let guard = EnvGuard::new(&["AGENT_BROWSER_AUTO_CONNECT", "AGENT_BROWSER_FORCE_LAUNCH"]);
+    guard.set("AGENT_BROWSER_AUTO_CONNECT", "1");
+    guard.remove("AGENT_BROWSER_FORCE_LAUNCH");
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(&json!({ "id": "1", "action": "launch" }), &mut state).await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "tab_new",
+            "url": "data:text/html,<title>History A</title>",
+            "label": "duplicate-source"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let source = get_data(&resp).clone();
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "navigate",
+            "url": "data:text/html,<title>History B</title>"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "tab_duplicate",
+            "tabId": "duplicate-source",
+            "label": "duplicate-copy"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let duplicate = get_data(&resp).clone();
+    assert_eq!(duplicate["duplicated"], true);
+    assert_eq!(duplicate["native"], true);
+    assert_eq!(duplicate["label"], "duplicate-copy");
+    assert_eq!(duplicate["sourceTargetId"], source["targetId"]);
+    assert!(duplicate.get("targetId").is_some());
+    assert!(
+        duplicate.get("url").is_none(),
+        "duplicate output must not expose URL"
+    );
+
+    let resp = execute_command(&json!({ "id": "4a", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    assert!(tabs.iter().any(|tab| {
+        tab["tabId"] == duplicate["tabId"]
+            && tab["targetId"] == duplicate["targetId"]
+            && tab["active"] == true
+    }));
+    assert!(tabs
+        .iter()
+        .any(|tab| tab["label"] == "duplicate-source" && tab["active"] == false));
+
+    // A URL-recreated tab has no source navigation history. Going back to A is
+    // the observable proof that Chrome's native duplicate primitive was used.
+    let resp = execute_command(&json!({ "id": "5", "action": "back" }), &mut state).await;
+    assert_success(&resp);
+    let resp = execute_command(&json!({ "id": "6", "action": "title" }), &mut state).await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["title"], "History A");
+
+    let stable_target = duplicate["targetId"].as_str().unwrap().to_string();
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "tab_duplicate", "label": "current-copy" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let current_duplicate = get_data(&resp).clone();
+    assert_eq!(current_duplicate["sourceTabId"], duplicate["tabId"]);
+
+    let resp = execute_command(
+        &json!({ "id": "8", "action": "tab_switch", "tabId": "duplicate-source" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "9",
+            "action": "tab_duplicate",
+            "tabId": stable_target,
+            "label": "target-copy"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let target_duplicate = get_data(&resp).clone();
+
+    let resp = execute_command(
+        &json!({
+            "id": "9a",
+            "action": "tab_duplicate",
+            "tabId": source["tabId"],
+            "label": "short-copy"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let short_duplicate = get_data(&resp).clone();
+
+    let resp = execute_command(
+        &json!({ "id": "10", "action": "tab_duplicate", "label": "current-copy" }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false);
+    assert!(resp["error"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("already used"));
+
+    // Closing the duplicate must leave the source tab isolated and usable.
+    let duplicate_tab_id = duplicate["tabId"].as_str().unwrap().to_string();
+    let resp = execute_command(
+        &json!({ "id": "11", "action": "tab_close", "tabId": duplicate_tab_id }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(&json!({ "id": "12", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    assert!(!tabs
+        .iter()
+        .any(|tab| tab["targetId"] == duplicate["targetId"]));
+    assert!(tabs.iter().any(|tab| tab["label"] == "duplicate-source"));
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+
+    // Reconnect after ending the owning session. Its still-open duplicates must
+    // have been removed from Chrome rather than leaking into the next session.
+    let mut state = DaemonState::new();
+    let resp = execute_command(&json!({ "id": "100", "action": "launch" }), &mut state).await;
+    assert_success(&resp);
+    let resp = execute_command(&json!({ "id": "101", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let tabs = get_data(&resp)["tabs"].as_array().unwrap();
+    for closed_target in [
+        current_duplicate["targetId"].as_str().unwrap(),
+        target_duplicate["targetId"].as_str().unwrap(),
+        short_duplicate["targetId"].as_str().unwrap(),
+    ] {
+        assert!(!tabs.iter().any(|tab| tab["targetId"] == closed_target));
+    }
+    let resp = execute_command(&json!({ "id": "102", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+#[tokio::test]
+#[ignore]
 async fn e2e_tab_ids_not_reused() {
     let mut state = DaemonState::new();
 

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -253,7 +253,7 @@ fn minimal_command(action: &str, id: &str) -> Value {
             obj.insert("name".to_string(), json!("parity-test-cred"));
         }
         "tab_switch" | "tab_close" | "tab_duplicate" => {
-            obj.insert("index".to_string(), json!(0));
+            obj.insert("tabId".to_string(), json!("t1"));
         }
         "viewport" | "user_agent" | "set_media" | "timezone" | "locale" | "geolocation"
         | "permissions" | "device" => {
@@ -369,6 +369,18 @@ fn minimal_command(action: &str, id: &str) -> Value {
         _ => {}
     }
     cmd
+}
+
+#[test]
+fn tab_parity_commands_use_tab_references() {
+    for action in ["tab_switch", "tab_close", "tab_duplicate"] {
+        let command = minimal_command(action, "tab-parity");
+        assert_eq!(command["tabId"], "t1", "{action} should exercise tabId");
+        assert!(
+            command.get("index").is_none(),
+            "{action} should not use index"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -99,6 +99,7 @@ const DOCUMENTED_ACTIONS: &[&str] = &[
     "pdf",
     "tab_list",
     "tab_new",
+    "tab_duplicate",
     "tab_switch",
     "tab_close",
     "viewport",
@@ -251,7 +252,7 @@ fn minimal_command(action: &str, id: &str) -> Value {
         "credentials_get" | "credentials_delete" | "auth_show" | "auth_delete" => {
             obj.insert("name".to_string(), json!("parity-test-cred"));
         }
-        "tab_switch" | "tab_close" => {
+        "tab_switch" | "tab_close" | "tab_duplicate" => {
             obj.insert("index".to_string(), json!(0));
         }
         "viewport" | "user_agent" | "set_media" | "timezone" | "locale" | "geolocation"

--- a/cli/src/native/relay.rs
+++ b/cli/src/native/relay.rs
@@ -46,6 +46,9 @@ struct TargetEntry {
 /// client.
 #[derive(Default)]
 pub struct RelayState {
+    /// Capabilities announced by the connected extension. An older extension
+    /// reports none, allowing daemons to fail unsupported operations clearly.
+    extension_capabilities: HashSet<String>,
     /// targetId -> entry
     targets: HashMap<String, TargetEntry>,
     /// relay-global command id -> (client that sent it, its original id)
@@ -61,13 +64,13 @@ pub struct RelayState {
     /// daemon) is absent here and gets the full, UNSCOPED target list — so this
     /// is fully backward-compatible.
     client_groups: HashMap<ClientId, String>,
-    /// targetId -> group name. Created tabs are tagged from `Target.createTarget`'s
-    /// `agentGroup`; an explicitly adopted tab is tagged to the adopter; a pop-up
-    /// inherits its opener's group (needs the extension to report `openerTargetId`).
+    /// targetId -> group name. Created and duplicated tabs are tagged from the
+    /// command's `agentGroup`; an explicitly adopted tab is tagged to the adopter;
+    /// a pop-up inherits its opener's group.
     target_group: HashMap<String, String>,
-    /// relay-global id of an in-flight `Target.createTarget` -> the `agentGroup`
-    /// it carried, so the reply's `targetId` can be tagged with that group.
-    pending_create: HashMap<i64, String>,
+    /// Relay-global id of an in-flight target-creating command to its
+    /// `agentGroup`, so the reply's `targetId` can be tagged with that group.
+    pending_target_group: HashMap<i64, String>,
     /// Sessions of OOPIF (cross-origin iframe) child targets the extension
     /// auto-attached (flat `Target.setAutoAttach`). Unlike the page-level
     /// `cb-tab-*` attaches (which the relay consumes to maintain `targets`),
@@ -105,6 +108,14 @@ impl RelayState {
         Self::default()
     }
 
+    pub fn set_extension_capabilities<I, S>(&mut self, capabilities: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.extension_capabilities = capabilities.into_iter().map(Into::into).collect();
+    }
+
     /// The challenge the relay sends to the extension as soon as it connects,
     /// kicking off the connect handshake.
     pub fn connect_challenge(nonce: &str) -> Value {
@@ -119,6 +130,14 @@ impl RelayState {
     /// Forget a disconnected client's in-flight commands so its orphaned
     /// `pending` entries don't leak.
     pub fn drop_client(&mut self, client_id: ClientId) {
+        let dropped: Vec<i64> = self
+            .pending
+            .iter()
+            .filter_map(|(gid, (cid, _))| (*cid == client_id).then_some(*gid))
+            .collect();
+        for gid in dropped {
+            self.pending_target_group.remove(&gid);
+        }
         self.pending.retain(|_, (cid, _)| *cid != client_id);
         self.client_groups.remove(&client_id);
     }
@@ -158,6 +177,18 @@ impl RelayState {
                     }
                 }
                 ClientRoute::Local(json!({ "id": id, "result": {} }))
+            }
+            "ABRelay.getCapabilities" => {
+                let mut capabilities: Vec<&str> = self
+                    .extension_capabilities
+                    .iter()
+                    .map(String::as_str)
+                    .collect();
+                capabilities.sort_unstable();
+                ClientRoute::Local(json!({
+                    "id": id,
+                    "result": { "capabilities": capabilities }
+                }))
             }
             // Discovery is best-effort and event-driven in real CDP; abs only
             // reads the getTargets result, so an empty ack is enough here.
@@ -228,12 +259,12 @@ impl RelayState {
                 self.next_global_id += 1;
                 let gid = self.next_global_id;
                 self.pending.insert(gid, (client_id, id));
-                // Remember the group a createTarget carries so the reply's
-                // targetId can be tagged to the creating session (issue #40).
-                if method == "Target.createTarget" {
+                // Remember the group a target-creating command carries so its
+                // reply can be attributed even when attach arrives first.
+                if method == "Target.createTarget" || method == "ABExt.duplicateTab" {
                     if let Some(g) = params.get("agentGroup").and_then(|g| g.as_str()) {
                         if !g.is_empty() {
-                            self.pending_create.insert(gid, g.to_string());
+                            self.pending_target_group.insert(gid, g.to_string());
                             self.client_groups
                                 .entry(client_id)
                                 .or_insert_with(|| g.to_string());
@@ -284,9 +315,9 @@ impl RelayState {
             && msg.get("method").is_none()
         {
             let gid = msg.get("id").and_then(|i| i.as_i64());
-            // A createTarget reply: tag the new tab's targetId with the group the
-            // command carried, so it lands in the creating session's scope (#40).
-            if let Some(g) = gid.and_then(|g| self.pending_create.remove(&g)) {
+            // A target-creating reply: tag the new target with the request's
+            // group, including when its attach event arrived before this reply.
+            if let Some(g) = gid.and_then(|g| self.pending_target_group.remove(&g)) {
                 if let Some(tid) = msg
                     .get("result")
                     .and_then(|r| r.get("targetId"))
@@ -753,6 +784,20 @@ mod tests {
             RelayOut::ToClient { to, .. } => assert_eq!(*to, None),
             _ => panic!(),
         }
+
+        let duplicate = s.route_client_command(
+            9,
+            &json!({ "id": 2, "method": "ABExt.duplicateTab", "params": {
+                "sourceTargetId": "source", "agentGroup": "agent-a"
+            } }),
+        );
+        let duplicate_gid = match duplicate {
+            ClientRoute::Forward(v) => v["id"].as_i64().unwrap(),
+            _ => panic!(),
+        };
+        assert!(s.pending_target_group.contains_key(&duplicate_gid));
+        s.drop_client(9);
+        assert!(!s.pending_target_group.contains_key(&duplicate_gid));
     }
 
     #[test]
@@ -775,6 +820,31 @@ mod tests {
             }
             _ => panic!("expected ToExt"),
         }
+    }
+
+    #[test]
+    fn capabilities_are_empty_until_the_extension_announces_them() {
+        let mut s = RelayState::new();
+        let empty =
+            s.route_client_command(1, &json!({ "id": 1, "method": "ABRelay.getCapabilities" }));
+        assert_eq!(
+            empty,
+            ClientRoute::Local(json!({
+                "id": 1,
+                "result": { "capabilities": [] }
+            }))
+        );
+
+        s.set_extension_capabilities(["nativeTabDuplicate"]);
+        let announced =
+            s.route_client_command(1, &json!({ "id": 2, "method": "ABRelay.getCapabilities" }));
+        assert_eq!(
+            announced,
+            ClientRoute::Local(json!({
+                "id": 2,
+                "result": { "capabilities": ["nativeTabDuplicate"] }
+            }))
+        );
     }
 
     // === Group-scoped isolation (issue #40) ===
@@ -804,6 +874,47 @@ mod tests {
                     "targetId": tid, "type": "page", "url": "about:blank", "attached": true } } } }),
             "",
         );
+    }
+
+    #[test]
+    fn duplicate_reply_attributes_target_to_requesting_group() {
+        let mut s = RelayState::new();
+        s.route_client_command(
+            1,
+            &json!({ "id": 1, "method": "ABRelay.setGroup", "params": { "group": "agent-a" } }),
+        );
+        let route = s.route_client_command(
+            1,
+            &json!({ "id": 2, "method": "ABExt.duplicateTab", "params": {
+                "sourceTargetId": "source", "agentGroup": "agent-a"
+            } }),
+        );
+        let gid = match route {
+            ClientRoute::Forward(env) => env["id"].as_i64().unwrap(),
+            _ => panic!("duplicateTab must forward to the extension"),
+        };
+
+        // attachTab announces the target before the extension sends the command
+        // response. The response must still make the target visible to agent-a.
+        s.handle_ext_message(
+            &json!({ "method": "forwardCDPEvent", "params": {
+                "method": "Target.attachedToTarget",
+                "params": { "sessionId": "sd", "targetInfo": {
+                    "targetId": "duplicate", "type": "page", "url": "https://example.com",
+                    "attached": true
+                } }
+            } }),
+            "",
+        );
+        assert!(get_target_ids(&mut s, 1).is_empty());
+
+        s.handle_ext_message(
+            &json!({ "id": gid, "result": {
+                "sourceTargetId": "source", "targetId": "duplicate"
+            } }),
+            "",
+        );
+        assert_eq!(get_target_ids(&mut s, 1), vec!["duplicate"]);
     }
 
     fn get_target_ids(s: &mut RelayState, client: ClientId) -> Vec<String> {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -790,6 +790,7 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             if let Some(total) = data.get("total").and_then(|v| v.as_i64()) {
                 let label_noun = match action {
                     Some("window_new") => "Window opened",
+                    Some("tab_duplicate") => "Tab duplicated",
                     _ => "Tab opened",
                 };
                 let tab_label = data.get("label").and_then(|v| v.as_str());
@@ -2625,8 +2626,16 @@ Operations:
   list                       List open tabs with their ids and labels (default)
   new [url]                  Open a new tab
   new --label <name> [url]   Open a new tab with a label like `docs` or `app`
-  close [t<N>|label]         Close a tab (current if no ref given)
-  <t<N>|label>               Switch to a tab by id or label
+  duplicate [ref]            Natively duplicate a tab (current if no ref given)
+  duplicate [ref] --label <name>
+                             Natively duplicate and label a tab
+  close [ref]                Close a tab (current if no ref given)
+  <ref>                      Switch to a tab
+
+Native duplication requires real Chrome connected through the chrome-use
+extension. It restores the previously visible foreground tab when complete.
+The duplicate becomes chrome-use's internal active tab. There is no URL-based
+fallback for launched Chrome, raw CDP, Lightpanda, or cloud providers.
 
 Global Options:
   --json               Output as JSON
@@ -2638,6 +2647,8 @@ Examples:
   chrome-use tab new
   chrome-use tab new https://example.com
   chrome-use tab new --label docs https://docs.example.com
+  chrome-use tab duplicate
+  chrome-use tab duplicate docs --label docs-copy
   chrome-use tab t2
   chrome-use tab docs
   chrome-use tab close
@@ -3651,7 +3662,10 @@ Storage:
   storage <local|session>    Manage web storage
 
 Tabs:
-  tab [new|list|close|<ref>] Manage tabs (<ref> = t<N>, a label, or a CDP targetId)
+  tab [new|duplicate|list|close|<ref>]
+                             Manage tabs (<ref> = t<N>, a label, or a CDP targetId)
+  tab duplicate [ref] [--label <name>]
+                             Natively duplicate on extension-connected real Chrome
   tab list --full            Full URLs + stable cross-session targetId per tab
   tab <targetId>             Adopt a specific tab (incl. another session's) by its
                              stable targetId, no reload — preserves in-page state

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -380,6 +380,8 @@
 <pre><code><span class="du-prompt">$</span> chrome-use tab                              <span class="du-cmt"># 列出标签（含 tabId 与 label）</span>
 <span class="du-prompt">$</span> chrome-use tab new [url]                    <span class="du-cmt"># 新标签</span>
 <span class="du-prompt">$</span> chrome-use tab new <span class="du-flag">--label</span> docs [url]       <span class="du-cmt"># 带可读 label 的新标签</span>
+<span class="du-prompt">$</span> chrome-use tab duplicate [ref]              <span class="du-cmt"># 原生复制标签，默认复制当前标签</span>
+<span class="du-prompt">$</span> chrome-use tab duplicate docs <span class="du-flag">--label</span> copy <span class="du-cmt"># 按 ref 复制并设置 label</span>
 <span class="du-prompt">$</span> chrome-use tab t2                           <span class="du-cmt"># 按 id 切换</span>
 <span class="du-prompt">$</span> chrome-use tab docs                         <span class="du-cmt"># 按 label 切换</span>
 <span class="du-prompt">$</span> chrome-use tab close                        <span class="du-cmt"># 关闭当前标签</span>
@@ -387,6 +389,11 @@
 <span class="du-prompt">$</span> chrome-use tab close docs                   <span class="du-cmt"># 按 label 关闭</span>
 <span class="du-prompt">$</span> chrome-use window new                       <span class="du-cmt"># 新窗口</span></code></pre>
       </div>
+      <p>
+        原生复制只支持通过 chrome-use 扩展连接的真实 Chrome。命令完成后会恢复此前可见的前台标签，
+        同时让副本成为 chrome-use 内部活动标签。启动型 Chrome、raw CDP、Lightpanda 和云 provider
+        不会退化为同 URL 新建标签；副本是否在后台开始加载仍由 Chrome 决定。
+      </p>
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ ref 属于快照时的活动标签</div>
         守护进程只维护单个活动标签，<code>@eN</code> 归属于快照运行时的那个标签。要操作另一个标签，

--- a/docs/en/commands.html
+++ b/docs/en/commands.html
@@ -387,6 +387,8 @@
 <pre><code><span class="du-prompt">$</span> chrome-use tab                              <span class="du-cmt"># list tabs (with tabId and label)</span>
 <span class="du-prompt">$</span> chrome-use tab new [url]                    <span class="du-cmt"># new tab</span>
 <span class="du-prompt">$</span> chrome-use tab new <span class="du-flag">--label</span> docs [url]       <span class="du-cmt"># new tab with a readable label</span>
+<span class="du-prompt">$</span> chrome-use tab duplicate [ref]              <span class="du-cmt"># native Duplicate tab; current by default</span>
+<span class="du-prompt">$</span> chrome-use tab duplicate docs <span class="du-flag">--label</span> copy <span class="du-cmt"># duplicate by ref and label the copy</span>
 <span class="du-prompt">$</span> chrome-use tab t2                           <span class="du-cmt"># switch by id</span>
 <span class="du-prompt">$</span> chrome-use tab docs                         <span class="du-cmt"># switch by label</span>
 <span class="du-prompt">$</span> chrome-use tab close                        <span class="du-cmt"># close the current tab</span>
@@ -394,6 +396,12 @@
 <span class="du-prompt">$</span> chrome-use tab close docs                   <span class="du-cmt"># close by label</span>
 <span class="du-prompt">$</span> chrome-use window new                       <span class="du-cmt"># new window</span></code></pre>
       </div>
+      <p>
+        Native duplication requires real Chrome connected through the chrome-use extension. It restores the
+        previously visible foreground tab, while the duplicate becomes chrome-use's internal active tab. There is
+        no same-URL fallback for launched Chrome, raw CDP, Lightpanda, or cloud providers. Chrome decides whether
+        the background duplicate starts loading.
+      </p>
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ refs belong to the tab active at snapshot time</div>
         The daemon maintains a single active tab, and <code>@eN</code> belongs to the tab that was active when the

--- a/docs/en/mcp.html
+++ b/docs/en/mcp.html
@@ -111,7 +111,7 @@
           <tr><td><code>chrome_use_select</code></td><td>Pick an option in a <code>&lt;select&gt;</code> dropdown</td></tr>
           <tr><td><code>chrome_use_screenshot</code></td><td>Capture a screenshot (output only, not for reading)</td></tr>
           <tr><td><code>chrome_use_scroll</code></td><td>Scroll the page or a container</td></tr>
-          <tr><td><code>chrome_use_tabs</code></td><td>List / switch this session's tabs</td></tr>
+          <tr><td><code>chrome_use_tabs</code></td><td>List, open, natively duplicate, close, or switch this session's tabs</td></tr>
           <tr><td><code>chrome_use_extract</code></td><td>Scrape the page into structured JSON by schema</td></tr>
           <tr><td><code>chrome_use_expect</code></td><td>Assert a condition, erroring if it fails</td></tr>
           <tr><td><code>chrome_use_find</code></td><td>Locate an element or tab by text / URL</td></tr>

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -108,7 +108,7 @@
           <tr><td><code>chrome_use_select</code></td><td>选中 <code>&lt;select&gt;</code> 下拉项</td></tr>
           <tr><td><code>chrome_use_screenshot</code></td><td>截图（仅作输出，不作为读取手段）</td></tr>
           <tr><td><code>chrome_use_scroll</code></td><td>滚动页面或某个容器</td></tr>
-          <tr><td><code>chrome_use_tabs</code></td><td>列出 / 切换本会话的标签</td></tr>
+          <tr><td><code>chrome_use_tabs</code></td><td>列出、新建、原生复制、关闭或切换本会话的标签</td></tr>
           <tr><td><code>chrome_use_extract</code></td><td>按 schema 把页面抓成结构化 JSON</td></tr>
           <tr><td><code>chrome_use_expect</code></td><td>断言某个条件，不满足即报错</td></tr>
           <tr><td><code>chrome_use_find</code></td><td>按文本 / URL 定位元素或标签</td></tr>

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -16,7 +16,7 @@
 // attach + Target handling; the transport is rewritten from WebSocket+token to
 // native messaging.
 
-importScripts('tab-duplicate.js')
+import { duplicateTab as runDuplicateTab } from './tab-duplicate.js'
 
 const HOST_NAME = 'com.agent_browser.connect'
 const SKIP_URL = /^(chrome|chrome-extension|devtools|chrome-untrusted|edge|about):/i
@@ -547,7 +547,7 @@ async function handleForwardCdpCommand(msg) {
   // tab action, including navigation history. The duplicated tab becomes owned
   // by the requesting session but the user's previously visible tab is restored.
   if (method === 'ABExt.duplicateTab') {
-    return await globalThis.ABTabDuplicate.duplicateTab(params, {
+    return await runDuplicateTab(params, {
       tabForTarget,
       getTab: (tabId) => chrome.tabs.get(tabId),
       eligible,

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -16,6 +16,8 @@
 // attach + Target handling; the transport is rewritten from WebSocket+token to
 // native messaging.
 
+importScripts('tab-duplicate.js')
+
 const HOST_NAME = 'com.agent_browser.connect'
 const SKIP_URL = /^(chrome|chrome-extension|devtools|chrome-untrusted|edge|about):/i
 
@@ -85,12 +87,15 @@ function colorForName(name) {
 
 // Put a freshly-created tab into the agent/session's own Chrome tab group, so
 // each agent's tabs are visually separated (from each other and from the user's
-// own tabs) on the shared real browser. Best-effort: grouping failures never
-// break tab creation.
+// own tabs) on the shared real browser. This helper is strict; callers may
+// explicitly downgrade grouping failures to best-effort when their contract
+// allows it.
 async function groupTabInto(tabId, name) {
-  if (!name || !chrome.tabGroups || !chrome.tabs.group) return
+  if (!name || !chrome.tabGroups || !chrome.tabs.group) {
+    throw new Error('groupTabInto: Chrome tab-group APIs are unavailable')
+  }
   const tab = await chrome.tabs.get(tabId).catch(() => null)
-  if (!tab) return
+  if (!tab) throw new Error(`groupTabInto: tab ${tabId} is unavailable`)
   let gid = groupIdByName.get(name)
   if (gid != null) {
     const ok = await chrome.tabGroups.get(gid).then(() => true).catch(() => false)
@@ -106,9 +111,14 @@ async function groupTabInto(tabId, name) {
   }
   if (gid == null) {
     gid = await chrome.tabs.group({ tabIds: tabId })
-    await chrome.tabGroups.update(gid, { title: name, color: colorForName(name) }).catch(() => {})
+    await chrome.tabGroups.update(gid, { title: name, color: colorForName(name) })
   } else {
-    await chrome.tabs.group({ groupId: gid, tabIds: tabId }).catch(() => {})
+    await chrome.tabs.group({ groupId: gid, tabIds: tabId })
+  }
+  const grouped = await chrome.tabs.get(tabId)
+  const groupInfo = await chrome.tabGroups.get(grouped.groupId)
+  if (grouped.groupId !== gid || groupInfo.title !== name) {
+    throw new Error(`groupTabInto: tab ${tabId} did not join group ${name}`)
   }
   groupIdByName.set(name, gid)
 }
@@ -314,6 +324,7 @@ function connectHost() {
       postToHost({
         method: 'hello',
         version: chrome.runtime.getManifest().version,
+        capabilities: ['nativeTabDuplicate'],
         ...extra,
       })
     } catch {}
@@ -529,6 +540,28 @@ async function handleForwardCdpCommand(msg) {
     // stuck on a page they own. On SW restart the adoption simply releases (banner
     // clears); re-`adopt` if still needed. Only agent-CREATED tabs are persisted.
     return { targetId: entry.targetId, url: match.url || '', title: match.title || '' }
+  }
+
+  // Native Chrome tab duplication. This intentionally has no URL-based
+  // fallback: callers use it when they need the semantics of Chrome's Duplicate
+  // tab action, including navigation history. The duplicated tab becomes owned
+  // by the requesting session but the user's previously visible tab is restored.
+  if (method === 'ABExt.duplicateTab') {
+    return await globalThis.ABTabDuplicate.duplicateTab(params, {
+      tabForTarget,
+      getTab: (tabId) => chrome.tabs.get(tabId),
+      eligible,
+      getLastFocusedWindow: () => chrome.windows.getLastFocused(),
+      getActiveTabs: (windowId) => chrome.tabs.query({ active: true, windowId }),
+      duplicateTab: (tabId) => chrome.tabs.duplicate(tabId),
+      markOwned,
+      unmarkOwned,
+      groupTabInto,
+      attachTab,
+      activateTab: (tabId) => chrome.tabs.update(tabId, { active: true }),
+      focusWindow: (windowId) => chrome.windows.update(windowId, { focused: true }),
+      removeTab: (tabId) => chrome.tabs.remove(tabId),
+    })
   }
 
   // Browser-level Target methods that map onto chrome.tabs.

--- a/extensions/ab-connect/tab-duplicate.js
+++ b/extensions/ab-connect/tab-duplicate.js
@@ -1,44 +1,46 @@
 // Testable native Duplicate tab transaction. The service worker supplies Chrome
 // adapters; tests supply deterministic fakes at the same system boundary.
-;(function installTabDuplicate(root) {
-  async function duplicateTab(params, deps) {
-    const sourceTargetId =
-      typeof params?.sourceTargetId === 'string' ? params.sourceTargetId.trim() : ''
-    const sourceTabId = sourceTargetId ? deps.tabForTarget(sourceTargetId) : null
-    if (sourceTabId == null) {
-      throw new Error(`duplicateTab: source target not found: ${sourceTargetId}`)
-    }
+async function bestEffort(operation) {
+  try {
+    await operation()
+  } catch {}
+}
 
-    const sourceTab = await deps.getTab(sourceTabId).catch(() => null)
-    if (!deps.eligible(sourceTab)) throw new Error('duplicateTab: source tab is unavailable')
-    const focusedWindow = await deps.getLastFocusedWindow().catch(() => null)
-    const restoreWindowId = focusedWindow?.id ?? sourceTab.windowId
-    const activeTabs = await deps.getActiveTabs(restoreWindowId).catch(() => [])
-    const restoreTabId = activeTabs[0]?.id ?? sourceTabId
-    const group = typeof params?.agentGroup === 'string' ? params.agentGroup.trim() : ''
-    if (!group) throw new Error('duplicateTab: agentGroup is required')
-
-    let duplicateTabId = null
-    try {
-      const duplicate = await deps.duplicateTab(sourceTabId)
-      duplicateTabId = duplicate?.id ?? null
-      if (duplicateTabId == null) throw new Error('duplicateTab: no tab id')
-      deps.markOwned(duplicateTabId)
-      await deps.groupTabInto(duplicateTabId, group)
-      const entry = await deps.attachTab(duplicateTabId)
-      await deps.activateTab(restoreTabId)
-      await deps.focusWindow(restoreWindowId)
-      return { sourceTargetId, targetId: entry.targetId }
-    } catch (error) {
-      if (duplicateTabId != null) {
-        deps.unmarkOwned(duplicateTabId)
-        await deps.removeTab(duplicateTabId).catch(() => {})
-      }
-      await deps.activateTab(restoreTabId).catch(() => {})
-      await deps.focusWindow(restoreWindowId).catch(() => {})
-      throw error
-    }
+export async function duplicateTab(params, deps) {
+  const sourceTargetId =
+    typeof params?.sourceTargetId === 'string' ? params.sourceTargetId.trim() : ''
+  const sourceTabId = sourceTargetId ? deps.tabForTarget(sourceTargetId) : null
+  if (sourceTabId == null) {
+    throw new Error(`duplicateTab: source target not found: ${sourceTargetId}`)
   }
 
-  root.ABTabDuplicate = Object.freeze({ duplicateTab })
-})(globalThis)
+  const sourceTab = await deps.getTab(sourceTabId).catch(() => null)
+  if (!deps.eligible(sourceTab)) throw new Error('duplicateTab: source tab is unavailable')
+  const focusedWindow = await deps.getLastFocusedWindow().catch(() => null)
+  const restoreWindowId = focusedWindow?.id ?? sourceTab.windowId
+  const activeTabs = await deps.getActiveTabs(restoreWindowId).catch(() => [])
+  const restoreTabId = activeTabs[0]?.id ?? sourceTabId
+  const group = typeof params?.agentGroup === 'string' ? params.agentGroup.trim() : ''
+  if (!group) throw new Error('duplicateTab: agentGroup is required')
+
+  let duplicateTabId = null
+  try {
+    const duplicate = await deps.duplicateTab(sourceTabId)
+    duplicateTabId = duplicate?.id ?? null
+    if (duplicateTabId == null) throw new Error('duplicateTab: no tab id')
+    deps.markOwned(duplicateTabId)
+    await deps.groupTabInto(duplicateTabId, group)
+    const entry = await deps.attachTab(duplicateTabId)
+    await deps.activateTab(restoreTabId)
+    await deps.focusWindow(restoreWindowId)
+    return { sourceTargetId, targetId: entry.targetId }
+  } catch (error) {
+    if (duplicateTabId != null) {
+      await bestEffort(() => deps.unmarkOwned(duplicateTabId))
+      await bestEffort(() => deps.removeTab(duplicateTabId))
+    }
+    await bestEffort(() => deps.activateTab(restoreTabId))
+    await bestEffort(() => deps.focusWindow(restoreWindowId))
+    throw error
+  }
+}

--- a/extensions/ab-connect/tab-duplicate.js
+++ b/extensions/ab-connect/tab-duplicate.js
@@ -1,0 +1,44 @@
+// Testable native Duplicate tab transaction. The service worker supplies Chrome
+// adapters; tests supply deterministic fakes at the same system boundary.
+;(function installTabDuplicate(root) {
+  async function duplicateTab(params, deps) {
+    const sourceTargetId =
+      typeof params?.sourceTargetId === 'string' ? params.sourceTargetId.trim() : ''
+    const sourceTabId = sourceTargetId ? deps.tabForTarget(sourceTargetId) : null
+    if (sourceTabId == null) {
+      throw new Error(`duplicateTab: source target not found: ${sourceTargetId}`)
+    }
+
+    const sourceTab = await deps.getTab(sourceTabId).catch(() => null)
+    if (!deps.eligible(sourceTab)) throw new Error('duplicateTab: source tab is unavailable')
+    const focusedWindow = await deps.getLastFocusedWindow().catch(() => null)
+    const restoreWindowId = focusedWindow?.id ?? sourceTab.windowId
+    const activeTabs = await deps.getActiveTabs(restoreWindowId).catch(() => [])
+    const restoreTabId = activeTabs[0]?.id ?? sourceTabId
+    const group = typeof params?.agentGroup === 'string' ? params.agentGroup.trim() : ''
+    if (!group) throw new Error('duplicateTab: agentGroup is required')
+
+    let duplicateTabId = null
+    try {
+      const duplicate = await deps.duplicateTab(sourceTabId)
+      duplicateTabId = duplicate?.id ?? null
+      if (duplicateTabId == null) throw new Error('duplicateTab: no tab id')
+      deps.markOwned(duplicateTabId)
+      await deps.groupTabInto(duplicateTabId, group)
+      const entry = await deps.attachTab(duplicateTabId)
+      await deps.activateTab(restoreTabId)
+      await deps.focusWindow(restoreWindowId)
+      return { sourceTargetId, targetId: entry.targetId }
+    } catch (error) {
+      if (duplicateTabId != null) {
+        deps.unmarkOwned(duplicateTabId)
+        await deps.removeTab(duplicateTabId).catch(() => {})
+      }
+      await deps.activateTab(restoreTabId).catch(() => {})
+      await deps.focusWindow(restoreWindowId).catch(() => {})
+      throw error
+    }
+  }
+
+  root.ABTabDuplicate = Object.freeze({ duplicateTab })
+})(globalThis)

--- a/extensions/ab-connect/tab-duplicate.test.js
+++ b/extensions/ab-connect/tab-duplicate.test.js
@@ -1,12 +1,6 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
 import test from 'node:test'
-import vm from 'node:vm'
-
-const source = readFileSync(new URL('./tab-duplicate.js', import.meta.url), 'utf8')
-const context = vm.createContext({})
-vm.runInContext(source, context)
-const { duplicateTab } = context.ABTabDuplicate
+import { duplicateTab } from './tab-duplicate.js'
 
 function fixture(overrides = {}) {
   const calls = []
@@ -75,6 +69,54 @@ test('native duplicate failure is returned without orphan cleanup', async () => 
   await assert.rejects(duplicateTab(params, deps), /native duplicate failed/)
   assert.ok(!calls.some((call) => call[0] === 'unmarkOwned'))
   assert.ok(!calls.some((call) => call[0] === 'remove'))
+})
+
+test('rollback continues after unmark ownership throws', async () => {
+  const original = new Error('group is unavailable')
+  const { calls, deps } = fixture({
+    groupTabInto: async () => Promise.reject(original),
+    unmarkOwned: () => {
+      calls.push(['unmarkOwned'])
+      throw new Error('unmark failed')
+    },
+    focusWindow: async (windowId) => calls.push(['focusWindow', windowId]),
+  })
+
+  await assert.rejects(duplicateTab(params, deps), (error) => error === original)
+  assert.ok(calls.some((call) => call[0] === 'remove'))
+  assert.ok(calls.some((call) => call[0] === 'activate'))
+  assert.ok(calls.some((call) => call[0] === 'focusWindow'))
+})
+
+test('rollback continues after tab removal rejects', async () => {
+  const original = new Error('attach is unavailable')
+  const { calls, deps } = fixture({
+    attachTab: async () => Promise.reject(original),
+    removeTab: async (tabId) => {
+      calls.push(['remove', tabId])
+      throw new Error('remove failed')
+    },
+    focusWindow: async (windowId) => calls.push(['focusWindow', windowId]),
+  })
+
+  await assert.rejects(duplicateTab(params, deps), (error) => error === original)
+  assert.ok(calls.some((call) => call[0] === 'activate'))
+  assert.ok(calls.some((call) => call[0] === 'focusWindow'))
+})
+
+test('rollback focuses the previous window after tab activation rejects', async () => {
+  const original = new Error('setup failed')
+  const { calls, deps } = fixture({
+    attachTab: async () => Promise.reject(original),
+    activateTab: async (tabId) => {
+      calls.push(['activate', tabId])
+      throw new Error('activate failed')
+    },
+    focusWindow: async (windowId) => calls.push(['focusWindow', windowId]),
+  })
+
+  await assert.rejects(duplicateTab(params, deps), (error) => error === original)
+  assert.ok(calls.some((call) => call[0] === 'focusWindow'))
 })
 
 for (const [stage, failure] of [

--- a/extensions/ab-connect/tab-duplicate.test.js
+++ b/extensions/ab-connect/tab-duplicate.test.js
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('./tab-duplicate.js', import.meta.url), 'utf8')
+const context = vm.createContext({})
+vm.runInContext(source, context)
+const { duplicateTab } = context.ABTabDuplicate
+
+function fixture(overrides = {}) {
+  const calls = []
+  const deps = {
+    tabForTarget: (targetId) => (targetId === 'source-target' ? 11 : null),
+    getTab: async (tabId) => ({ id: tabId, windowId: 3, url: 'https://example.com/b' }),
+    eligible: (tab) => Boolean(tab?.id && tab?.url),
+    getLastFocusedWindow: async () => ({ id: 3 }),
+    getActiveTabs: async () => [{ id: 7 }],
+    duplicateTab: async (tabId) => {
+      calls.push(['duplicate', tabId])
+      return { id: 22 }
+    },
+    markOwned: (tabId) => calls.push(['markOwned', tabId]),
+    unmarkOwned: (tabId) => calls.push(['unmarkOwned', tabId]),
+    groupTabInto: async (tabId, group) => calls.push(['group', tabId, group]),
+    attachTab: async (tabId) => {
+      calls.push(['attach', tabId])
+      return { targetId: 'duplicate-target' }
+    },
+    activateTab: async (tabId) => calls.push(['activate', tabId]),
+    focusWindow: async () => {},
+    removeTab: async (tabId) => calls.push(['remove', tabId]),
+    ...overrides,
+  }
+  return { calls, deps }
+}
+
+const params = { sourceTargetId: 'source-target', agentGroup: 'agent-a' }
+
+test('native duplicate is grouped, attached, owned, and restores the foreground tab', async () => {
+  const { calls, deps } = fixture()
+  const result = await duplicateTab(params, deps)
+
+  assert.equal(result.sourceTargetId, 'source-target')
+  assert.equal(result.targetId, 'duplicate-target')
+  assert.deepEqual(calls, [
+    ['duplicate', 11],
+    ['markOwned', 22],
+    ['group', 22, 'agent-a'],
+    ['attach', 22],
+    ['activate', 7],
+  ])
+})
+
+test('native duplicate restores the active tab and focus from another window', async () => {
+  const { calls, deps } = fixture({
+    getLastFocusedWindow: async () => ({ id: 9 }),
+    getActiveTabs: async (windowId) => {
+      calls.push(['getActiveTabs', windowId])
+      return [{ id: 70 }]
+    },
+    focusWindow: async (windowId) => calls.push(['focusWindow', windowId]),
+  })
+  await duplicateTab(params, deps)
+
+  assert.ok(calls.some((call) => call[0] === 'getActiveTabs' && call[1] === 9))
+  assert.ok(calls.some((call) => call[0] === 'activate' && call[1] === 70))
+  assert.ok(calls.some((call) => call[0] === 'focusWindow' && call[1] === 9))
+})
+
+test('native duplicate failure is returned without orphan cleanup', async () => {
+  const { calls, deps } = fixture({
+    duplicateTab: async () => Promise.reject(new Error('native duplicate failed')),
+  })
+  await assert.rejects(duplicateTab(params, deps), /native duplicate failed/)
+  assert.ok(!calls.some((call) => call[0] === 'unmarkOwned'))
+  assert.ok(!calls.some((call) => call[0] === 'remove'))
+})
+
+for (const [stage, failure] of [
+  ['group', { groupTabInto: async () => Promise.reject(new Error('group failed')) }],
+  ['attach', { attachTab: async () => Promise.reject(new Error('attach failed')) }],
+  ['restore', { activateTab: async () => Promise.reject(new Error('restore failed')) }],
+]) {
+  test(`${stage} failure removes the orphaned duplicate`, async () => {
+    const { calls, deps } = fixture(failure)
+    await assert.rejects(duplicateTab(params, deps), new RegExp(`${stage} failed`))
+    assert.ok(calls.some((call) => call[0] === 'unmarkOwned' && call[1] === 22))
+    assert.ok(calls.some((call) => call[0] === 'remove' && call[1] === 22))
+  })
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chrome-use": "bin/chrome-use.js"
   },
   "scripts": {
+    "test:extension": "node --test extensions/ab-connect/tab-duplicate.test.js",
     "prepare": "husky || true",
     "version:sync": "node scripts/sync-version.js",
     "version": "npm run version:sync && git add cli/Cargo.toml",

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -903,6 +903,8 @@ Pass `--hide-scrollbars false` when launching to keep native scrollbars visible.
 chrome-use tab                      # list open tabs (with stable tabId)
 chrome-use tabs                     # alias for `tab` (lists too)
 chrome-use tab new https://docs...  # open a new tab (and switch to it)
+chrome-use tab duplicate            # native Duplicate tab; copy becomes the internal active tab
+chrome-use tab duplicate docs --label docs-copy
 chrome-use tab t2                   # switch to tab t2
 chrome-use tab close t2             # close tab t2
 ```
@@ -914,6 +916,12 @@ Tab ids are stable strings (`t1`, `t2`, …), never reused within a session, so
 the same id keeps referring to the same tab across commands. Positional
 integers are **not** accepted — use `t2`, not `2`. After switching, refs from a
 prior snapshot on a different tab no longer apply — re-snapshot.
+
+`tab duplicate [ref] [--label <name>]` is available only through the
+extension-connected real Chrome path. It calls Chrome's native Duplicate tab
+operation, restores the previously visible foreground tab, and keeps the copy as
+chrome-use's internal active tab. It never recreates the source URL as a
+fallback. Chrome may still load the duplicate while it is in the background.
 
 ### Run multiple browsers in parallel / reset stuck daemons
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -226,6 +226,8 @@ chrome-use network requests --filter api    # Filter requests
 chrome-use tab                              # List tabs with tabId and label
 chrome-use tab new [url]                    # New tab
 chrome-use tab new --label docs [url]       # New tab with a memorable label
+chrome-use tab duplicate [ref]              # Native Duplicate tab (current by default)
+chrome-use tab duplicate docs --label copy  # Duplicate by ref and label the copy
 chrome-use tab t2                           # Switch to tab by id
 chrome-use tab docs                         # Switch to tab by label
 chrome-use tab close                        # Close current tab
@@ -257,6 +259,13 @@ Labels are never auto-generated, never rewritten on navigation, and must be
 unique within a session. To interact with another tab, switch to it first:
 the daemon maintains a single active tab, so refs (`@eN`) belong to the tab
 that was active when the snapshot ran.
+
+Native duplication requires real Chrome connected through the chrome-use
+extension. The command accepts a `t<N>` id, label, or stable CDP target ID. It
+restores the previously visible foreground tab when complete while making the
+copy chrome-use's internal active tab. Providers without native duplication
+return an error; chrome-use never substitutes a same-URL new tab. Background
+loading remains controlled by Chrome.
 
 ## Frames
 


### PR DESCRIPTION
Closes #115

## What changed

- add `chrome-use tab duplicate [tab-ref] [--label <name>]` with current tab, short ID, label, and stable target ID resolution
- expose the same duplicate action through `chrome_use_tabs` MCP
- use an explicit `ABExt.duplicateTab` extension command backed by `chrome.tabs.duplicate()`
- preserve session ownership and agent-group attribution, including attach-before-response relay races
- restore the previously focused Chrome window and active tab while keeping the duplicate as chrome-use's internal active target
- return source and duplicate tab/target identifiers without exposing the URL
- reject launched Chrome, raw CDP, Lightpanda, old extensions, and providers without the native capability
- roll back orphaned duplicates when grouping, debugger attachment, setup, or foreground restoration fails
- update CLI help, README, core skill references, static English/Chinese docs, MCP docs, and inline documentation

## Validation

Passed:

- `cd cli && cargo fmt -- --check`
- `cd cli && cargo test` (1103 tests)
- `cd cli && cargo clippy`
- `pnpm test:extension` (6 tests)
- JavaScript syntax checks for the extension files
- launched-provider duplicate E2E

Full isolated-launch E2E result:

- 73 passed
- 3 unrelated existing/environment failures:
  - drag buttons assertion returns `None`
  - ffmpeg is not installed for recording
  - macOS default devicePixelRatio is 2 while the test expects 1

The extension-connected native-duplicate E2E is included and gated by `CHROME_USE_EXTENSION_E2E=1`. It was not executed locally because current stable Chrome rejects command-line unpacked-extension loading; executing it would require manually installing the checkout extension in Chrome.

## Compatibility and safety

- no URL-based `Target.createTarget` fallback
- no package or Cargo version changes
- no changelog or release-note changes
- older extensions advertise no capability and receive a clear unsupported error
- existing `Target.createTarget` grouping remains best-effort
- session shutdown closes only targets created or duplicated by that session

## Documentation note

The repository AGENTS.md mentions `docs/src/app/`, but that directory does not exist on current `main`. This PR updates the actual static docs pages under `docs/` and their `docs/en/` mirrors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `chrome-use tab duplicate` with optional tab reference and `--label` support.
  * Extended tab tools and MCP `chrome_use_tabs` with a new native duplication action.
  * Native duplication preserves navigation history and session tab tracking; duplicate becomes the internal active tab while the previous foreground tab is restored.

* **Documentation**
  * Updated CLI help, command references, MCP docs, and skills/README with new examples and availability notes.

* **Tests**
  * Added unit and native end-to-end coverage for duplication routing, error handling, rollback, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->