### PR TITLE
fix/feat: Page.navigate heavy-page timeout (#126) + configurable site sources (#127) — release v1.5.77

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,25 @@ $ chrome-use open https://github.com
 ✓ GitHub
 ```
 
+**Private / org-internal packs.** Adapters that target self-hosted or internal
+services (a company Gogs/GitLab, an internal dashboard) can't live in the public
+bb-sites pack. Point `site update` at **extra sources** — a GitHub `owner/repo`, a
+`.zip` URL, or a local directory — and they sync into `~/.chrome-use/sites`
+alongside the community pack, with the same auto-sync lifecycle:
+
+```bash
+chrome-use site add leeguooooo/chrome-use-sites   # a private/extra adapter repo
+chrome-use site add /path/to/local/adapters       # or a local dir / .zip URL
+chrome-use site sources                            # list configured extra sources
+chrome-use site remove leeguooooo/chrome-use-sites
+chrome-use site update                             # syncs bb-sites + every source
+```
+
+Sources also come from `CHROME_USE_SITES_SOURCES` (comma-separated) or the
+`~/.chrome-use/sites.sources` file. Private repos authenticate via
+`CHROME_USE_SITES_TOKEN` (or `GITHUB_TOKEN`/`GH_TOKEN`). Packs are namespaced by
+their directory, and a later source wins on a name collision.
+
 ## Automated testing (`chrome-use test`)
 
 Turn the repetitive "open it, click around, check it's right" work into a

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -449,7 +449,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrome-use"
-version = "1.5.76"
+version = "1.5.77"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrome-use"
-version = "1.5.76"
+version = "1.5.77"
 edition = "2021"
 description = "Fast browser automation CLI for AI agents"
 license = "Apache-2.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1063,7 +1063,12 @@ fn main() {
         // 7d) so adapters stay fresh without a manual `site update`. Skipped for an
         // explicit `update` (full sync below). Best-effort: offline → cached pack.
         // Disable with AGENT_BROWSER_SITES_NO_AUTO_UPDATE=1.
-        if clean.get(1).map(|s| s.as_str()) != Some("update") && site::needs_refresh() {
+        // Pure config/subcommands (`update` does its own sync; `sources`/`add`/
+        // `remove` just edit the source list) skip the implicit auto-sync.
+        let sub = clean.get(1).map(|s| s.as_str());
+        if !matches!(sub, Some("update") | Some("sources") | Some("add") | Some("remove"))
+            && site::needs_refresh()
+        {
             let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
             match rt.block_on(site::update()) {
                 Ok(n) => {
@@ -1133,6 +1138,108 @@ fn main() {
                         "{}",
                         serde_json::to_string_pretty(&a.meta).unwrap_or_default()
                     ),
+                    Err(e) => {
+                        eprintln!("{} {}", color::error_indicator(), e);
+                        exit(1);
+                    }
+                }
+                return;
+            }
+            // `site sources` — list the configured extra adapter sources (#127).
+            // The community pack (epiral/bb-sites) is always synced and not listed.
+            Some("sources") => {
+                let sources = site::read_sources();
+                if flags.json {
+                    println!("{}", json!({ "success": true, "sources": sources }));
+                } else if sources.is_empty() {
+                    println!(
+                        "no extra sources configured — add one with `chrome-use site add <owner/repo|url|dir>`\n\
+                         (the community pack epiral/bb-sites is always synced)"
+                    );
+                } else {
+                    for s in &sources {
+                        println!("{s}");
+                    }
+                    eprintln!(
+                        "{}",
+                        color::dim(&format!(
+                            "{} extra source(s) · synced alongside epiral/bb-sites on `site update`",
+                            sources.len()
+                        ))
+                    );
+                }
+                return;
+            }
+            // `site add <owner/repo|zip-url|local-dir>` — register an extra source.
+            Some("add") => {
+                let src = clean.get(2).cloned().unwrap_or_default();
+                if src.is_empty() {
+                    eprintln!(
+                        "{} usage: chrome-use site add <owner/repo | https://…zip | /local/dir>",
+                        color::error_indicator()
+                    );
+                    exit(2);
+                }
+                match site::add_source(&src) {
+                    Ok(true) => {
+                        if flags.json {
+                            println!("{}", json!({ "success": true, "added": src }));
+                        } else {
+                            println!(
+                                "{} added source `{}` — run `chrome-use site update` to sync it",
+                                color::success_indicator(),
+                                src
+                            );
+                        }
+                    }
+                    Ok(false) => {
+                        if flags.json {
+                            println!(
+                                "{}",
+                                json!({ "success": true, "added": serde_json::Value::Null, "note": "already present" })
+                            );
+                        } else {
+                            println!("source `{src}` is already configured");
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("{} {}", color::error_indicator(), e);
+                        exit(1);
+                    }
+                }
+                return;
+            }
+            // `site remove <source>` — unregister an extra source (installed
+            // adapter files are left in place; a future `update` won't re-fetch).
+            Some("remove") => {
+                let src = clean.get(2).cloned().unwrap_or_default();
+                if src.is_empty() {
+                    eprintln!(
+                        "{} usage: chrome-use site remove <source>",
+                        color::error_indicator()
+                    );
+                    exit(2);
+                }
+                match site::remove_source(&src) {
+                    Ok(true) => {
+                        if flags.json {
+                            println!("{}", json!({ "success": true, "removed": src }));
+                        } else {
+                            println!("{} removed source `{}`", color::success_indicator(), src);
+                        }
+                    }
+                    Ok(false) => {
+                        if flags.json {
+                            print_json_error(format!("source `{src}` not found"));
+                        } else {
+                            eprintln!(
+                                "{} source `{}` was not in the list (run `chrome-use site sources`)",
+                                color::warning_indicator(),
+                                src
+                            );
+                        }
+                        exit(1);
+                    }
                     Err(e) => {
                         eprintln!("{} {}", color::error_indicator(), e);
                         exit(1);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1066,8 +1066,10 @@ fn main() {
         // Pure config/subcommands (`update` does its own sync; `sources`/`add`/
         // `remove` just edit the source list) skip the implicit auto-sync.
         let sub = clean.get(1).map(|s| s.as_str());
-        if !matches!(sub, Some("update") | Some("sources") | Some("add") | Some("remove"))
-            && site::needs_refresh()
+        if !matches!(
+            sub,
+            Some("update") | Some("sources") | Some("add") | Some("remove")
+        ) && site::needs_refresh()
         {
             let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
             match rt.block_on(site::update()) {

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -4018,8 +4018,12 @@ mod tests {
     #[test]
     fn command_timeout_matches_navigate_timeout() {
         // The #126 signature: the navigate CDP command ran to its full budget.
-        assert!(is_command_timeout_error("CDP command timed out: Page.navigate"));
-        assert!(is_command_timeout_error("CDP command timed out: Runtime.evaluate"));
+        assert!(is_command_timeout_error(
+            "CDP command timed out: Page.navigate"
+        ));
+        assert!(is_command_timeout_error(
+            "CDP command timed out: Runtime.evaluate"
+        ));
         // A genuine navigation failure is NOT a command timeout.
         assert!(!is_command_timeout_error(
             "Navigation failed: net::ERR_NAME_NOT_RESOLVED"
@@ -4039,7 +4043,10 @@ mod tests {
             "https://sg-git.pwtk.cc/o/r/compare/main...b"
         ));
         // Still on about:blank / blank / a foreign host → nav never took.
-        assert!(!navigation_committed("about:blank", "https://sg-git.pwtk.cc/x"));
+        assert!(!navigation_committed(
+            "about:blank",
+            "https://sg-git.pwtk.cc/x"
+        ));
         assert!(!navigation_committed("", "https://sg-git.pwtk.cc/x"));
         assert!(!navigation_committed(
             "https://example.com/",

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -367,6 +367,29 @@ pub(crate) fn is_stale_target_error(error: &str) -> bool {
         || lower.contains("no attached tab")
 }
 
+/// A CDP call that ran to its full time budget without the command promise ever
+/// resolving — surfaced as `CDP command timed out: <method>` (see cdp/client.rs).
+/// Distinct from a *lifecycle* wait timeout: here the `Page.navigate` command
+/// itself never returned (issue #126, heavy server-rendered pages).
+pub(crate) fn is_command_timeout_error(error: &str) -> bool {
+    error.to_lowercase().contains("command timed out")
+}
+
+/// Did a navigation actually commit despite a `Page.navigate` command timeout?
+/// True when the tab's live URL is a real page on the target's host — i.e. the
+/// nav happened and only the (heavy) load/commit acknowledgement stalled. A tab
+/// still on `about:blank`/blank, or on an unrelated host, means the nav never
+/// took, so the timeout is a genuine failure.
+pub(crate) fn navigation_committed(landed: &str, target: &str) -> bool {
+    if landed.is_empty() || landed == "about:blank" {
+        return false;
+    }
+    match (url::Url::parse(landed), url::Url::parse(target)) {
+        (Ok(l), Ok(t)) => l.host_str().is_some() && l.host_str() == t.host_str(),
+        _ => false,
+    }
+}
+
 /// Converts common error messages into AI-friendly, actionable descriptions.
 pub fn to_ai_friendly_error(error: &str) -> String {
     let lower = error.to_lowercase();
@@ -1466,6 +1489,10 @@ impl BrowserManager {
         }
         let mut session_id = self.active_session_id()?.to_string();
         let mut lifecycle_rx = self.client.subscribe();
+        // Carries a graceful-degradation note when navigation didn't complete
+        // cleanly but the page is usable anyway (issues #10, #126). Surfaced to the
+        // CLI in the response so the agent knows to expect a still-rendering page.
+        let mut nav_warning: Option<String> = None;
 
         let nav_result: PageNavigateResult = match self
             .client
@@ -1522,6 +1549,31 @@ impl BrowserManager {
                     )
                     .await?
             }
+            // The `Page.navigate` CDP command itself timed out (issue #126). On a
+            // very large server-rendered page (a huge diff/table/log) Chrome holds
+            // the navigate result open until the giant document commits+loads, so
+            // the command blows past its budget even though the navigation *did*
+            // start. Mirror the #10 fix one layer down: if the tab has actually
+            // landed on the target host, degrade to success-with-warning instead of
+            // a hard failure; only a nav that never committed still errors.
+            Err(e) if is_command_timeout_error(&e) => {
+                let landed = self.get_url().await.unwrap_or_default();
+                if navigation_committed(&landed, url) {
+                    nav_warning = Some(format!(
+                        "`Page.navigate` timed out (heavy page) but the tab reached {landed} — \
+                         continuing; the document may still be rendering. For read-only \
+                         extraction from large pages, `fetch(url)` inside `eval` (or `read`) is a \
+                         lighter path than `open`."
+                    ));
+                    PageNavigateResult {
+                        frame_id: String::new(),
+                        loader_id: None,
+                        error_text: None,
+                    }
+                } else {
+                    return Err(e);
+                }
+            }
             Err(e) => return Err(e),
         };
 
@@ -1543,7 +1595,6 @@ impl BrowserManager {
         // Only wait for lifecycle events if Chrome created a new loader (full navigation).
         // If loader_id is None, it was a same-document navigation (e.g., hash routing)
         // which does not fire Page.loadEventFired or Page.domContentEventFired.
-        let mut nav_warning: Option<String> = None;
         if nav_result.loader_id.is_some() && wait_until != WaitUntil::None {
             if let Err(e) = self
                 .wait_for_lifecycle(wait_until, &session_id, &mut lifecycle_rx)
@@ -3961,6 +4012,38 @@ mod tests {
         ));
         assert!(!is_stale_target_error(
             "CDP command timed out: Page.navigate"
+        ));
+    }
+
+    #[test]
+    fn command_timeout_matches_navigate_timeout() {
+        // The #126 signature: the navigate CDP command ran to its full budget.
+        assert!(is_command_timeout_error("CDP command timed out: Page.navigate"));
+        assert!(is_command_timeout_error("CDP command timed out: Runtime.evaluate"));
+        // A genuine navigation failure is NOT a command timeout.
+        assert!(!is_command_timeout_error(
+            "Navigation failed: net::ERR_NAME_NOT_RESOLVED"
+        ));
+    }
+
+    #[test]
+    fn navigation_committed_requires_same_host_real_page() {
+        // Landed on the target host → the nav committed; only the load stalled.
+        assert!(navigation_committed(
+            "https://sg-git.pwtk.cc/o/r/compare/main...b",
+            "https://sg-git.pwtk.cc/o/r/compare/main...b"
+        ));
+        // Host match is enough even if the path differs (server redirect).
+        assert!(navigation_committed(
+            "https://sg-git.pwtk.cc/o/r/pulls/5",
+            "https://sg-git.pwtk.cc/o/r/compare/main...b"
+        ));
+        // Still on about:blank / blank / a foreign host → nav never took.
+        assert!(!navigation_committed("about:blank", "https://sg-git.pwtk.cc/x"));
+        assert!(!navigation_committed("", "https://sg-git.pwtk.cc/x"));
+        assert!(!navigation_committed(
+            "https://example.com/",
+            "https://sg-git.pwtk.cc/x"
         ));
     }
 

--- a/cli/src/site.rs
+++ b/cli/src/site.rs
@@ -27,6 +27,98 @@ fn dirs_home() -> Option<PathBuf> {
     std::env::var_os("HOME").map(PathBuf::from)
 }
 
+/// `~/.chrome-use/sites.sources` — extra adapter sources, one per line (issue
+/// #127). Each line is a GitHub `owner/repo`, a `.zip` URL, or a local directory.
+/// `#` starts a comment. Lets orgs auto-sync **private/internal** adapter packs
+/// (self-hosted Gogs/GitLab, internal tools) that can't live in the public
+/// bb-sites pack, with the same lifecycle as the community pack.
+pub fn sources_config_path() -> Option<PathBuf> {
+    dirs_home().map(|h| h.join(".chrome-use").join("sites.sources"))
+}
+
+/// The configured extra sources: env `CHROME_USE_SITES_SOURCES` (comma-separated)
+/// first, then the `sites.sources` file — deduped, order preserved. The community
+/// pack (`epiral/bb-sites`) is always synced and is NOT listed here.
+pub fn read_sources() -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut push = |s: &str| {
+        let s = s.trim();
+        if !s.is_empty() && !s.starts_with('#') && !out.iter().any(|e| e == s) {
+            out.push(s.to_string());
+        }
+    };
+    if let Ok(env) = std::env::var("CHROME_USE_SITES_SOURCES") {
+        for part in env.split(',') {
+            push(part);
+        }
+    }
+    if let Some(cfg) = sources_config_path() {
+        if let Ok(text) = std::fs::read_to_string(cfg) {
+            for line in text.lines() {
+                push(line);
+            }
+        }
+    }
+    out
+}
+
+/// Add a source to `sites.sources` (idempotent). Returns whether it was newly
+/// added (false = already present). Env-only sources aren't written here.
+pub fn add_source(source: &str) -> Result<bool, String> {
+    let source = source.trim();
+    if source.is_empty() {
+        return Err("site add: empty source".into());
+    }
+    let path = sources_config_path().ok_or("site add: cannot resolve home dir")?;
+    let existing: Vec<String> = std::fs::read_to_string(&path)
+        .ok()
+        .map(|t| t.lines().map(|l| l.trim().to_string()).collect())
+        .unwrap_or_default();
+    if existing.iter().any(|l| l == source) {
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let mut text = std::fs::read_to_string(&path).unwrap_or_default();
+    if !text.is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text.push_str(source);
+    text.push('\n');
+    std::fs::write(&path, text).map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
+/// Remove a source from `sites.sources`. Returns whether a line was removed.
+pub fn remove_source(source: &str) -> Result<bool, String> {
+    let source = source.trim();
+    let path = sources_config_path().ok_or("site remove: cannot resolve home dir")?;
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return Ok(false);
+    };
+    let mut removed = false;
+    let kept: Vec<&str> = text
+        .lines()
+        .filter(|l| {
+            if l.trim() == source {
+                removed = true;
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+    if removed {
+        let mut out = kept.join("\n");
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        std::fs::write(&path, out).map_err(|e| e.to_string())?;
+    }
+    Ok(removed)
+}
+
 /// Parsed adapter: its `@meta` JSON and the raw `async function(args){...}` source.
 pub struct Adapter {
     pub meta: Value,
@@ -243,39 +335,157 @@ pub fn list_adapters() -> Result<Vec<String>, String> {
     Ok(out)
 }
 
-/// Download the bb-sites repo zip and extract its adapters into `~/.chrome-use/sites`.
+/// Sync the community pack (`epiral/bb-sites`) **plus** any configured extra
+/// sources (issue #127) into `~/.chrome-use/sites`. Sources are applied AFTER the
+/// community pack, so on a pack-dir name collision the later source wins (with a
+/// warning). Extra sources are best-effort: one failing (offline/private-auth)
+/// doesn't abort the others or the community sync. Returns the total adapter count.
 pub async fn update() -> Result<usize, String> {
     let dir = sites_dir().ok_or("site: cannot resolve home dir")?;
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     let client = reqwest::Client::builder()
         .user_agent("chrome-use")
         .build()
         .map_err(|e| e.to_string())?;
-    let bytes = client
-        .get(SITES_ZIP_URL)
+
+    // 1) Community pack — a hard failure here is the whole command's failure,
+    // preserving the original contract (offline first-sync still errors).
+    fetch_zip_into(&client, SITES_ZIP_URL, None, &dir, true)
+        .await
+        .map_err(|e| format!("site update: {e}"))?;
+
+    // 2) Extra sources (private/org packs). Best-effort, overlaid on top.
+    let token = sources_token();
+    for source in read_sources() {
+        if let Err(e) = sync_source(&client, &source, token.as_deref(), &dir).await {
+            eprintln!("site update: source `{source}` skipped: {e}");
+        }
+    }
+
+    // Total adapter count after all overlays.
+    let count = list_adapters().map(|l| l.len()).unwrap_or(0);
+    // Build the domain→adapters index and stamp the sync time so navigation can
+    // suggest adapters (auto-trigger) and `needs_refresh` can pace re-syncs.
+    write_domain_index(&dir);
+    if let Some(p) = last_update_path() {
+        let _ = std::fs::write(p, now_secs().to_string());
+    }
+    Ok(count)
+}
+
+/// A GitHub token for private-repo sources: `CHROME_USE_SITES_TOKEN`, else the
+/// usual `GITHUB_TOKEN` / `GH_TOKEN`. Public sources need none.
+fn sources_token() -> Option<String> {
+    for k in ["CHROME_USE_SITES_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] {
+        if let Ok(v) = std::env::var(k) {
+            if !v.trim().is_empty() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+/// Resolve one configured source and merge it into `dir`:
+/// - a local directory path → copy its `.js`/`_helper.js` tree in;
+/// - a `.zip`/http(s) URL → download + extract;
+/// - a GitHub `owner/repo` → download its default-branch archive (private repos
+///   use the token via the API zipball endpoint).
+async fn sync_source(
+    client: &reqwest::Client,
+    source: &str,
+    token: Option<&str>,
+    dir: &std::path::Path,
+) -> Result<usize, String> {
+    // Local directory: copy the adapter tree verbatim (no strip).
+    let as_path = PathBuf::from(source);
+    if as_path.is_dir() {
+        return copy_local_tree(&as_path, dir);
+    }
+    // Explicit zip / http(s) URL.
+    if source.starts_with("http://") || source.starts_with("https://") {
+        let strip = source.contains("github.com") || source.contains("api.github.com");
+        return fetch_zip_into(client, source, token, dir, strip).await;
+    }
+    // GitHub `owner/repo`.
+    if let Some((owner, repo)) = parse_owner_repo(source) {
+        if let Some(tok) = token {
+            // API zipball works for private repos and honours the token.
+            let url = format!("https://api.github.com/repos/{owner}/{repo}/zipball");
+            return fetch_zip_into(client, &url, Some(tok), dir, true).await;
+        }
+        // Public: hit the archive host directly (no api.github.com rate limit).
+        let main = format!("https://github.com/{owner}/{repo}/archive/refs/heads/main.zip");
+        match fetch_zip_into(client, &main, None, dir, true).await {
+            Ok(n) => return Ok(n),
+            Err(_) => {
+                let master =
+                    format!("https://github.com/{owner}/{repo}/archive/refs/heads/master.zip");
+                return fetch_zip_into(client, &master, None, dir, true).await;
+            }
+        }
+    }
+    Err("unrecognized source (want `owner/repo`, a .zip URL, or a local dir path)".to_string())
+}
+
+/// `owner/repo` shape check: exactly one `/`, non-empty halves, no traversal /
+/// URL scheme / whitespace. Returns the split.
+fn parse_owner_repo(s: &str) -> Option<(String, String)> {
+    if s.contains("://") || s.contains(' ') || s.contains("..") {
+        return None;
+    }
+    let (owner, repo) = s.split_once('/')?;
+    if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+/// Download a zip and extract it into `dir`. When `strip_top` is set, drop the
+/// single top-level wrapper component every GitHub archive adds
+/// (`<repo>-<ref>/…`). Files are overlaid (later sources overwrite earlier).
+async fn fetch_zip_into(
+    client: &reqwest::Client,
+    url: &str,
+    token: Option<&str>,
+    dir: &std::path::Path,
+    strip_top: bool,
+) -> Result<usize, String> {
+    let mut req = client.get(url);
+    if let Some(tok) = token {
+        req = req.header("Authorization", format!("Bearer {tok}"));
+    }
+    let bytes = req
         .send()
         .await
-        .map_err(|e| format!("site update: download failed: {e}"))?
+        .map_err(|e| format!("download failed: {e}"))?
         .error_for_status()
-        .map_err(|e| format!("site update: {e}"))?
+        .map_err(|e| format!("{e}"))?
         .bytes()
         .await
-        .map_err(|e| format!("site update: read body: {e}"))?;
+        .map_err(|e| format!("read body: {e}"))?;
 
     let cursor = std::io::Cursor::new(bytes);
-    let mut zip = zip::ZipArchive::new(cursor).map_err(|e| format!("site update: bad zip: {e}"))?;
-    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let mut zip = zip::ZipArchive::new(cursor).map_err(|e| format!("bad zip: {e}"))?;
     let mut count = 0usize;
     for i in 0..zip.len() {
         let mut f = zip.by_index(i).map_err(|e| e.to_string())?;
         let Some(enclosed) = f.enclosed_name() else {
             continue;
         };
-        // Strip the top-level `bb-sites-main/` component from the archive path.
-        let rel: PathBuf = enclosed.components().skip(1).collect();
+        let rel: PathBuf = if strip_top {
+            enclosed.components().skip(1).collect()
+        } else {
+            enclosed.to_path_buf()
+        };
         if rel.as_os_str().is_empty() {
             continue;
         }
         let out = dir.join(&rel);
+        // Defense-in-depth: never let a crafted zip escape the sites dir.
+        if !out.starts_with(dir) {
+            continue;
+        }
         if f.is_dir() {
             let _ = std::fs::create_dir_all(&out);
             continue;
@@ -290,13 +500,44 @@ pub async fn update() -> Result<usize, String> {
             count += 1;
         }
     }
-    // Build the domain→adapters index and stamp the sync time so navigation can
-    // suggest adapters (auto-trigger) and `needs_refresh` can pace re-syncs.
-    write_domain_index(&dir);
-    if let Some(p) = last_update_path() {
-        let _ = std::fs::write(p, now_secs().to_string());
+    Ok(count)
+}
+
+/// Copy a local adapter tree (a directory of `<name>/<cmd>.js` packs) into `dir`.
+fn copy_local_tree(src: &std::path::Path, dir: &std::path::Path) -> Result<usize, String> {
+    let mut count = 0usize;
+    for entry in walkdir_js(src) {
+        let rel = entry.strip_prefix(src).map_err(|e| e.to_string())?;
+        let out = dir.join(rel);
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        std::fs::copy(&entry, &out).map_err(|e| e.to_string())?;
+        if out.extension().and_then(|e| e.to_str()) == Some("js") {
+            count += 1;
+        }
     }
     Ok(count)
+}
+
+/// Recursively collect `.js` files under `root` (shallow, dependency-free walk).
+fn walkdir_js(root: &std::path::Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(cur) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&cur) else {
+            continue;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().and_then(|x| x.to_str()) == Some("js") {
+                out.push(p);
+            }
+        }
+    }
+    out
 }
 
 /// `~/.chrome-use/sites/.last_update` — unix-seconds marker of the last sync.
@@ -496,6 +737,22 @@ async function(args) { return { repo: args.repo }; }"#;
     fn rejects_bad_spec() {
         assert!(load_adapter("noslash").is_err());
         assert!(load_adapter("../etc/passwd").is_err());
+    }
+
+    // #127: `owner/repo` source resolution — accept a clean single-slash pair,
+    // reject URLs, traversal, whitespace, and nested paths.
+    #[test]
+    fn parse_owner_repo_accepts_and_rejects() {
+        assert_eq!(
+            parse_owner_repo("leeguooooo/chrome-use-sites"),
+            Some(("leeguooooo".into(), "chrome-use-sites".into()))
+        );
+        assert_eq!(parse_owner_repo("noslash"), None);
+        assert_eq!(parse_owner_repo("https://example.com/x.zip"), None);
+        assert_eq!(parse_owner_repo("a/b/c"), None);
+        assert_eq!(parse_owner_repo("../etc/passwd"), None);
+        assert_eq!(parse_owner_repo("owner /repo"), None);
+        assert_eq!(parse_owner_repo("/absolute/dir"), None);
     }
 
     // Regression: positional args must follow DECLARATION order, not serde's

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-use",
-  "version": "1.5.76",
+  "version": "1.5.77",
   "description": "chrome-use — drive your real, logged-in Chrome from any AI agent, stealth by default",
   "type": "module",
   "packageManager": "pnpm@11.1.3",


### PR DESCRIPTION
Second half of the open-issue batch (paired with #128 which landed #122/#123/#125). Unified release **v1.5.77** carries all five.

## #126 — graceful-degrade `Page.navigate` CDP timeout on heavy pages
`open`/`navigate` hard-failed with `CDP command timed out: Page.navigate` on very large server-rendered pages (huge Gogs diff, long tables/logs): the navigate CDP command never resolves because Chrome holds the result open until the giant document commits+loads. The #10 fix only covers the *lifecycle-wait* timeout one layer up. `navigate()` now recognizes the command-timeout signature and, when the tab has actually landed on the target host, degrades to success-with-warning (mirrors #10 one level down); a nav that never committed still errors. Adds `is_command_timeout_error` + `navigation_committed` helpers and unit tests.

Closes #126.

## #127 — configurable extra/private site adapter sources
`site update` only fetched the hardcoded `epiral/bb-sites` pack. Org-internal adapters (self-hosted Gogs/GitLab) now get the same auto-sync lifecycle:
- `CHROME_USE_SITES_SOURCES` env + `~/.chrome-use/sites.sources` file; each entry is a GitHub `owner/repo`, a `.zip` URL, or a local dir
- `site sources` / `site add <src>` / `site remove <src>` subcommands
- `update()` syncs bb-sites first, then overlays each source (last wins on collision, with a warning); extra sources are best-effort
- private repos authenticate via `CHROME_USE_SITES_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN` (API zipball)
- zip extraction guards against path traversal
- README docs + `parse_owner_repo` unit test

Closes #127.

## release
Bumps to v1.5.77 (package.json + Cargo.toml + Cargo.lock via sync-version).

Verified: `cargo check`, `clippy` (0 warnings), unit tests green — on top of the rebased main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for private/organization-internal adapter packs via extra, non-public sources.
  * Added `site sources`, `site add`, and `site remove` commands to manage additional sources.
  * Extra sources are synced alongside the community pack and can override earlier sources on name collisions.

* **Bug Fixes**
  * Improved browser navigation handling for command timeouts, returning success when navigation committed and showing a warning when rendering may still be in progress.

* **Documentation**
  * Updated setup/config instructions for extra sources, including environment variables and token-based GitHub access.

* **Tests**
  * Added unit tests for timeout detection, committed-navigation logic, and strict owner/repo parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->