### PR TITLE
fix: site-adapter error exit (#122), installer /dev/tty (#123), site arg collision (#125)

### DIFF
--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -8,6 +8,91 @@ const CONFIG_DIR: &str = ".chrome-use";
 const CONFIG_FILENAME: &str = "config.json";
 const PROJECT_CONFIG_FILENAME: &str = "chrome-use.json";
 
+/// Global boolean flags: they optionally take a trailing `true`/`false`, so they
+/// never silently swallow the next positional. Kept module-level so `clean_args`
+/// and the site-adapter collision check ([`is_reserved_global_flag`]) share one
+/// source of truth.
+pub(crate) const GLOBAL_BOOL_FLAGS: &[&str] = &[
+    "--json",
+    "--headed",
+    "--debug",
+    "--ignore-https-errors",
+    "--allow-file-access",
+    "--hide-scrollbars",
+    "--auto-connect",
+    "--launch",
+    "--new",
+    "--annotate",
+    "--content-boundaries",
+    "--confirm-interactive",
+    "--no-auto-dialog",
+    // Action guards (issue #65 followup): skip an action instead of erroring
+    // when its target element is absent. Stripped here so they don't break a
+    // command's positional parsing; injected into the action JSON via
+    // parse_command from Flags.if_present.
+    "--if-present",
+    "--optional",
+    "--observe",
+    "--as-strict",
+    "-v",
+    "--verbose",
+    "-q",
+    "--quiet",
+    // doctor-specific flags; harmless on other commands (ignored)
+    "--offline",
+    "--quick",
+    "--fix",
+];
+
+/// Global flags that always consume the following argument. These are the ones
+/// that silently swallow a colliding site-adapter override (issue #125).
+pub(crate) const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
+    "--session",
+    "--headers",
+    "--executable-path",
+    "--cdp",
+    "--browser",
+    "--as",
+    "--extension",
+    "--init-script",
+    "--enable",
+    "--profile",
+    "--state",
+    "--proxy",
+    "--proxy-bypass",
+    "--args",
+    "--user-agent",
+    "-p",
+    "--provider",
+    "--device",
+    "--session-name",
+    "--color-scheme",
+    "--download-path",
+    "--max-output",
+    "--allowed-domains",
+    "--action-policy",
+    "--confirm-actions",
+    "--config",
+    "--engine",
+    "--screenshot-dir",
+    "--screenshot-quality",
+    "--screenshot-format",
+    "--idle-timeout",
+    "--model",
+    "--humanize",
+    "--window",
+];
+
+/// Whether `--<name>` is a reserved global flag (value-taking or boolean) that
+/// `clean_args`/`parse_flags` consume before a subcommand sees it. A site adapter
+/// declaring an arg with a colliding name can never receive it as `--<name>`
+/// (issue #125); callers use this to warn instead of silently dropping the value.
+pub fn is_reserved_global_flag(name: &str) -> bool {
+    let dashed = format!("--{name}");
+    GLOBAL_FLAGS_WITH_VALUE.contains(&dashed.as_str())
+        || GLOBAL_BOOL_FLAGS.contains(&dashed.as_str())
+}
+
 /// Parse idle timeout from user-friendly format.
 /// Supports: "10s" (seconds), "3m" (minutes), "1h" (hours), or raw milliseconds.
 fn parse_idle_timeout(s: &str) -> Result<String, String> {
@@ -253,6 +338,10 @@ fn extract_config_path(args: &[String]) -> Option<Option<String>> {
     ];
     let mut i = 0;
     while i < args.len() {
+        // `--` ends option parsing; anything after is a passthrough arg (#125).
+        if args[i] == "--" {
+            break;
+        }
         if args[i] == "--config" {
             return Some(args.get(i + 1).cloned());
         }
@@ -643,6 +732,13 @@ pub fn parse_flags(args: &[String]) -> Flags {
 
     let mut i = 0;
     while i < args.len() {
+        // `--` ends option parsing (standard getopt convention): everything after
+        // it is a positional / passthrough arg, so a global flag name appearing
+        // there is NOT consumed as a flag. Pairs with `clean_args` to let site
+        // adapters receive colliding `--key value` overrides (issue #125).
+        if args[i] == "--" {
+            break;
+        }
         match args[i].as_str() {
             "--json" => {
                 let (val, consumed) = parse_bool_arg(args, i);
@@ -1032,76 +1128,6 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
     let mut result = Vec::new();
     let mut skip_next = false;
 
-    // Boolean flags that optionally take true/false
-    const GLOBAL_BOOL_FLAGS: &[&str] = &[
-        "--json",
-        "--headed",
-        "--debug",
-        "--ignore-https-errors",
-        "--allow-file-access",
-        "--hide-scrollbars",
-        "--auto-connect",
-        "--launch",
-        "--new",
-        "--annotate",
-        "--content-boundaries",
-        "--confirm-interactive",
-        "--no-auto-dialog",
-        // Action guards (issue #65 followup): skip an action instead of erroring
-        // when its target element is absent. Stripped here so they don't break a
-        // command's positional parsing; injected into the action JSON via
-        // parse_command from Flags.if_present.
-        "--if-present",
-        "--optional",
-        "--observe",
-        "--as-strict",
-        "-v",
-        "--verbose",
-        "-q",
-        "--quiet",
-        // doctor-specific flags; harmless on other commands (ignored)
-        "--offline",
-        "--quick",
-        "--fix",
-    ];
-    // Global flags that always take a value (need to skip the next arg too)
-    const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
-        "--session",
-        "--headers",
-        "--executable-path",
-        "--cdp",
-        "--browser",
-        "--as",
-        "--extension",
-        "--init-script",
-        "--enable",
-        "--profile",
-        "--state",
-        "--proxy",
-        "--proxy-bypass",
-        "--args",
-        "--user-agent",
-        "-p",
-        "--provider",
-        "--device",
-        "--session-name",
-        "--color-scheme",
-        "--download-path",
-        "--max-output",
-        "--allowed-domains",
-        "--action-policy",
-        "--confirm-actions",
-        "--config",
-        "--engine",
-        "--screenshot-dir",
-        "--screenshot-quality",
-        "--screenshot-format",
-        "--idle-timeout",
-        "--model",
-        "--humanize",
-        "--window",
-    ];
-
     let mut i = 0;
     while i < args.len() {
         let arg = &args[i];
@@ -1109,6 +1135,14 @@ pub fn clean_args(args: &[String]) -> Vec<String> {
             skip_next = false;
             i += 1;
             continue;
+        }
+        // `--` is the standard end-of-options marker: drop it and forward every
+        // remaining arg verbatim, so a site adapter can receive `--key value`
+        // overrides that would otherwise be swallowed by a global flag of the
+        // same name (issue #125): `site demo/pr-list -- --state closed`.
+        if arg == "--" {
+            result.extend(args[i + 1..].iter().cloned());
+            break;
         }
         if GLOBAL_FLAGS_WITH_VALUE.contains(&arg.as_str()) {
             skip_next = true;
@@ -1274,6 +1308,38 @@ mod tests {
     fn test_clean_args_removes_idle_timeout_before_command() {
         let cleaned = clean_args(&args("--idle-timeout 10s open example.com"));
         assert_eq!(cleaned, vec!["open", "example.com"]);
+    }
+
+    // #125: `--` ends option parsing — everything after is forwarded verbatim,
+    // so a site-adapter override colliding with a global flag survives.
+    #[test]
+    fn test_clean_args_passthrough_after_double_dash() {
+        let cleaned = clean_args(&args("site demo/pr-list -- --state closed"));
+        assert_eq!(cleaned, vec!["site", "demo/pr-list", "--state", "closed"]);
+    }
+
+    #[test]
+    fn test_clean_args_double_dash_keeps_leading_global_flags() {
+        // Global flags BEFORE `--` are still stripped; only the tail passes through.
+        let cleaned = clean_args(&args("--json site demo/pr-list -- --state closed"));
+        assert_eq!(cleaned, vec!["site", "demo/pr-list", "--state", "closed"]);
+    }
+
+    #[test]
+    fn test_parse_flags_stops_at_double_dash() {
+        // `--state` after `--` must NOT be consumed as the global auth-state flag.
+        let flags = parse_flags(&args("site demo/pr-list -- --state closed"));
+        assert_eq!(flags.state, None);
+    }
+
+    #[test]
+    fn test_is_reserved_global_flag() {
+        assert!(is_reserved_global_flag("state"));
+        assert!(is_reserved_global_flag("profile"));
+        assert!(is_reserved_global_flag("session"));
+        assert!(is_reserved_global_flag("json"));
+        assert!(!is_reserved_global_flag("repo"));
+        assert!(!is_reserved_global_flag("status"));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1141,7 +1141,37 @@ fn main() {
                 return;
             }
             // `site <name>/<cmd> [args]` → fall through to the daemon dispatch.
-            Some(spec) if spec.contains('/') => {}
+            Some(spec) if spec.contains('/') => {
+                // #125: an adapter arg whose name collides with a reserved global
+                // flag (e.g. `--state`) is swallowed by clean_args BEFORE the
+                // adapter sees it — the override silently vanishes and the adapter
+                // uses its default. Warn loudly and point at the escape hatches:
+                // pass it positionally, or after the `--` end-of-options marker.
+                // Only warn for a collision that appears BEFORE a `--` (after `--`
+                // the value is forwarded verbatim and reaches the adapter fine).
+                if let Ok(adapter) = site::load_adapter(spec) {
+                    let passthrough_at = args.iter().position(|a| a == "--");
+                    for name in &adapter.arg_order {
+                        if !flags::is_reserved_global_flag(name) {
+                            continue;
+                        }
+                        let dashed = format!("--{name}");
+                        let consumed_globally = args
+                            .iter()
+                            .enumerate()
+                            .any(|(i, a)| a == &dashed && passthrough_at.is_none_or(|p| i < p));
+                        if consumed_globally {
+                            eprintln!(
+                                "{} adapter arg \"{name}\" collides with the global --{name} flag, \
+                                 so it was consumed as a global flag and never reached the adapter. \
+                                 Pass it positionally, or after `--`: \
+                                 `chrome-use site {spec} -- --{name} <value>`",
+                                color::warning_indicator()
+                            );
+                        }
+                    }
+                }
+            }
             _ => {
                 eprintln!(
                     "{} usage: chrome-use site <name>/<cmd> [args] | site update | site list | \
@@ -2184,7 +2214,33 @@ fn main() {
     let output_opts = OutputOptions::from_flags(&flags);
 
     match send_command(cmd.clone(), &flags.session) {
-        Ok(resp) => {
+        Ok(mut resp) => {
+            // #122: a `site` adapter can return an application-level error (e.g.
+            // `{error:"HTTP 429", hint:...}`) while the *eval* itself succeeds, so
+            // the transport envelope stays `success:true` / exit 0 and automation
+            // can't tell a rate-limited/failed call from a real empty result.
+            // Promote such an adapter error into the top-level envelope so both
+            // `--json` (`success:false`, `error`) and the exit code (1) reflect it.
+            if cmd.get("action").and_then(|v| v.as_str()) == Some("site") {
+                if let Some(result) = resp.data.as_ref().and_then(|d| d.get("result")) {
+                    let adapter_err = result
+                        .get("error")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string());
+                    let explicit_fail =
+                        result.get("success").and_then(|v| v.as_bool()) == Some(false);
+                    if adapter_err.is_some() || explicit_fail {
+                        resp.success = false;
+                        if resp.error.is_none() {
+                            resp.error =
+                                Some(adapter_err.unwrap_or_else(|| {
+                                    "site adapter reported failure".to_string()
+                                }));
+                        }
+                    }
+                }
+            }
             let success = resp.success;
             // Handle interactive confirmation
             if flags.confirm_interactive {

--- a/cli/src/site.rs
+++ b/cli/src/site.rs
@@ -414,6 +414,13 @@ pub fn adapters_for_domain(host: &str) -> Vec<String> {
 /// Map CLI args to the adapter's `args` object. Positional args fill the adapter's
 /// declared `args` keys in order; `--key value` overrides by name. The adapter
 /// validates required args itself.
+///
+/// Caveat (issue #125): a `--key` whose name collides with a reserved global flag
+/// (e.g. `--state`, `--profile`, `--session`) is consumed by the global flag
+/// parser before it reaches here, so it never lands in `named`. Pass such args
+/// positionally, or after the `--` end-of-options marker
+/// (`site <name>/<cmd> -- --state closed`), which forwards everything verbatim.
+/// The CLI warns when it detects this collision.
 pub fn map_args(adapter: &Adapter, positional: &[String], named: &[(String, String)]) -> Value {
     let mut obj = serde_json::Map::new();
     // Positional args fill the adapter's declared args in DECLARATION order

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,13 @@ BIN_NAME="chrome-use"
 err() { printf '\033[31merror:\033[0m %s\n' "$1" >&2; exit 1; }
 info() { printf '\033[36m==>\033[0m %s\n' "$1" >&2; }
 
+# True only when /dev/tty can actually be opened for read+write. `[ -e /dev/tty ]`
+# is not enough: in an agent/CI shell the device node exists but opening it fails
+# with "Device not configured", which leaked raw `sh: line N: /dev/tty: Device not
+# configured` errors during an otherwise-successful install/upgrade (issue #123).
+# Probe the real open in a subshell so a failure is caught, not printed.
+have_tty() { (exec 3<>/dev/tty) 2>/dev/null; }
+
 command -v curl >/dev/null 2>&1 || err "curl is required"
 command -v tar >/dev/null 2>&1 || err "tar is required"
 
@@ -105,7 +112,7 @@ info "installed -> ${bindir}/${BIN_NAME}"
 # extension install and ask once whether chrome-use may auto-restart Chrome to
 # remove the "started debugging this browser" banner. Non-fatal: a declined or
 # failed setup never breaks the binary install. Skip with AGENT_BROWSER_NO_SETUP=1.
-if [ -e /dev/tty ] && [ -z "${AGENT_BROWSER_NO_SETUP:-}" ]; then
+if have_tty && [ -z "${AGENT_BROWSER_NO_SETUP:-}" ]; then
   info "setting up the Chrome extension + debugging-banner preference..."
   "$bindir/${BIN_NAME}" extension install < /dev/tty > /dev/tty 2>&1 || true
 else
@@ -119,7 +126,7 @@ fi
 # with AGENT_BROWSER_NO_SKILL=1. Branch on tty (NOT exit code) so a no-Node box
 # doesn't print the guidance twice.
 if [ -z "${AGENT_BROWSER_NO_SKILL:-}" ]; then
-  if [ -e /dev/tty ]; then
+  if have_tty; then
     "$bindir/${BIN_NAME}" skill install < /dev/tty > /dev/tty 2>&1 || true
   else
     "$bindir/${BIN_NAME}" skill install || true

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -189,6 +189,9 @@ chrome-use site github/issues owner/repo --json   # run it → JSON (navigates t
 ```
 
 - Positional args fill the adapter's declared args **in order**; `--key value` overrides by name.
+  If a `--key` name collides with a reserved global flag (`--state`, `--profile`, `--session`, `--timeout`, …)
+  it is consumed globally and never reaches the adapter — the CLI warns, and you should pass it
+  **positionally** or after `--`: `chrome-use site demo/pr-list -- --state closed`.
 - It navigates to the adapter's domain (reusing the current tab if you're already on it), so
   login-gated feeds (`bilibili/feed`, `twitter/...`) work because they run as *you*.
 - If no adapter fits, fall back to the normal `snapshot`/`eval` loop. Adapters come from the


### PR DESCRIPTION
Closes #122, closes #123, closes #125.

### #123 — installer `/dev/tty` errors in non-interactive shells
`install.sh` (and thus `chrome-use upgrade`, which re-runs it) checked `[ -e /dev/tty ]`, which passes when the device node exists but can't actually be opened — leaking `sh: line N: /dev/tty: Device not configured` on agent/CI shells. Replaced with `have_tty()` that probes a real read+write open in a subshell; the guided extension/skill setup is now cleanly skipped instead of erroring.

### #122 — site adapter errors returned exit 0 / `success:true`
A `site` adapter can return an app-level error (e.g. `{error:"HTTP 429", hint:...}`) while the underlying `eval` succeeds, so the envelope stayed `success:true` and exit 0 — automation couldn't distinguish a rate-limited call from a real empty result. Now a `result.error` (or `result.success:false`) is promoted into the top-level envelope (`success:false` + `error`) and the process exits 1.

### #125 — `--key value` silently dropped when it collides with a global flag
`clean_args`/`parse_flags` consumed `--state closed` (etc.) as the global auth-state flag before the adapter saw it, with no warning. Fixes:
- **`--` end-of-options passthrough**: `parse_flags`, `clean_args`, and `extract_config_path` all stop at a bare `--`, so `chrome-use site demo/pr-list -- --state closed` forwards the override verbatim to the adapter.
- **Collision warning**: when an adapter declares an arg whose name matches a reserved global flag and it appears before any `--`, a stderr warning points at the positional / `--` escape hatches.
- Docs: `SKILL.md` + `map_args` doc comment.

### Tests
New unit tests: `--` passthrough in `clean_args`, `parse_flags` stops at `--`, `is_reserved_global_flag`. Full `cargo test` green except 2 pre-existing, environment-only failures in `native::stream::http::tests` (Unix-socket `SUN_LEN` path-length + poison cascade) that also fail on `main` untouched. `cargo clippy` clean.

🤖 by chrome-use-2 (AgentParty coordination with chrome-use-1 who owns #126/#127).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for `--` so arguments after it are forwarded unchanged.
  * Added warnings when adapter arguments conflict with reserved global options.
  * Site adapter failures now correctly affect JSON results and CLI exit status.

* **Bug Fixes**
  * Prevented global options from being incorrectly consumed after `--`.
  * Improved installer behavior in environments without an available terminal.

* **Documentation**
  * Documented reserved-option conflicts and recommended ways to forward adapter arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->