### PR TITLE
fix: stale-session loud timeout (#117) + screenshot black regions (#119)

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -997,12 +997,19 @@ fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
 
     // A long-running command (notably `script`, which runs a whole op-list in one
     // round-trip) carries its own `timeout_ms`; give the socket read that budget
-    // plus margin so we don't cut off a legitimately long script at the default 30s.
+    // plus margin so we don't cut off a legitimately long script.
+    //
+    // For a plain command (`get`/`eval`/…) the daemon caps each CDP call at 30s
+    // and then returns a proper error response ("CDP command timed out: …"). Our
+    // read budget MUST exceed that daemon budget, otherwise the socket read fires
+    // at the same 30s, we abandon the connection before the daemon's error line
+    // arrives, and the actionable diagnostic is lost — the exact swallow behind
+    // issue #117. 45s = daemon's 30s CDP budget + 15s margin.
     let read_to = cmd
         .get("timeout_ms")
         .and_then(|v| v.as_u64())
         .map(|ms| Duration::from_millis(ms.saturating_add(15_000)))
-        .unwrap_or(Duration::from_secs(30));
+        .unwrap_or(Duration::from_secs(45));
     stream.set_read_timeout(Some(read_to)).ok();
     stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
 
@@ -1015,9 +1022,25 @@ fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
 
     let mut reader = BufReader::new(stream);
     let mut response_line = String::new();
-    reader
-        .read_line(&mut response_line)
-        .map_err(|e| format!("Failed to read: {}", e))?;
+    reader.read_line(&mut response_line).map_err(|e| {
+        // A read that runs the full budget without a byte means the daemon never
+        // answered — its browser connection is stale/hung (issue #117). Surface a
+        // clear, actionable error that is NOT classified transient, so we fail
+        // loudly and non-zero instead of silently retrying the 45s read 5× (and
+        // leaving the caller with "daemon may be busy or unresponsive").
+        if matches!(
+            e.kind(),
+            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+        ) {
+            format!(
+                "session unresponsive: no response within {}s — the browser connection is \
+                 likely stale. Reconnect with `connect`, or close and reopen the session.",
+                read_to.as_secs()
+            )
+        } else {
+            format!("Failed to read: {}", e)
+        }
+    })?;
 
     serde_json::from_str(&response_line).map_err(|e| format!("Invalid response: {}", e))
 }

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -406,6 +406,18 @@ pub fn to_ai_friendly_error(error: &str) -> String {
         return "Another element is covering the target element. Try scrolling or closing overlays."
             .to_string();
     }
+    // A CDP call that ran to its full budget ("CDP command timed out: …") means
+    // the browser connection is unresponsive — over the extension relay this
+    // happens when the relay/service-worker went stale mid-session while
+    // `sessions` still reports the daemon alive (issue #117). Keep the concrete
+    // failing method and spell out recovery instead of leaving a bare timeout.
+    if lower.contains("timed out") {
+        return format!(
+            "{error}\nHint: the session's browser connection is unresponsive (likely a stale \
+             relay/service-worker mid-session). Reconnect with `connect`, or close the session \
+             and reopen it."
+        );
+    }
     if lower.contains("timeout") {
         return "Operation timed out. The page may still be loading or the element may not exist."
             .to_string();

--- a/cli/src/native/screenshot.rs
+++ b/cli/src/native/screenshot.rs
@@ -234,11 +234,38 @@ async fn capture_screenshot_base64(
         }
     }
 
-    let result: CaptureScreenshotResult = client
-        .send_command_typed("Page.captureScreenshot", &params, Some(session_id))
-        .await?;
+    // Fill the compositor base with opaque white before capturing. Under
+    // `fromSurface: true` (always on), regions the GPU compositor did not paint
+    // into the captured surface — common with `position: fixed` / `overflow`
+    // scroll / `backdrop-filter` layers under mobile device emulation — come
+    // back transparent, which encodes as a solid BLACK region in the output
+    // (issue #119). An opaque default background makes those uncaptured regions
+    // render white (matching the light page the user actually sees) instead of
+    // black. It draws behind all real content, so fully-painted pages are
+    // unaffected. Restored immediately after so it never leaks into the live
+    // page or later captures.
+    let _ = client
+        .send_command(
+            "Emulation.setDefaultBackgroundColorOverride",
+            Some(serde_json::json!({ "color": { "r": 255, "g": 255, "b": 255, "a": 255 } })),
+            Some(session_id),
+        )
+        .await;
 
