### PR TITLE
feat(site): sync official adapters by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,14 +279,17 @@ inside your logged-in tab* (your cookies, same-origin `fetch`, the site's own
 modules) and returns clean JSON. The site can't tell it apart from you, because it
 *is* you.
 
-chrome-use ships none of these adapters — `site update` fetches the community
-[**bb-sites**](https://github.com/epiral/bb-sites) pack at runtime (like a package
-manager pulling a dependency), then runs them over chrome-use's stealth transport:
+chrome-use ships none of these adapters. `site update` fetches two default packs at
+runtime: the community [**bb-sites**](https://github.com/epiral/bb-sites) pack and
+the official [**chrome-use-sites**](https://github.com/leeguooooo/chrome-use-sites)
+pack. It works like a package manager pulling dependencies, then runs the adapters
+over chrome-use's stealth transport:
 
 ```bash
-chrome-use site update                          # fetch the adapter pack (~145 commands)
+chrome-use site update                          # fetch both default packs + configured extras
 chrome-use site list                            # github/issues, reddit/search, bilibili/feed, …
 chrome-use site info github/issues              # see an adapter's args + domain
+chrome-use site sources                         # show community, official, and extra sources
 
 # Run one — navigates to the site (reusing the tab if you're already there) and returns JSON
 chrome-use site github/issues epiral/bb-browser --json
@@ -295,11 +298,10 @@ chrome-use site bilibili/feed --json            # works because it's your logged
 ```
 
 Positional args fill the adapter's declared args in order; `--key value` overrides
-by name. Adapters are authored by the bb-sites community and remain their authors'
-property — chrome-use just runs them.
+by name. Adapters remain their authors' property; chrome-use just runs them.
 
 **Auto-sync + auto-suggest.** You rarely type `site update` yourself: chrome-use
-syncs the pack on first use and refreshes it weekly in the background (tune with
+syncs both default packs on first use and refreshes them weekly in the background (tune with
 `AGENT_BROWSER_SITES_TTL_DAYS`, disable with `AGENT_BROWSER_SITES_NO_AUTO_UPDATE=1`).
 And when you `open`/`snapshot` a page whose domain has adapters, chrome-use surfaces
 them right in the output — a `💡 site adapters for <domain>` line, plus a
@@ -314,24 +316,25 @@ $ chrome-use open https://github.com
 ✓ GitHub
 ```
 
-**Private / org-internal packs.** Adapters that target self-hosted or internal
-services (a company Gogs/GitLab, an internal dashboard) can't live in the public
-bb-sites pack. Point `site update` at **extra sources** — a GitHub `owner/repo`, a
-`.zip` URL, or a local directory — and they sync into `~/.chrome-use/sites`
-alongside the community pack, with the same auto-sync lifecycle:
+**Sources.** The community `epiral/bb-sites` pack and official
+`leeguooooo/chrome-use-sites` pack are built-in defaults; no `site add` is needed.
+For other private or org-internal adapters, register an **extra source** as a GitHub
+`owner/repo`, a `.zip` URL, or a local directory. Extra sources sync into
+`~/.chrome-use/sites` with the same auto-sync lifecycle:
 
 ```bash
-chrome-use site add leeguooooo/chrome-use-sites   # a private/extra adapter repo
+chrome-use site sources                            # lists both defaults + extras
+chrome-use site add acme/internal-sites            # a private/extra adapter repo
 chrome-use site add /path/to/local/adapters       # or a local dir / .zip URL
-chrome-use site sources                            # list configured extra sources
-chrome-use site remove leeguooooo/chrome-use-sites
-chrome-use site update                             # syncs bb-sites + every source
+chrome-use site remove acme/internal-sites
+chrome-use site update                             # syncs both defaults + every extra
 ```
 
 Sources also come from `CHROME_USE_SITES_SOURCES` (comma-separated) or the
 `~/.chrome-use/sites.sources` file. Private repos authenticate via
-`CHROME_USE_SITES_TOKEN` (or `GITHUB_TOKEN`/`GH_TOKEN`). Packs are namespaced by
-their directory, and a later source wins on a name collision.
+`CHROME_USE_SITES_TOKEN` (or `GITHUB_TOKEN`/`GH_TOKEN`). The two built-in defaults
+cannot be removed. Packs are namespaced by their directory, and a later source wins
+on a name collision.
 
 ## Automated testing (`chrome-use test`)
 

--- a/README.md
+++ b/README.md
@@ -304,13 +304,13 @@ by name. Adapters remain their authors' property; chrome-use just runs them.
 syncs both default packs on first use and refreshes them weekly in the background (tune with
 `AGENT_BROWSER_SITES_TTL_DAYS`, disable with `AGENT_BROWSER_SITES_NO_AUTO_UPDATE=1`).
 And when you `open`/`snapshot` a page whose domain has adapters, chrome-use surfaces
-them right in the output — a `💡 site adapters for <domain>` line, plus a
+them right in the output — a `site adapters for <domain>` line, plus a
 `siteAdapters` field under `--json` — so an agent reaches for the structured-data
 adapter instead of scraping the DOM:
 
 ```text
 $ chrome-use open https://github.com
-💡 site adapters for github.com — prefer these for structured data:
+site adapters for github.com — prefer these for structured data:
    github/issues, github/me, github/repo, …
    e.g. chrome-use site github/issues --json
 ✓ GitHub

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1059,7 +1059,7 @@ fn main() {
     // `info` are CLI-side (download/filesystem); `site <name>/<cmd> [args]` falls
     // through to the daemon dispatch below (navigate to the adapter's domain + eval).
     if clean.first().map(|s| s.as_str()) == Some("site") {
-        // Auto-sync the adapter pack on first use and periodically (TTL, default
+        // Auto-sync the adapter packs on first use and periodically (TTL, default
         // 7d) so adapters stay fresh without a manual `site update`. Skipped for an
         // explicit `update` (full sync below). Best-effort: offline → cached pack.
         // Disable with AGENT_BROWSER_SITES_NO_AUTO_UPDATE=1.
@@ -1147,25 +1147,28 @@ fn main() {
                 }
                 return;
             }
-            // `site sources` — list the configured extra adapter sources (#127).
-            // The community pack (epiral/bb-sites) is always synced and not listed.
+            // `site sources` — list the built-in defaults and configured extras.
             Some("sources") => {
                 let sources = site::read_sources();
                 if flags.json {
-                    println!("{}", json!({ "success": true, "sources": sources }));
-                } else if sources.is_empty() {
                     println!(
-                        "no extra sources configured — add one with `chrome-use site add <owner/repo|url|dir>`\n\
-                         (the community pack epiral/bb-sites is always synced)"
+                        "{}",
+                        json!({
+                            "success": true,
+                            "defaultSources": site::default_sources(),
+                            "sources": sources
+                        })
                     );
                 } else {
-                    for s in &sources {
-                        println!("{s}");
+                    println!("{} (default: community)", site::COMMUNITY_SITES_SOURCE);
+                    println!("{} (default: official)", site::OFFICIAL_SITES_SOURCE);
+                    for source in &sources {
+                        println!("{source} (extra)");
                     }
                     eprintln!(
                         "{}",
                         color::dim(&format!(
-                            "{} extra source(s) · synced alongside epiral/bb-sites on `site update`",
+                            "2 default source(s) + {} extra source(s) · synced on `site update`",
                             sources.len()
                         ))
                     );
@@ -1195,13 +1198,18 @@ fn main() {
                         }
                     }
                     Ok(false) => {
+                        let note = if site::is_default_source(&src) {
+                            "built-in default"
+                        } else {
+                            "already present"
+                        };
                         if flags.json {
                             println!(
                                 "{}",
-                                json!({ "success": true, "added": serde_json::Value::Null, "note": "already present" })
+                                json!({ "success": true, "added": serde_json::Value::Null, "note": note })
                             );
                         } else {
-                            println!("source `{src}` is already configured");
+                            println!("source `{src}` is already configured ({note})");
                         }
                     }
                     Err(e) => {
@@ -1284,7 +1292,7 @@ fn main() {
             _ => {
                 eprintln!(
                     "{} usage: chrome-use site <name>/<cmd> [args] | site update | site list | \
-                     site info <name>/<cmd>",
+                     site info <name>/<cmd> | site sources | site add|remove <source>",
                     color::error_indicator()
                 );
                 exit(2);

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -198,7 +198,7 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                 .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
                 .unwrap_or_default();
             if !cmds.is_empty() {
-                eprintln!("💡 site adapters for {domain} — prefer these for structured data:");
+                eprintln!("site adapters for {domain} — prefer these for structured data:");
                 eprintln!("   {}", color::dim(&cmds.join(", ")));
                 eprintln!(
                     "   {}",

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3787,12 +3787,14 @@ Batch:
                               --bail stops on first error (default: continue all)
 
 Site adapters:  turn a website into a structured-data CLI (runs as you, in your tab)
-  site update                Fetch the community adapter pack into ~/.chrome-use/sites
+  site update                Fetch the community + official packs and configured extras
   site list                  List installed adapters (name/cmd)
   site info <name>/<cmd>     Show an adapter's @meta (args, domain, capabilities)
   site <name>/<cmd> [args]   Run an adapter: navigate to its site + return JSON
                              e.g. site github/issues epiral/repo, site reddit/search rust
                              Positional args fill declared args in order; --key value overrides
+  site sources               List built-in default sources and configured extras
+  site add|remove <source>   Manage extra GitHub repo, .zip URL, or local-dir sources
 
 Auth Vault:
   auth save <name> [opts]    Save auth profile (--url, --username, --password/--password-stdin)

--- a/cli/src/site.rs
+++ b/cli/src/site.rs
@@ -3,20 +3,31 @@
 //! site's cookies / same-origin fetch / its own webpack modules — the site thinks
 //! it's you, because it is).
 //!
-//! The adapter format is the community **bb-sites** convention
-//! (<https://github.com/epiral/bb-sites>): one `.js` file per command, a
+//! The adapter format follows the **bb-sites** convention: one `.js` file per command, a
 //! `/* @meta {...} */` JSON header (name, description, domain, args), then an
-//! `async function(args){ ... return {...} }`. chrome-use ships none of those
-//! adapters — `chrome-use site update` fetches the upstream repo at runtime into
-//! `~/.chrome-use/sites` (like a package manager pulling a dependency), so the
-//! adapters stay the property of their authors. Running an adapter navigates to
-//! its `@meta.domain` and `eval`s the function in the site's own logged-in page.
+//! `async function(args){ ... return {...} }`. chrome-use ships none of those adapters —
+//! `chrome-use site update` fetches the community **epiral/bb-sites** pack and the
+//! official **leeguooooo/chrome-use-sites** pack at runtime into `~/.chrome-use/sites`
+//! (like a package manager pulling dependencies), so the adapters stay the property of
+//! their authors. Running an adapter navigates to its `@meta.domain` and `eval`s the
+//! function in the site's own logged-in page.
 
 use std::path::PathBuf;
 
 use serde_json::Value;
 
-const SITES_ZIP_URL: &str = "https://github.com/epiral/bb-sites/archive/refs/heads/main.zip";
+pub const COMMUNITY_SITES_SOURCE: &str = "epiral/bb-sites";
+pub const OFFICIAL_SITES_SOURCE: &str = "leeguooooo/chrome-use-sites";
+const DEFAULT_SITES_SOURCES: [&str; 2] = [COMMUNITY_SITES_SOURCE, OFFICIAL_SITES_SOURCE];
+
+/// Built-in adapter sources, synced on every update without user configuration.
+pub fn default_sources() -> &'static [&'static str] {
+    &DEFAULT_SITES_SOURCES
+}
+
+pub fn is_default_source(source: &str) -> bool {
+    DEFAULT_SITES_SOURCES.contains(&source.trim())
+}
 
 /// `~/.chrome-use/sites` — where synced adapters live.
 pub fn sites_dir() -> Option<PathBuf> {
@@ -31,19 +42,25 @@ fn dirs_home() -> Option<PathBuf> {
 /// #127). Each line is a GitHub `owner/repo`, a `.zip` URL, or a local directory.
 /// `#` starts a comment. Lets orgs auto-sync **private/internal** adapter packs
 /// (self-hosted Gogs/GitLab, internal tools) that can't live in the public
-/// bb-sites pack, with the same lifecycle as the community pack.
+/// built-in packs, with the same lifecycle as the community and official packs.
 pub fn sources_config_path() -> Option<PathBuf> {
     dirs_home().map(|h| h.join(".chrome-use").join("sites.sources"))
 }
 
 /// The configured extra sources: env `CHROME_USE_SITES_SOURCES` (comma-separated)
-/// first, then the `sites.sources` file — deduped, order preserved. The community
-/// pack (`epiral/bb-sites`) is always synced and is NOT listed here.
+/// first, then the `sites.sources` file — deduped, order preserved. The built-in
+/// community and official packs are always synced and are NOT listed here. If an
+/// older configuration explicitly contains either built-in source, it is ignored
+/// so the repository is not downloaded twice.
 pub fn read_sources() -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut push = |s: &str| {
         let s = s.trim();
-        if !s.is_empty() && !s.starts_with('#') && !out.iter().any(|e| e == s) {
+        if !s.is_empty()
+            && !s.starts_with('#')
+            && !is_default_source(s)
+            && !out.iter().any(|e| e == s)
+        {
             out.push(s.to_string());
         }
     };
@@ -69,6 +86,9 @@ pub fn add_source(source: &str) -> Result<bool, String> {
     if source.is_empty() {
         return Err("site add: empty source".into());
     }
+    if is_default_source(source) {
+        return Ok(false);
+    }
     let path = sources_config_path().ok_or("site add: cannot resolve home dir")?;
     let existing: Vec<String> = std::fs::read_to_string(&path)
         .ok()
@@ -93,6 +113,11 @@ pub fn add_source(source: &str) -> Result<bool, String> {
 /// Remove a source from `sites.sources`. Returns whether a line was removed.
 pub fn remove_source(source: &str) -> Result<bool, String> {
     let source = source.trim();
+    if is_default_source(source) {
+        return Err(format!(
+            "site remove: `{source}` is a built-in default source and cannot be removed"
+        ));
+    }
     let path = sources_config_path().ok_or("site remove: cannot resolve home dir")?;
     let Ok(text) = std::fs::read_to_string(&path) else {
         return Ok(false);
@@ -335,11 +360,12 @@ pub fn list_adapters() -> Result<Vec<String>, String> {
     Ok(out)
 }
 
-/// Sync the community pack (`epiral/bb-sites`) **plus** any configured extra
-/// sources (issue #127) into `~/.chrome-use/sites`. Sources are applied AFTER the
-/// community pack, so on a pack-dir name collision the later source wins (with a
-/// warning). Extra sources are best-effort: one failing (offline/private-auth)
-/// doesn't abort the others or the community sync. Returns the total adapter count.
+/// Sync both built-in packs (`epiral/bb-sites` community and
+/// `leeguooooo/chrome-use-sites` official) **plus** any configured extra sources
+/// into `~/.chrome-use/sites`. Sources are applied in order, so on a pack-dir name
+/// collision the later source wins (with a warning). Both built-in sources are
+/// required; extra sources are best-effort, so one failing (offline/private-auth)
+/// doesn't abort the others or the built-in sync. Returns the total adapter count.
 pub async fn update() -> Result<usize, String> {
     let dir = sites_dir().ok_or("site: cannot resolve home dir")?;
     std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
@@ -348,13 +374,16 @@ pub async fn update() -> Result<usize, String> {
         .build()
         .map_err(|e| e.to_string())?;
 
-    // 1) Community pack — a hard failure here is the whole command's failure,
-    // preserving the original contract (offline first-sync still errors).
-    fetch_zip_into(&client, SITES_ZIP_URL, None, &dir, true)
-        .await
-        .map_err(|e| format!("site update: {e}"))?;
+    // 1) Built-in packs — both are first-class defaults. A hard failure preserves
+    // the original contract: an incomplete first sync must not look successful.
+    for source in default_sources() {
+        sync_source(&client, source, None, &dir)
+            .await
+            .map_err(|e| format!("site update: default source `{source}` failed: {e}"))?;
+    }
 
-    // 2) Extra sources (private/org packs). Best-effort, overlaid on top.
+    // 2) Extra sources (private/org packs). Best-effort, overlaid on top. Built-in
+    // names are filtered by read_sources() for compatibility with old config files.
     let token = sources_token();
     for source in read_sources() {
         if let Err(e) = sync_source(&client, &source, token.as_deref(), &dir).await {
@@ -386,7 +415,7 @@ fn sources_token() -> Option<String> {
     None
 }
 
-/// Resolve one configured source and merge it into `dir`:
+/// Resolve one built-in or configured source and merge it into `dir`:
 /// - a local directory path → copy its `.js`/`_helper.js` tree in;
 /// - a `.zip`/http(s) URL → download + extract;
 /// - a GitHub `owner/repo` → download its default-branch archive (private repos
@@ -594,7 +623,7 @@ fn write_domain_index(dir: &std::path::Path) {
 
 const DEFAULT_TTL_DAYS: u64 = 7;
 
-/// Whether the adapter pack should be (re)synced: true on first use (nothing
+/// Whether the adapter packs should be (re)synced: true on first use (nothing
 /// installed) or when the last sync is older than the TTL. Disabled by
 /// `AGENT_BROWSER_SITES_NO_AUTO_UPDATE=1`; TTL overridable via
 /// `AGENT_BROWSER_SITES_TTL_DAYS` (0 = always).
@@ -626,7 +655,7 @@ pub fn needs_refresh() -> bool {
 
 /// Adapters whose `@meta.domain` matches `host` (exact, or `host` is a subdomain
 /// of it) — for auto-suggesting `site` commands when you land on a known site.
-/// Reads the prebuilt `.index.json`; empty if the pack isn't synced yet.
+/// Reads the prebuilt `.index.json`; empty if the packs aren't synced yet.
 pub fn adapters_for_domain(host: &str) -> Vec<String> {
     let host = host.trim_start_matches("www.");
     let Some(raw) = index_path().and_then(|p| std::fs::read_to_string(p).ok()) else {
@@ -753,6 +782,21 @@ async function(args) { return { repo: args.repo }; }"#;
         assert_eq!(parse_owner_repo("../etc/passwd"), None);
         assert_eq!(parse_owner_repo("owner /repo"), None);
         assert_eq!(parse_owner_repo("/absolute/dir"), None);
+    }
+
+    #[test]
+    fn built_in_sources_include_community_and_official_packs() {
+        assert_eq!(
+            default_sources(),
+            &["epiral/bb-sites", "leeguooooo/chrome-use-sites"]
+        );
+        assert!(is_default_source("epiral/bb-sites"));
+        assert!(is_default_source(" leeguooooo/chrome-use-sites "));
+        assert!(!is_default_source("example/private-sites"));
+        assert!(!add_source(OFFICIAL_SITES_SOURCE).unwrap());
+        assert!(remove_source(COMMUNITY_SITES_SOURCE)
+            .unwrap_err()
+            .contains("built-in default source"));
     }
 
     // Regression: positional args must follow DECLARATION order, not serde's

--- a/docs/en/site-adapters.html
+++ b/docs/en/site-adapters.html
@@ -189,7 +189,7 @@
       </p>
 
       <ul>
-        <li>a line on stderr: <code>💡 site adapters for &lt;domain&gt;</code>;</li>
+        <li>a line on stderr: <code>site adapters for &lt;domain&gt;</code>;</li>
         <li>a <code>siteAdapters: {domain, commands}</code> field in <code>--json</code> output.</li>
       </ul>
 
@@ -200,12 +200,12 @@
         </div>
 <pre><code><span class="du-prompt">$</span> chrome-use open https://github.com/epiral/bb-sites
 <span class="du-cmt"># … as the page opens, a line pops up on stderr:</span>
-💡 site adapters for github.com: github/issues, github/pulls, github/repo …</code></pre>
+site adapters for github.com: github/issues, github/pulls, github/repo …</code></pre>
       </div>
 
       <div class="du-callout tip">
         <div class="du-callout-title">✅ See the hint, prefer the <code>site &lt;name&gt;/&lt;cmd&gt;</code> it lists</div>
-        When you see <code>💡 site adapters for &lt;domain&gt;</code>, <strong>don't snapshot + click to read the data</strong> —
+        When you see <code>site adapters for &lt;domain&gt;</code>, <strong>don't snapshot + click to read the data</strong> —
         just use the <code>site &lt;name&gt;/&lt;cmd&gt;</code> it names: cheaper, more reliable, and already installed. You also
         <strong>don't need</strong> to run <code>site update</code> yourself first — just use the command it gives you.
       </div>

--- a/docs/en/site-adapters.html
+++ b/docs/en/site-adapters.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title>Site Adapters · chrome-use</title>
-  <meta name="description" content="Site adapters: a small community-written JS snippet that hits a site's own JSON API directly from your logged-in tab and returns clean structured data — no clicking, no scraping, no screenshots. The full site update / list / info / run flow, plus auto-hints and how it compares to the alternatives." />
+  <meta name="description" content="Site adapters: a small JS snippet that hits a site's own JSON API directly from your logged-in tab and returns clean structured data — no clicking, no scraping, no screenshots. The full site update / list / info / run flow, plus auto-hints and how it compares to the alternatives." />
 
   <meta name="theme-color" content="#fcfbf4" />
   <meta property="og:type" content="article" />
@@ -79,7 +79,7 @@
 
       <h2>How to use it</h2>
       <p>
-        Four actions: pull the pack once (<code>update</code>), see what's installed (<code>list</code>), see how a given adapter is
+        Four actions: pull the sources once (<code>update</code>), see what's installed (<code>list</code>), see how a given adapter is
         called (<code>info</code>), and run it (<code>site &lt;name&gt;/&lt;cmd&gt;</code>).
       </p>
 
@@ -88,14 +88,14 @@
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
           <span class="du-code-name">bash</span>
         </div>
-<pre><code><span class="du-prompt">$</span> chrome-use site update                            <span class="du-cmt"># one-time: pull the adapter pack (count grows with bb-sites)</span>
+<pre><code><span class="du-prompt">$</span> chrome-use site update                            <span class="du-cmt"># one-time: pull community, official, and extra sources</span>
 <span class="du-prompt">$</span> chrome-use site list                              <span class="du-cmt"># what's installed (github/issues, reddit/search…)</span>
 <span class="du-prompt">$</span> chrome-use site info github/issues                <span class="du-cmt"># an adapter's params + which domain it runs on</span>
 <span class="du-prompt">$</span> chrome-use site github/issues owner/repo <span class="du-flag">--json</span>   <span class="du-cmt"># run → JSON (navigates there for you)</span></code></pre>
       </div>
 
       <ul>
-        <li><code>site update</code>: pulls the whole adapter set from the bb-sites community pack. Only needed once; after that chrome-use keeps it in sync automatically (see "Auto-triggering" below).</li>
+        <li><code>site update</code>: pulls adapters from the bb-sites community source, the chrome-use-sites official source, and any configured extras. Only needed once; after that chrome-use keeps them in sync automatically (see "Auto-triggering" below).</li>
         <li><code>site list</code>: lists every <code>&lt;name&gt;/&lt;cmd&gt;</code> installed locally, e.g. <code>github/issues</code>, <code>reddit/search</code>.</li>
         <li><code>site info &lt;name&gt;/&lt;cmd&gt;</code>: shows which params an adapter declares and which domain it runs on — check this before calling, and you'll know what to pass.</li>
         <li><code>site &lt;name&gt;/&lt;cmd&gt; [args] --json</code>: actually runs it. Add <code>--json</code> for one line of parseable structured output.</li>
@@ -183,7 +183,7 @@
 
       <h2>Auto-triggering — see it, use it</h2>
       <p>
-        You don't have to remember which sites have adapters. chrome-use keeps the adapter pack in sync automatically
+        You don't have to remember which sites have adapters. chrome-use keeps the adapter sources in sync automatically
         (<strong>on first use + weekly</strong>), and when you <code>open</code> / <code>navigate</code> / <code>snapshot</code> a page whose
         <strong>domain has adapters</strong>, it proactively hints you:
       </p>
@@ -212,7 +212,7 @@
 
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ Exception on a fresh environment</div>
-        Only on a <strong>brand-new environment where the adapter pack hasn't been pulled yet</strong> might naming a
+        Only on a <strong>brand-new environment where the adapter sources haven't been pulled yet</strong> might naming a
         <code>site &lt;name&gt;/&lt;cmd&gt;</code> report "not installed." In that case run <code>site update</code> once and re-run the command.
       </div>
 
@@ -264,15 +264,16 @@
 
       <h2>Source and license</h2>
       <p>
-        Adapters come from the <a href="https://github.com/epiral/bb-sites">bb-sites</a> community pack.
+        Adapters come from two defaults: the <a href="https://github.com/epiral/bb-sites">bb-sites</a> community source and
+        the <a href="https://github.com/leeguooooo/chrome-use-sites">chrome-use-sites</a> official source.
         chrome-use <strong>fetches and executes them at runtime</strong> — this repo <span class="mark">does not bundle or redistribute</span>
         any adapter code, and <code>site update</code> fetches the latest version from upstream each time.
       </p>
 
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ Fetched at runtime, not built in</div>
-        Because adapters are maintained upstream by the community and fetched only at runtime, the command set you see changes as bb-sites
-        updates; <code>site list</code> reflects the version you synced to locally this time.
+        Because adapters are maintained in the community and official sources and fetched only at runtime, the command set you see changes
+        as either default source updates; <code>site list</code> reflects the version you synced to locally this time.
       </div>
 
       <hr class="du-divider" />

--- a/docs/site-adapters.html
+++ b/docs/site-adapters.html
@@ -184,7 +184,7 @@
       </p>
 
       <ul>
-        <li>stderr 上一行 <code>💡 site adapters for &lt;domain&gt;</code>；</li>
+        <li>stderr 上一行 <code>site adapters for &lt;domain&gt;</code>；</li>
         <li><code>--json</code> 输出里的 <code>siteAdapters: {domain, commands}</code> 字段。</li>
       </ul>
 
@@ -195,12 +195,12 @@
         </div>
 <pre><code><span class="du-prompt">$</span> chrome-use open https://github.com/epiral/bb-sites
 <span class="du-cmt"># … 页面打开的同时，stderr 冒出一行：</span>
-💡 site adapters for github.com: github/issues, github/pulls, github/repo …</code></pre>
+site adapters for github.com: github/issues, github/pulls, github/repo …</code></pre>
       </div>
 
       <div class="du-callout tip">
         <div class="du-callout-title">✅ 看到提示，优先用它列出的 <code>site &lt;name&gt;/&lt;cmd&gt;</code></div>
-        看到 <code>💡 site adapters for &lt;domain&gt;</code> 时，<strong>别再 snapshot + click 去读数据</strong>——
+        看到 <code>site adapters for &lt;domain&gt;</code> 时，<strong>别再 snapshot + click 去读数据</strong>——
         直接用它点名的 <code>site &lt;name&gt;/&lt;cmd&gt;</code>：更省、更稳，而且已经装好了。你也<strong>不需要</strong>自己先跑
         <code>site update</code>，用它给出的命令即可。
       </div>

--- a/docs/site-adapters.html
+++ b/docs/site-adapters.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title>站点适配器 · chrome-use 文档</title>
-  <meta name="description" content="站点适配器：社区写的一小段 JS，在你登录态的标签页里直接打站点自己的 JSON API，返回干净结构化数据——不点击、不爬、不截图。site update / list / info / run 全流程，以及自动触发提示与选型对比。" />
+  <meta name="description" content="站点适配器：一小段 JS，在你登录态的标签页里直接调用站点自己的 JSON API，返回干净结构化数据——不点击、不爬、不截图。site update / list / info / run 全流程，以及自动触发提示与选型对比。" />
 
   <meta name="theme-color" content="#fcfbf4" />
   <meta property="og:type" content="article" />
@@ -77,7 +77,7 @@
 
       <h2>怎么用</h2>
       <p>
-        四个动作：一次性拉包（<code>update</code>）、看装了哪些（<code>list</code>）、看某个适配器怎么调
+        四个动作：一次性拉取源（<code>update</code>）、看装了哪些（<code>list</code>）、看某个适配器怎么调
         （<code>info</code>）、运行它（<code>site &lt;name&gt;/&lt;cmd&gt;</code>）。
       </p>
 
@@ -86,14 +86,14 @@
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
           <span class="du-code-name">bash</span>
         </div>
-<pre><code><span class="du-prompt">$</span> chrome-use site update                            <span class="du-cmt"># 一次性：拉取适配器包（命令数随 bb-sites 同步增长）</span>
+<pre><code><span class="du-prompt">$</span> chrome-use site update                            <span class="du-cmt"># 一次性：拉取社区源、官方源及额外源</span>
 <span class="du-prompt">$</span> chrome-use site list                              <span class="du-cmt"># 已装了哪些（github/issues、reddit/search…）</span>
 <span class="du-prompt">$</span> chrome-use site info github/issues                <span class="du-cmt"># 某适配器的参数 + 在哪个域名上跑</span>
 <span class="du-prompt">$</span> chrome-use site github/issues owner/repo <span class="du-flag">--json</span>   <span class="du-cmt"># 运行 → JSON（自动帮你导航过去）</span></code></pre>
       </div>
 
       <ul>
-        <li><code>site update</code>：从 bb-sites 社区包拉取整套适配器。只需一次；之后 chrome-use 会自动保持同步（见下方「自动触发」）。</li>
+        <li><code>site update</code>：默认从 bb-sites 社区源和 chrome-use-sites 官方源拉取适配器，并同步用户配置的额外源。只需一次；之后 chrome-use 会自动保持同步（见下方「自动触发」）。</li>
         <li><code>site list</code>：列出本地已安装的所有 <code>&lt;name&gt;/&lt;cmd&gt;</code>，例如 <code>github/issues</code>、<code>reddit/search</code>。</li>
         <li><code>site info &lt;name&gt;/&lt;cmd&gt;</code>：查一个适配器声明了哪些参数、以及它会在哪个域名上运行——调之前先看这个，就知道该传什么。</li>
         <li><code>site &lt;name&gt;/&lt;cmd&gt; [args] --json</code>：真正运行。加 <code>--json</code> 拿一行可解析的结构化输出。</li>
@@ -179,7 +179,7 @@
 
       <h2>自动触发 —— 看到就用它</h2>
       <p>
-        你不用记住哪些站点有适配器。chrome-use 会自动保持适配器包同步（<strong>首次使用 + 每周</strong>），
+        你不用记住哪些站点有适配器。chrome-use 会自动保持适配器源同步（<strong>首次使用 + 每周</strong>），
         并且当你 <code>open</code> / <code>navigate</code> / <code>snapshot</code> 一个<strong>域名有适配器</strong>的页面时主动提示你：
       </p>
 
@@ -207,7 +207,7 @@
 
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ 全新环境的例外</div>
-        只有在<strong>刚装好、适配器包还没拉取</strong>的全新环境里，点名一个 <code>site &lt;name&gt;/&lt;cmd&gt;</code>
+        只有在<strong>刚装好、适配器源还没拉取</strong>的全新环境里，点名一个 <code>site &lt;name&gt;/&lt;cmd&gt;</code>
         可能提示「未安装」。这时手动跑一次 <code>site update</code>，再重跑那条命令即可。
       </div>
 
@@ -258,14 +258,15 @@
 
       <h2>来源与许可</h2>
       <p>
-        适配器来自 <a href="https://github.com/epiral/bb-sites">bb-sites</a> 社区包。
+        适配器默认来自 <a href="https://github.com/epiral/bb-sites">bb-sites</a> 社区源和
+        <a href="https://github.com/leeguooooo/chrome-use-sites">chrome-use-sites</a> 官方源。
         chrome-use 负责在<strong>运行时拉取并执行</strong>它们——本仓库<span class="mark">不打包、不重分发</span>任何适配器代码，
         <code>site update</code> 每次从上游获取最新版本。
       </p>
 
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ 运行时拉取，不内置</div>
-        因为适配器是上游社区维护、运行时才拉取的，所以你看到的命令集会随 bb-sites 更新而变化；
+        因为适配器由社区源和官方源维护、运行时才拉取，所以你看到的命令集会随两个默认源更新而变化；
         <code>site list</code> 反映的是你本地这一次同步到的版本。
       </div>
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -200,7 +200,7 @@ chrome-use site github/issues owner/repo --json   # run it → JSON (navigates t
 
 > **Auto-trigger — act on it.** chrome-use keeps both packs synced automatically (first use +
 > weekly), and when you `open`/`navigate`/`snapshot` a page whose domain has adapters it tells
-> you: a `💡 site adapters for <domain>` line on stderr, and a `siteAdapters: {domain, commands}`
+> you: a `site adapters for <domain>` line on stderr, and a `siteAdapters: {domain, commands}`
 > field in `--json`. **When you see that, prefer the listed `site <name>/<cmd>` over snapshot+click
 > for reading data** — it's the cheaper, more reliable path and it's already installed. You don't
 > need to run `site update` yourself; just use the command it names. (Only on a brand-new setup

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -182,7 +182,7 @@ clean structured data — no clicking, no scraping, no screenshots. It's the sam
 `eval`, packaged per-site.
 
 ```bash
-chrome-use site update                       # one-time: fetch the adapter pack (~145 cmds)
+chrome-use site update                       # one-time: fetch community + official packs
 chrome-use site list                         # what's installed (github/issues, reddit/search, …)
 chrome-use site info github/issues           # an adapter's args + which domain it runs on
 chrome-use site github/issues owner/repo --json   # run it → JSON (navigates there for you)
@@ -194,16 +194,17 @@ chrome-use site github/issues owner/repo --json   # run it → JSON (navigates t
   **positionally** or after `--`: `chrome-use site demo/pr-list -- --state closed`.
 - It navigates to the adapter's domain (reusing the current tab if you're already on it), so
   login-gated feeds (`bilibili/feed`, `twitter/...`) work because they run as *you*.
-- If no adapter fits, fall back to the normal `snapshot`/`eval` loop. Adapters come from the
-  [bb-sites](https://github.com/epiral/bb-sites) community pack; chrome-use fetches & runs them.
+- If no adapter fits, fall back to the normal `snapshot`/`eval` loop. chrome-use fetches and
+  runs two default sources: the [bb-sites](https://github.com/epiral/bb-sites) community pack
+  and the official [chrome-use-sites](https://github.com/leeguooooo/chrome-use-sites) pack.
 
-> **Auto-trigger — act on it.** chrome-use keeps the pack synced automatically (first use +
+> **Auto-trigger — act on it.** chrome-use keeps both packs synced automatically (first use +
 > weekly), and when you `open`/`navigate`/`snapshot` a page whose domain has adapters it tells
 > you: a `💡 site adapters for <domain>` line on stderr, and a `siteAdapters: {domain, commands}`
 > field in `--json`. **When you see that, prefer the listed `site <name>/<cmd>` over snapshot+click
 > for reading data** — it's the cheaper, more reliable path and it's already installed. You don't
 > need to run `site update` yourself; just use the command it names. (Only on a brand-new setup
-> where the pack hasn't been fetched yet, a named `site <name>/<cmd>` may say it's not installed —
+> where the packs haven't been fetched yet, a named `site <name>/<cmd>` may say it's not installed —
 > run `site update` once, then re-run the command.)
 
 ## Quickstart


### PR DESCRIPTION
## Summary

- make `epiral/bb-sites` and `leeguooooo/chrome-use-sites` first-class default adapter sources
- sync both defaults on every `site update`, while preserving best-effort configured extras
- ignore legacy duplicate entries for either built-in source and prevent removing defaults
- expose default sources in `site sources` text and JSON output
- update CLI help, README, core skill guidance, and bilingual docs

## Verification

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --manifest-path cli/Cargo.toml` (1046 passed, 3 ignored)
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- isolated live sync with an empty temporary `HOME`: 148 adapters fetched, including `sggit/pr-create`, `sggit/pr-list`, and `sggit/pr-merge`, with no `sites.sources` file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `site update` now syncs both built-in default adapter sources (community + official), and overlays any configured extra sources.
  * Added `site sources` to show built-in defaults alongside configured extras.
  * Added `site add` / `site remove <source>` commands for managing extra sources (repos, ZIP URLs, or local directories).

* **Bug Fixes**
  * Built-in default sources can no longer be removed or duplicated; adding them is idempotent.

* **Documentation**
  * Updated README and site adapter docs (including auto-sync, authentication, precedence, and examples) to consistently describe “sources” rather than a single pack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->