### PR TITLE
feat(network): capture WebSocket connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ chrome-use network route "*/api/save" --method POST --set-header Authorization="
 chrome-use network route "*/v1/*" --rewrite-url https://staging.example.com/v1/thing                     # redirect
 chrome-use network route "*/api/me" --edit-status 503 --edit-header X-Env=test --replace 'prod=>staging' # edit the real response
 chrome-use network route "*/analytics" --abort                                                           # block
+chrome-use network requests --type websocket                                                              # connection metadata only, no frame payloads
 ```
 
 Verbs/fields mirror Playwright's `route`/`fulfill`/`continue`/`abort`. Deep-dive

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -185,6 +185,8 @@ fn set_json_path(root: &mut Value, path: &str, val: Value) {
     }
 }
 
+/// Captured HTTP request or WebSocket connection metadata exposed by
+/// `network requests`. WebSocket frame payloads are intentionally excluded.
 #[derive(Clone, serde::Serialize)]
 pub struct TrackedRequest {
     pub url: String,
@@ -1032,10 +1034,7 @@ impl DaemonState {
                                         .and_then(|v| v.as_str())
                                         .unwrap_or("Other")
                                         .to_string();
-                                    let timestamp = std::time::SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map(|d| d.as_millis() as u64)
-                                        .unwrap_or(0);
+                                    let timestamp = unix_timestamp_millis() as u64;
                                     self.tracked_requests.push(TrackedRequest {
                                         url,
                                         method,
@@ -1053,6 +1052,33 @@ impl DaemonState {
                                     });
                                 }
                             }
+                        }
+                        "Network.webSocketCreated" if self.request_tracking => {
+                            let request_id = event
+                                .params
+                                .get("requestId")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            let url = event
+                                .params
+                                .get("url")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            let timestamp = unix_timestamp_millis() as u64;
+                            self.tracked_requests.push(TrackedRequest {
+                                url,
+                                method: "GET".to_string(),
+                                headers: json!({}),
+                                timestamp,
+                                resource_type: "WebSocket".to_string(),
+                                request_id,
+                                post_data: None,
+                                status: None,
+                                response_headers: None,
+                                mime_type: None,
+                            });
                         }
                         "Network.responseReceived"
                             if self.har_recording || self.request_tracking =>
@@ -11022,10 +11048,16 @@ async fn enable_request_tracking(state: &mut DaemonState) {
     }
     state.request_tracking = true;
     if let Some(ref mgr) = state.browser {
+        let mut session_ids: Vec<String> = state.iframe_sessions.values().cloned().collect();
         if let Ok(session_id) = mgr.active_session_id() {
+            session_ids.push(session_id.to_string());
+        }
+        session_ids.sort();
+        session_ids.dedup();
+        for session_id in session_ids {
             let _ = mgr
                 .client
-                .send_command_no_params("Network.enable", Some(session_id))
+                .send_command_no_params("Network.enable", Some(&session_id))
                 .await;
         }
     }

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -117,6 +117,84 @@ async fn send_raw_http_request(port: u64, request: &str) -> String {
     String::from_utf8(response).expect("HTTP response should be utf-8")
 }
 
+async fn spawn_html_server(
+    html: String,
+    request_count: usize,
+) -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("HTTP listener should bind");
+    let port = listener
+        .local_addr()
+        .expect("HTTP listener should have an address")
+        .port();
+    let task = tokio::spawn(async move {
+        for _ in 0..request_count {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("HTTP server should accept a connection");
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                html.len(),
+                html
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("HTTP response should be written");
+        }
+    });
+    (port, task)
+}
+
+async fn spawn_websocket_server(connection_count: usize) -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("websocket listener should bind");
+    let port = listener
+        .local_addr()
+        .expect("websocket listener should have an address")
+        .port();
+    let task = tokio::spawn(async move {
+        for _ in 0..connection_count {
+            let (stream, _) = listener
+                .accept()
+                .await
+                .expect("websocket server should accept a connection");
+            tokio::spawn(async move {
+                let mut websocket = tokio_tungstenite::accept_async(stream)
+                    .await
+                    .expect("websocket handshake should succeed");
+                while websocket.next().await.is_some() {}
+            });
+        }
+    });
+    (port, task)
+}
+
+async fn wait_for_evaluation(state: &mut DaemonState, script: &str, failure_message: &str) {
+    for attempt in 0..50 {
+        let evaluated = execute_command(
+            &json!({
+                "id": format!("condition-{attempt}"),
+                "action": "evaluate",
+                "script": script
+            }),
+            state,
+        )
+        .await;
+        assert_success(&evaluated);
+        if get_data(&evaluated)["result"] == true {
+            return;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+    panic!("{failure_message}");
+}
+
 #[cfg(unix)]
 async fn spawn_fake_daemon_socket(
     socket_dir: &std::path::Path,
@@ -211,6 +289,193 @@ async fn e2e_launch_navigate_evaluate_close() {
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);
     assert_eq!(get_data(&resp)["closed"], true);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_network_requests_capture_websocket_connections() {
+    let (websocket_port, websocket_task) = spawn_websocket_server(2).await;
+    let iframe_page = format!(
+        r#"<!doctype html>
+<title>WebSocket iframe probe</title>
+<link rel="icon" href="data:,">
+<script>
+window.addEventListener("message", (event) => {{
+  if (event.data !== "start-websocket-probe") return;
+  window.websocketProbe = new WebSocket("ws://localhost:{websocket_port}/ws/iframe-probe");
+  window.websocketProbe.addEventListener("open", () => {{
+    parent.postMessage("iframe-websocket-open", "*");
+  }});
+}});
+parent.postMessage("iframe-probe-loaded", "*");
+</script>"#
+    );
+    let (iframe_port, iframe_task) = spawn_html_server(iframe_page, 1).await;
+    let page = format!(
+        r#"<!doctype html>
+<title>WebSocket network probe</title>
+<link rel="icon" href="data:,">
+<iframe id="probe-frame" src="http://localhost:{iframe_port}/"></iframe>
+<script>
+window.addEventListener("message", (event) => {{
+  if (event.data === "iframe-probe-loaded") window.iframeProbeLoaded = true;
+  if (event.data === "iframe-websocket-open") window.iframeWebsocketReady = true;
+}});
+window.startNetworkProbes = () => {{
+  window.websocketProbe = new WebSocket("ws://127.0.0.1:{websocket_port}/ws/top-level-probe");
+  window.websocketProbe.addEventListener("open", () => {{
+    window.topLevelWebsocketReady = true;
+  }});
+  fetch("/http-probe").then(() => {{
+    window.httpProbeReady = true;
+  }});
+  document.getElementById("probe-frame").contentWindow.postMessage("start-websocket-probe", "*");
+}};
+</script>"#
+    );
+    let (http_port, http_task) = spawn_html_server(page, 2).await;
+
+    let mut state = DaemonState::new();
+    let launch = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&launch);
+
+    let navigate = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": format!("http://127.0.0.1:{http_port}/")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&navigate);
+
+    wait_for_evaluation(
+        &mut state,
+        "window.iframeProbeLoaded === true",
+        "cross-origin iframe should attach before request tracking starts",
+    )
+    .await;
+
+    let clear_before = execute_command(
+        &json!({ "id": "3", "action": "requests", "clear": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&clear_before);
+
+    let start = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "window.startNetworkProbes()"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&start);
+
+    wait_for_evaluation(
+        &mut state,
+        "window.topLevelWebsocketReady === true && window.iframeWebsocketReady === true && window.httpProbeReady === true",
+        "top-level, iframe, and HTTP probes should complete"
+    )
+    .await;
+
+    let requests = execute_command(
+        &json!({
+            "id": "5",
+            "action": "requests",
+            "filter": "/ws/",
+            "type": "websocket"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&requests);
+    let captured = get_data(&requests)["requests"]
+        .as_array()
+        .expect("requests response should contain an array");
+    assert_eq!(
+        captured.len(),
+        2,
+        "network requests should capture top-level and pre-existing iframe websockets: {}",
+        serde_json::to_string_pretty(&requests).unwrap_or_default()
+    );
+    for connection in captured {
+        assert_eq!(connection["resourceType"], "WebSocket");
+        assert_eq!(connection["method"], "GET");
+        assert!(
+            connection["timestamp"]
+                .as_u64()
+                .is_some_and(|value| value > 0),
+            "websocket timestamp should be present"
+        );
+        assert!(
+            connection["requestId"]
+                .as_str()
+                .is_some_and(|request_id| !request_id.is_empty()),
+            "websocket requestId should be present"
+        );
+        assert!(
+            connection.get("postData").is_none(),
+            "websocket frame payloads must not be captured"
+        );
+    }
+    assert!(captured.iter().any(|connection| {
+        connection["url"] == format!("ws://127.0.0.1:{websocket_port}/ws/top-level-probe")
+    }));
+    assert!(captured.iter().any(|connection| {
+        connection["url"] == format!("ws://localhost:{websocket_port}/ws/iframe-probe")
+    }));
+
+    let http_requests = execute_command(
+        &json!({
+            "id": "6",
+            "action": "requests",
+            "filter": "/http-probe",
+            "type": "fetch"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&http_requests);
+    assert_eq!(
+        get_data(&http_requests)["requests"]
+            .as_array()
+            .expect("HTTP requests response should contain an array")
+            .len(),
+        1,
+        "existing HTTP request tracking should remain unchanged"
+    );
+
+    let clear_after = execute_command(
+        &json!({ "id": "7", "action": "requests", "clear": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&clear_after);
+    let after_clear = execute_command(
+        &json!({
+            "id": "8",
+            "action": "requests",
+            "type": "websocket"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&after_clear);
+    assert_eq!(get_data(&after_clear)["requests"], json!([]));
+
+    let close = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&close);
+    http_task.abort();
+    iframe_task.abort();
+    websocket_task.abort();
 }
 
 #[tokio::test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2505,7 +2505,7 @@ Subcommands:
   requests [options]         List captured requests
     --clear                  Clear request log
     --filter <pattern>       Filter by URL pattern
-    --type <types>           Filter by resource type (comma-separated: xhr,fetch,document)
+    --type <types>           Filter by resource type (comma-separated: xhr,fetch,document,websocket)
     --method <method>        Filter by HTTP method (GET, POST, etc.)
     --status <code>          Filter by status (200, 2xx, 400-499)
   request <requestId>        View full request/response detail (including body)
@@ -2525,6 +2525,7 @@ Examples:
   chrome-use network requests
   chrome-use network requests --filter "api"
   chrome-use network requests --type xhr,fetch
+  chrome-use network requests --type websocket
   chrome-use network requests --method POST --status 2xx
   chrome-use network requests --clear
   chrome-use network request 1234.5

--- a/docs/en/network.html
+++ b/docs/en/network.html
@@ -186,9 +186,9 @@
 
       <h2>Observe and record traffic</h2>
       <p>
-        Before rewriting, see clearly which requests are in flight. <code>network requests</code> lists captured traffic,
-        and <code>--clear</code> starts recording fresh; <code>network har</code> records the whole session into a standard
-        HAR file.
+        Before rewriting, see clearly which requests are in flight. <code>network requests</code> lists captured HTTP
+        requests and WebSocket connection metadata, and <code>--clear</code> starts recording fresh. WebSocket frame
+        payloads are not recorded. <code>network har</code> records HTTP traffic into a standard HAR file.
       </p>
 
       <div class="du-code">
@@ -198,6 +198,7 @@
         </div>
 <pre><code><span class="du-prompt">$</span> chrome-use network requests <span class="du-flag">--clear</span>        <span class="du-cmt"># clear and start capturing again</span>
 <span class="du-prompt">$</span> chrome-use network requests                <span class="du-cmt"># see which requests went out</span>
+<span class="du-prompt">$</span> chrome-use network requests <span class="du-flag">--type</span> websocket <span class="du-cmt"># show WebSocket connection metadata only</span>
 
 <span class="du-prompt">$</span> chrome-use network har start               <span class="du-cmt"># record all traffic</span>
 <span class="du-cmt"># ... perform your actions ...</span>

--- a/docs/network.html
+++ b/docs/network.html
@@ -181,8 +181,9 @@
 
       <h2>观察与录制流量</h2>
       <p>
-        改写之前，先看清楚都有哪些请求在飞。<code>network requests</code> 列出已捕获的流量，
-        <code>--clear</code> 从头开始记；<code>network har</code> 则把整段流量录成标准的 HAR 文件。
+        改写之前，先看清楚都有哪些请求在飞。<code>network requests</code> 列出已捕获的 HTTP 请求和 WebSocket
+        连接元数据，<code>--clear</code> 从头开始记；WebSocket 不记录消息帧内容。
+        <code>network har</code> 则把 HTTP 流量录成标准的 HAR 文件。
       </p>
 
       <div class="du-code">
@@ -192,6 +193,7 @@
         </div>
 <pre><code><span class="du-prompt">$</span> chrome-use network requests <span class="du-flag">--clear</span>        <span class="du-cmt"># 清空并重新开始捕获</span>
 <span class="du-prompt">$</span> chrome-use network requests                <span class="du-cmt"># 查看都发出了哪些请求</span>
+<span class="du-prompt">$</span> chrome-use network requests <span class="du-flag">--type</span> websocket <span class="du-cmt"># 只看 WebSocket 连接元数据</span>
 
 <span class="du-prompt">$</span> chrome-use network har start               <span class="du-cmt"># 录制全部流量</span>
 <span class="du-cmt"># ... 执行你的操作 ...</span>

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -948,7 +948,9 @@ proxy, no extension permission). Three modes: **mock** the response
 **rewrite** the outgoing request (`--method`/`--set-body`/`--set-header`/`--rewrite-url`),
 or **edit** the real response (`--edit-status`/`--edit-header`/`--replace 'from=>to'`);
 `--abort` blocks entirely. Scope with `--resource-type xhr,fetch`; inspect/record via
-`network requests` and `network har start|stop`; `network unroute` drops all routes.
+`network requests` and `network har start|stop`; filter WebSocket connections with
+`network requests --type websocket`. Connection metadata is recorded, not frame payloads.
+`network unroute` drops all routes.
 
 Full detail: `chrome-use skills get network`
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -218,6 +218,7 @@ chrome-use network route <url> --set-json data.user.vip=true --set-json items.0.
 chrome-use network unroute [url]            # Remove routes
 chrome-use network requests                 # View tracked requests
 chrome-use network requests --filter api    # Filter requests
+chrome-use network requests --type websocket # View WebSocket connection metadata (not frame payloads)
 ```
 
 ## Tabs and Windows