-    Ok(result.data)
+    let result: Result<CaptureScreenshotResult, String> = client
+        .send_command_typed("Page.captureScreenshot", &params, Some(session_id))
+        .await;
+
+    // Clear the override regardless of capture success (empty params = reset).
+    let _ = client
+        .send_command(
+            "Emulation.setDefaultBackgroundColorOverride",
+            Some(serde_json::json!({})),
+            Some(session_id),
+        )
+        .await;
+
+    Ok(result?.data)
 }
 
 async fn collect_annotations(


### PR DESCRIPTION
Two independent bug fixes, one per commit.

## #117 — Stale session daemon makes get/eval time out with empty output

**Root cause (client-side race).** The daemon caps each CDP call at 30s and returns a proper `CDP command timed out: Runtime.evaluate` error response. But the CLI's socket read budget in `send_command_once` was *also* 30s, so the client abandoned the socket at the same instant the daemon was writing its error line, classified its own read timeout (`os error 35`) as **transient**, and retried 5× (~150s) — discarding the actionable diagnostic and leaving only `daemon may be busy or unresponsive`.

**Fix.**
- `connection.rs`: default read budget **30s → 45s** (> the daemon's 30s CDP budget) so the daemon's error wins the race and reaches the caller.
- `connection.rs`: a full-budget read timeout (`WouldBlock`/`TimedOut`) now maps to a clear, **non-transient** `session unresponsive: … reconnect with connect, or close and reopen` error — no more silent 5× retry.
- `browser.rs`: CDP-timeout errors get an actionable reconnect hint appended.

Net: one ~30s wait → **loud, non-zero** failure with guidance, no 150s retry hang.

Not addressed here (deliberately, follow-up): the deeper latent cause is that `is_connection_alive` probes with `Browser.getVersion`, which the relay answers *locally* → a hung per-tab path always reads "alive". Fixing that risks the Chrome-136 reconnect-storm the existing comment warns about, so this PR takes the issue's "**or** fail loudly" path. `sessions` liveness (pid/version only) is also left as-is to keep the listing fast.

## #119 — screenshot: fixed bottom sheet creates large black regions at mobile viewport

**Root cause.** `Page.captureScreenshot` hardcodes `fromSurface: true` and never sets a base background. GPU-compositor tiles not painted into the captured surface — common with `position: fixed` / `overflow` scroll / `backdrop-filter` layers under mobile device emulation — come back transparent, which encodes as a solid **black** region even though the live page is light/white.

**Fix.** Set an opaque-white `Emulation.setDefaultBackgroundColorOverride` around each capture (cleared afterwards, even on capture error) so uncaptured regions render white instead of black. It draws behind all real content, so fully-painted pages are unchanged.

Rejected alternatives: `captureBeyondViewport` (repositions `position:fixed` elements — ironic for this bug) and `fromSurface:false` (would break the canvas/WebGL capture features).

## Verification
- `cargo build` clean; touched-module unit tests pass (25 screenshot + 18 connection/transient).
- #119: no-regression verified on synthetic mobile fixed-sheet + backdrop-filter pages (render identically, output stays 390×844). ⚠️ The black region is GPU/driver-specific and does **not** reproduce on my Mac — please confirm the fix on the machine that reproduces #119.
- #117: normal `eval`/`get` on a healthy session still work (exit 0).

Closes #117
Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Extended the command read window to reduce premature timeout errors.
  - Improved connection timeout messages with clearer guidance when a session becomes unresponsive.
  - Added actionable recovery suggestions, including reconnecting or reopening the session.
  - Updated screenshot capture to use a solid white background, improving consistency for transparent or empty page areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->