### PR DESCRIPTION
## Summary

- capture page `Network.webSocketCreated` events in the existing `network requests` output
- enable request tracking for the active page and already attached cross-origin iframe sessions
- support existing URL, resource type, and clear filters without recording WebSocket frame payloads
- document `network requests --type websocket` in CLI help, README, core skill references, and network docs

## Why

A page can have an open WebSocket while `chrome-use network requests --json` reports no WebSocket traffic because request tracking only handled HTTP request and response events. This prevents tools from using the official network evidence for terminal and other WebSocket flows.

## Validation

- `cargo fmt -- --check`
- `cargo test --quiet -- --test-threads=1` (1038 passed, 79 ignored; doctor CLI 2 passed)
- `cargo clippy`
- focused real Chrome E2E with local HTTP and WebSocket servers (passed)
- full ignored E2E: 75 passed; two unrelated existing environment failures remain: drag buttons assertion and missing ffmpeg

The E2E proves both a top-level page and an already attached cross-origin iframe reach WebSocket OPEN and appear in filtered network output. It also verifies existing HTTP tracking, timestamps, clear behavior, and that frame payloads are absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network request tracking now includes WebSocket connection metadata from pages and iframes.
  * Added filtering for WebSocket connections with `network requests --type websocket`.
  * Request history can be cleared while preserving existing HTTP tracking behavior.

* **Documentation**
  * Updated command help and network guides to explain WebSocket metadata capture.
  * Clarified that WebSocket frame payloads are not recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->