### PR TITLE
fix(tabs): bound native duplicate transactions

### DIFF
--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1615,6 +1615,28 @@ async fn e2e_tab_duplicate_preserves_native_history_on_extension_connected_chrom
         .unwrap_or_default()
         .contains("already used"));
 
+    // Repeated native duplication must return exactly one registered tab per
+    // command. A late extension response used to make the command time out,
+    // then surface an extra tab during the next resync.
+    let mut expected_total = short_duplicate["total"].as_u64().unwrap();
+    let mut stress_targets = Vec::new();
+    for index in 0..10 {
+        let resp = execute_command(
+            &json!({
+                "id": format!("stress-{index}"),
+                "action": "tab_duplicate",
+                "label": format!("stress-copy-{index}")
+            }),
+            &mut state,
+        )
+        .await;
+        assert_success(&resp);
+        let data = get_data(&resp);
+        expected_total += 1;
+        assert_eq!(data["total"].as_u64(), Some(expected_total));
+        stress_targets.push(data["targetId"].as_str().unwrap().to_string());
+    }
+
     // Closing the duplicate must leave the source tab isolated and usable.
     let duplicate_tab_id = duplicate["tabId"].as_str().unwrap().to_string();
     let resp = execute_command(
@@ -1646,7 +1668,10 @@ async fn e2e_tab_duplicate_preserves_native_history_on_extension_connected_chrom
         current_duplicate["targetId"].as_str().unwrap(),
         target_duplicate["targetId"].as_str().unwrap(),
         short_duplicate["targetId"].as_str().unwrap(),
-    ] {
+    ]
+    .into_iter()
+    .chain(stress_targets.iter().map(String::as_str))
+    {
         assert!(!tabs.iter().any(|tab| tab["targetId"] == closed_target));
     }
     let resp = execute_command(&json!({ "id": "102", "action": "close" }), &mut state).await;

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -49,6 +49,66 @@ function rememberSessionTarget(sessionId, targetId) {
 }
 /** tab-group name -> chrome tabGroups id (best-effort cache) */
 const groupIdByName = new Map()
+/** Source tabId -> native duplicate API promises awaiting exact tab classification. */
+const pendingNativeDuplicates = new Map()
+/** Native duplicate tabs owned by an explicit duplicate transaction. */
+const nativeDuplicateTabs = new Set()
+const NATIVE_DUPLICATE_CLASSIFICATION_TIMEOUT_MS = 5000
+const NATIVE_DUPLICATE_REGISTRY_TIMEOUT_MS = 30000
+
+function duplicateTabForTransaction(sourceTabId) {
+  const pending = pendingNativeDuplicates.get(sourceTabId) || new Set()
+  pendingNativeDuplicates.set(sourceTabId, pending)
+  const operation = chrome.tabs.duplicate(sourceTabId).then((tab) => {
+    if (tab?.id != null) nativeDuplicateTabs.add(tab.id)
+    return tab
+  })
+  let expiry
+  const classification = Promise.race([
+    operation.then(
+      () => undefined,
+      () => undefined,
+    ),
+    new Promise((resolve) => {
+      expiry = setTimeout(resolve, NATIVE_DUPLICATE_REGISTRY_TIMEOUT_MS)
+    }),
+  ])
+  pending.add(classification)
+  void classification.finally(() => {
+    clearTimeout(expiry)
+    pending.delete(classification)
+    if (pending.size === 0) pendingNativeDuplicates.delete(sourceTabId)
+  })
+  return operation
+}
+
+async function isNativeDuplicateLifecycleEvent(tab) {
+  if (tab?.id == null) return false
+  if (nativeDuplicateTabs.has(tab.id)) return true
+  if (typeof tab.openerTabId !== 'number') return false
+  const pending = [...(pendingNativeDuplicates.get(tab.openerTabId) || [])]
+  if (pending.length === 0) return false
+  let timer
+  const classified = await Promise.race([
+    Promise.allSettled(pending).then(() => true),
+    new Promise((resolve) => {
+      timer = setTimeout(() => resolve(false), NATIVE_DUPLICATE_CLASSIFICATION_TIMEOUT_MS)
+    }),
+  ])
+  clearTimeout(timer)
+  if (!classified) {
+    void Promise.allSettled(pending).then(async () => {
+      if (nativeDuplicateTabs.has(tab.id) || tabs.has(tab.id) || !port) return
+      const liveTab = await chrome.tabs.get(tab.id).catch(() => null)
+      if (!eligible(liveTab)) return
+      try {
+        await attachTab(tab.id)
+      } catch {}
+    })
+    return true
+  }
+  return nativeDuplicateTabs.has(tab.id)
+}
 
 // Shared "agent window" (opt-in via the daemon's `dedicatedWindow` hint). When
 // set, all agent tabs are created in this one separate window — same Chrome
@@ -669,17 +729,26 @@ async function handleForwardCdpCommand(msg) {
     return await runDuplicateTab(params, {
       tabForTarget,
       getTab: (tabId) => chrome.tabs.get(tabId),
+      getWindow: (windowId) => chrome.windows.get(windowId),
       eligible,
       getLastFocusedWindow: () => chrome.windows.getLastFocused(),
       getActiveTabs: (windowId) => chrome.tabs.query({ active: true, windowId }),
-      duplicateTab: (tabId) => chrome.tabs.duplicate(tabId),
+      duplicateTab: duplicateTabForTransaction,
       markOwned,
       unmarkOwned,
       groupTabInto,
       attachTab,
+      completeTab: (tabId) => nativeDuplicateTabs.delete(tabId),
+      isolateTab: async (tabId) => {
+        detachTab(tabId, true)
+        await chrome.debugger.detach({ tabId }).catch(() => {})
+      },
       activateTab: (tabId) => chrome.tabs.update(tabId, { active: true }),
       focusWindow: (windowId) => chrome.windows.update(windowId, { focused: true }),
-      removeTab: (tabId) => chrome.tabs.remove(tabId),
+      removeTab: async (tabId) => {
+        await chrome.tabs.remove(tabId)
+        nativeDuplicateTabs.delete(tabId)
+      },
     })
   }
 
@@ -815,7 +884,7 @@ async function handleForwardCdpCommand(msg) {
 
 // ---- attach / detach ------------------------------------------------------
 
-async function attachTab(tabId) {
+async function attachTab(tabId, transactionIsActive) {
   const existing = tabs.get(tabId)
   if (existing) return existing
   const dbg = { tabId }
@@ -852,6 +921,10 @@ async function attachTab(tabId) {
   const targetInfo = info?.targetInfo
   const targetId = String(targetInfo?.targetId || '')
   if (!targetId) throw new Error('attachTab: no targetId')
+  if (transactionIsActive && !transactionIsActive()) {
+    await chrome.debugger.detach(dbg).catch(() => {})
+    throw new Error('attachTab: duplicate transaction cancelled')
+  }
   // Derive the session id from the STABLE Chrome tabId, not a monotonic counter
   // (issue #17). A tab's chrome.debugger session can be torn down and
   // re-established — cross-process navigation, a service-worker restart wiping
@@ -861,13 +934,17 @@ async function attachTab(tabId) {
   // never tells it to rebind) → permanent "stale sessionId / tab is gone". The
   // tabId is stable across all of that, so `cb-tab-<tabId>` restores the SAME
   // session the daemon already holds → eval/snapshot auto-follow the new page.
+  const { openerTargetId, abGroup } = await tabScopeHints(tabId)
+  if (transactionIsActive && !transactionIsActive()) {
+    await chrome.debugger.detach(dbg).catch(() => {})
+    throw new Error('attachTab: duplicate transaction cancelled')
+  }
   const sessionId = `cb-tab-${tabId}`
   const entry = { sessionId, targetId }
   tabs.set(tabId, entry)
   sessionToTab.set(sessionId, tabId)
   rememberSessionTarget(sessionId, targetId)
   setBadge(tabId, port ? 'on' : 'connecting')
-  const { openerTargetId, abGroup } = await tabScopeHints(tabId)
   postToHost({
     method: 'forwardCDPEvent',
     params: {
@@ -913,6 +990,7 @@ async function reattachOwnedTabs() {
       unmarkOwned(tabId)
       continue
     }
+    if (nativeDuplicateTabs.has(tabId)) continue
     if (!tabs.has(tabId)) {
       try {
         await attachTab(tabId)
@@ -989,10 +1067,12 @@ chrome.debugger.onDetach.addListener((source, reason) =>
     // user or DevTools initiated.
     if (reason === 'canceled_by_user' || reason === 'replaced_with_devtools') return
     if (!port) return
+    if (nativeDuplicateTabs.has(tabId)) return
     // The swapped-in process needs a moment to settle; retry with backoff.
     for (let i = 0; i < 6; i++) {
       await new Promise((r) => setTimeout(r, 250 + i * 200))
       if (tabs.has(tabId)) return // already re-attached (e.g. via onUpdated)
+      if (nativeDuplicateTabs.has(tabId)) return
       const tab = await chrome.tabs.get(tabId).catch(() => null)
       if (!tab || !eligible(tab)) return // tab gone or now a restricted page
       try {
@@ -1030,6 +1110,7 @@ chrome.debugger.onDetach.addListener((source, reason) =>
 chrome.tabs.onCreated.addListener((tab) =>
   void whenReady(async () => {
     if (!port || !tab || tab.id == null) return
+    if (await isNativeDuplicateLifecycleEvent(tab)) return
     const opener = tab.openerTabId
     if (typeof opener !== 'number') return
     if (!ownedTabs.has(opener) && !tabs.has(opener)) return
@@ -1047,6 +1128,7 @@ chrome.tabs.onCreated.addListener((tab) =>
 )
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) =>
   void whenReady(async () => {
+    if (await isNativeDuplicateLifecycleEvent(tab)) return
     if (changeInfo.status === 'complete' && eligible(tab) && !tabs.has(tabId) && port) {
       try {
         await attachTab(tabId)
@@ -1057,6 +1139,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) =>
 chrome.tabs.onRemoved.addListener(
   (tabId) =>
     void whenReady(() => {
+      nativeDuplicateTabs.delete(tabId)
       unmarkOwned(tabId)
       detachTab(tabId, true)
     }),

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -746,8 +746,11 @@ async function handleForwardCdpCommand(msg) {
       activateTab: (tabId) => chrome.tabs.update(tabId, { active: true }),
       focusWindow: (windowId) => chrome.windows.update(windowId, { focused: true }),
       removeTab: async (tabId) => {
-        await chrome.tabs.remove(tabId)
-        nativeDuplicateTabs.delete(tabId)
+        try {
+          await chrome.tabs.remove(tabId)
+        } finally {
+          nativeDuplicateTabs.delete(tabId)
+        }
       },
     })
   }

--- a/extensions/ab-connect/tab-duplicate.js
+++ b/extensions/ab-connect/tab-duplicate.js
@@ -1,9 +1,71 @@
 // Testable native Duplicate tab transaction. The service worker supplies Chrome
 // adapters; tests supply deterministic fakes at the same system boundary.
-async function bestEffort(operation) {
+const DEFAULT_TRANSACTION_TIMEOUT_MS = 5000
+const DEFAULT_CLEANUP_TIMEOUT_MS = 2000
+const TIMED_OUT = Symbol('timed-out')
+
+async function withTimeout(operation, timeoutMs) {
+  let timer
   try {
-    await operation()
+    return await Promise.race([
+      Promise.resolve().then(operation),
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve(TIMED_OUT), timeoutMs)
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function bestEffort(operation, timeoutMs) {
+  try {
+    await withTimeout(operation, timeoutMs)
   } catch {}
+}
+
+async function observeWithin(operation, timeoutMs) {
+  if (timeoutMs <= 0) return false
+  try {
+    const result = await withTimeout(operation, timeoutMs)
+    return result !== TIMED_OUT && Boolean(result)
+  } catch {
+    return false
+  }
+}
+
+function remainingTime(deadline) {
+  return Math.max(0, deadline - Date.now())
+}
+
+async function completeBefore(operation, deadline, stage) {
+  const timeoutMs = remainingTime(deadline)
+  if (timeoutMs === 0) throw new Error(`duplicateTab: ${stage} timed out`)
+  const result = await withTimeout(operation, timeoutMs)
+  if (result !== TIMED_OUT) return result
+  throw new Error(`duplicateTab: ${stage} timed out`)
+}
+
+async function settleOrVerify(operation, verify, deadline, operationTimeoutMs, stage) {
+  try {
+    await completeBefore(
+      operation,
+      Math.min(deadline, Date.now() + operationTimeoutMs),
+      stage,
+    )
+  } catch (error) {
+    if (await observeWithin(verify, remainingTime(deadline))) return
+    throw error
+  }
+}
+
+async function restoreForegroundBestEffort(deps, tabId, windowId, timeoutMs) {
+  await bestEffort(() => deps.activateTab(tabId), timeoutMs)
+  const focused = await observeWithin(
+    () => deps.getWindow(windowId).then((window) => window?.focused === true),
+    timeoutMs,
+  )
+  if (!focused) await bestEffort(() => deps.focusWindow(windowId), timeoutMs)
 }
 
 export async function duplicateTab(params, deps) {
@@ -23,24 +85,74 @@ export async function duplicateTab(params, deps) {
   const group = typeof params?.agentGroup === 'string' ? params.agentGroup.trim() : ''
   if (!group) throw new Error('duplicateTab: agentGroup is required')
 
+  const cleanupTimeoutMs = deps.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS
+  const transactionTimeoutMs = deps.transactionTimeoutMs ?? DEFAULT_TRANSACTION_TIMEOUT_MS
+  const transactionDeadline = Date.now() + transactionTimeoutMs
+  let transactionActive = true
   let duplicateTabId = null
+  const duplicatePromise = Promise.resolve().then(() => deps.duplicateTab(sourceTabId))
   try {
-    const duplicate = await deps.duplicateTab(sourceTabId)
+    const duplicate = await completeBefore(
+      () => duplicatePromise,
+      transactionDeadline,
+      'native duplicate',
+    )
     duplicateTabId = duplicate?.id ?? null
     if (duplicateTabId == null) throw new Error('duplicateTab: no tab id')
     deps.markOwned(duplicateTabId)
-    await deps.groupTabInto(duplicateTabId, group)
-    const entry = await deps.attachTab(duplicateTabId)
-    await deps.activateTab(restoreTabId)
-    await deps.focusWindow(restoreWindowId)
+    await completeBefore(
+      () => deps.groupTabInto(duplicateTabId, group),
+      transactionDeadline,
+      'tab grouping',
+    )
+    const entry = await completeBefore(
+      () => deps.attachTab(duplicateTabId, () => transactionActive),
+      transactionDeadline,
+      'debugger attach',
+    )
+    await settleOrVerify(
+      () => deps.activateTab(restoreTabId),
+      () => deps.getTab(restoreTabId).then((tab) => tab?.active === true),
+      transactionDeadline,
+      cleanupTimeoutMs,
+      'foreground tab restore',
+    )
+    const windowIsFocused = () =>
+      deps.getWindow(restoreWindowId).then((window) => window?.focused === true)
+    if (!(await observeWithin(windowIsFocused, remainingTime(transactionDeadline)))) {
+      await settleOrVerify(
+        () => deps.focusWindow(restoreWindowId),
+        windowIsFocused,
+        transactionDeadline,
+        cleanupTimeoutMs,
+        'foreground window restore',
+      )
+    }
+    deps.completeTab(duplicateTabId)
     return { sourceTargetId, targetId: entry.targetId }
   } catch (error) {
+    transactionActive = false
     if (duplicateTabId != null) {
-      await bestEffort(() => deps.unmarkOwned(duplicateTabId))
-      await bestEffort(() => deps.removeTab(duplicateTabId))
+      await bestEffort(() => deps.unmarkOwned(duplicateTabId), cleanupTimeoutMs)
+      await bestEffort(() => deps.isolateTab(duplicateTabId), cleanupTimeoutMs)
+      await bestEffort(() => deps.removeTab(duplicateTabId), cleanupTimeoutMs)
+    } else {
+      void duplicatePromise.then(
+        async (duplicate) => {
+          const lateTabId = duplicate?.id ?? null
+          if (lateTabId == null) return
+          await bestEffort(() => deps.isolateTab(lateTabId), cleanupTimeoutMs)
+          await bestEffort(() => deps.removeTab(lateTabId), cleanupTimeoutMs)
+        },
+        () => {},
+      )
     }
-    await bestEffort(() => deps.activateTab(restoreTabId))
-    await bestEffort(() => deps.focusWindow(restoreWindowId))
+    await restoreForegroundBestEffort(
+      deps,
+      restoreTabId,
+      restoreWindowId,
+      cleanupTimeoutMs,
+    )
     throw error
   }
 }

--- a/extensions/ab-connect/tab-duplicate.js
+++ b/extensions/ab-connect/tab-duplicate.js
@@ -59,13 +59,15 @@ async function settleOrVerify(operation, verify, deadline, operationTimeoutMs, s
   }
 }
 
-async function restoreForegroundBestEffort(deps, tabId, windowId, timeoutMs) {
-  await bestEffort(() => deps.activateTab(tabId), timeoutMs)
+async function restoreForegroundBestEffort(deps, tabId, windowId, deadline) {
+  await bestEffort(() => deps.activateTab(tabId), remainingTime(deadline))
   const focused = await observeWithin(
     () => deps.getWindow(windowId).then((window) => window?.focused === true),
-    timeoutMs,
+    remainingTime(deadline),
   )
-  if (!focused) await bestEffort(() => deps.focusWindow(windowId), timeoutMs)
+  if (!focused) {
+    await bestEffort(() => deps.focusWindow(windowId), remainingTime(deadline))
+  }
 }
 
 export async function duplicateTab(params, deps) {
@@ -132,17 +134,34 @@ export async function duplicateTab(params, deps) {
     return { sourceTargetId, targetId: entry.targetId }
   } catch (error) {
     transactionActive = false
+    const cleanupDeadline = Date.now() + cleanupTimeoutMs
     if (duplicateTabId != null) {
-      await bestEffort(() => deps.unmarkOwned(duplicateTabId), cleanupTimeoutMs)
-      await bestEffort(() => deps.isolateTab(duplicateTabId), cleanupTimeoutMs)
-      await bestEffort(() => deps.removeTab(duplicateTabId), cleanupTimeoutMs)
+      await bestEffort(
+        () => deps.unmarkOwned(duplicateTabId),
+        remainingTime(cleanupDeadline),
+      )
+      await bestEffort(
+        () => deps.isolateTab(duplicateTabId),
+        remainingTime(cleanupDeadline),
+      )
+      await bestEffort(
+        () => deps.removeTab(duplicateTabId),
+        remainingTime(cleanupDeadline),
+      )
     } else {
       void duplicatePromise.then(
         async (duplicate) => {
           const lateTabId = duplicate?.id ?? null
           if (lateTabId == null) return
-          await bestEffort(() => deps.isolateTab(lateTabId), cleanupTimeoutMs)
-          await bestEffort(() => deps.removeTab(lateTabId), cleanupTimeoutMs)
+          const lateCleanupDeadline = Date.now() + cleanupTimeoutMs
+          await bestEffort(
+            () => deps.isolateTab(lateTabId),
+            remainingTime(lateCleanupDeadline),
+          )
+          await bestEffort(
+            () => deps.removeTab(lateTabId),
+            remainingTime(lateCleanupDeadline),
+          )
         },
         () => {},
       )
@@ -151,7 +170,7 @@ export async function duplicateTab(params, deps) {
       deps,
       restoreTabId,
       restoreWindowId,
-      cleanupTimeoutMs,
+      cleanupDeadline,
     )
     throw error
   }

--- a/extensions/ab-connect/tab-duplicate.test.js
+++ b/extensions/ab-connect/tab-duplicate.test.js
@@ -9,6 +9,7 @@ function fixture(overrides = {}) {
     getTab: async (tabId) => ({ id: tabId, windowId: 3, url: 'https://example.com/b' }),
     eligible: (tab) => Boolean(tab?.id && tab?.url),
     getLastFocusedWindow: async () => ({ id: 3 }),
+    getWindow: async (windowId) => ({ id: windowId, focused: false }),
     getActiveTabs: async () => [{ id: 7 }],
     duplicateTab: async (tabId) => {
       calls.push(['duplicate', tabId])
@@ -21,6 +22,8 @@ function fixture(overrides = {}) {
       calls.push(['attach', tabId])
       return { targetId: 'duplicate-target' }
     },
+    completeTab: (tabId) => calls.push(['complete', tabId]),
+    isolateTab: async (tabId) => calls.push(['isolate', tabId]),
     activateTab: async (tabId) => calls.push(['activate', tabId]),
     focusWindow: async () => {},
     removeTab: async (tabId) => calls.push(['remove', tabId]),
@@ -30,6 +33,7 @@ function fixture(overrides = {}) {
 }
 
 const params = { sourceTargetId: 'source-target', agentGroup: 'agent-a' }
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 test('native duplicate is grouped, attached, owned, and restores the foreground tab', async () => {
   const { calls, deps } = fixture()
@@ -43,6 +47,7 @@ test('native duplicate is grouped, attached, owned, and restores the foreground 
     ['group', 22, 'agent-a'],
     ['attach', 22],
     ['activate', 7],
+    ['complete', 22],
   ])
 })
 
@@ -60,6 +65,175 @@ test('native duplicate restores the active tab and focus from another window', a
   assert.ok(calls.some((call) => call[0] === 'getActiveTabs' && call[1] === 9))
   assert.ok(calls.some((call) => call[0] === 'activate' && call[1] === 70))
   assert.ok(calls.some((call) => call[0] === 'focusWindow' && call[1] === 9))
+})
+
+test('native duplicate does not stall when foreground activation completed without resolving', { timeout: 200 }, async () => {
+  const { deps } = fixture({
+    transactionTimeoutMs: 20,
+    cleanupTimeoutMs: 5,
+    activateTab: () => new Promise(() => {}),
+    getTab: async (tabId) => ({
+      id: tabId,
+      windowId: 3,
+      url: 'https://example.com/b',
+      active: tabId === 7,
+    }),
+  })
+
+  const result = await duplicateTab(params, deps)
+
+  assert.equal(result.targetId, 'duplicate-target')
+})
+
+test('native duplicate does not stall when window focus completed without resolving', { timeout: 200 }, async () => {
+  let getWindowCalls = 0
+  const { calls, deps } = fixture({
+    transactionTimeoutMs: 20,
+    cleanupTimeoutMs: 5,
+    focusWindow: (windowId) => {
+      calls.push(['focusWindow', windowId])
+      return new Promise(() => {})
+    },
+    getWindow: async (windowId) => {
+      getWindowCalls += 1
+      return { id: windowId, focused: getWindowCalls > 1 }
+    },
+  })
+
+  const result = await duplicateTab(params, deps)
+
+  assert.equal(result.targetId, 'duplicate-target')
+  assert.ok(calls.some((call) => call[0] === 'focusWindow'))
+})
+
+test('native duplicate skips a redundant window focus request', async () => {
+  const { calls, deps } = fixture({
+    getWindow: async (windowId) => ({ id: windowId, focused: true }),
+    focusWindow: async (windowId) => calls.push(['focusWindow', windowId]),
+  })
+
+  await duplicateTab(params, deps)
+
+  assert.ok(!calls.some((call) => call[0] === 'focusWindow'))
+})
+
+test('foreground restore timeout rolls back the duplicate without stalling', { timeout: 200 }, async () => {
+  const { calls, deps } = fixture({
+    transactionTimeoutMs: 20,
+    cleanupTimeoutMs: 5,
+    activateTab: () => new Promise(() => {}),
+    getTab: async (tabId) => ({
+      id: tabId,
+      windowId: 3,
+      url: 'https://example.com/b',
+      active: false,
+    }),
+  })
+
+  await assert.rejects(duplicateTab(params, deps), /foreground tab restore timed out/)
+  assert.ok(calls.some((call) => call[0] === 'remove' && call[1] === 22))
+})
+
+test('foreground restore observation timeout does not stall rollback', { timeout: 200 }, async () => {
+  let getTabCalls = 0
+  const { calls, deps } = fixture({
+    transactionTimeoutMs: 20,
+    cleanupTimeoutMs: 5,
+    activateTab: () => new Promise(() => {}),
+    getTab: async (tabId) => {
+      getTabCalls += 1
+      if (getTabCalls > 1) return await new Promise(() => {})
+      return { id: tabId, windowId: 3, url: 'https://example.com/b' }
+    },
+  })
+
+  await assert.rejects(duplicateTab(params, deps), /foreground tab restore timed out/)
+  assert.ok(calls.some((call) => call[0] === 'remove' && call[1] === 22))
+})
+
+for (const [stage, failure, expected] of [
+  ['group', { groupTabInto: () => new Promise(() => {}) }, /tab grouping timed out/],
+  ['debugger attach', { attachTab: () => new Promise(() => {}) }, /debugger attach timed out/],
+]) {
+  test(`${stage} timeout rolls back the duplicate without stalling`, { timeout: 200 }, async () => {
+    const { calls, deps } = fixture({ transactionTimeoutMs: 5, ...failure })
+
+    await assert.rejects(duplicateTab(params, deps), expected)
+    assert.ok(calls.some((call) => call[0] === 'remove' && call[1] === 22))
+  })
+}
+
+test('late native duplicate is removed after the transaction times out', async () => {
+  const { calls, deps } = fixture({
+    transactionTimeoutMs: 5,
+    duplicateTab: async (tabId) => {
+      await wait(15)
+      calls.push(['duplicate', tabId])
+      return { id: 22 }
+    },
+  })
+
+  await assert.rejects(duplicateTab(params, deps), /native duplicate timed out/)
+  await wait(20)
+
+  assert.ok(calls.some((call) => call[0] === 'remove' && call[1] === 22))
+})
+
+test(
+  'late native duplicate cleanup does not overwrite a newer foreground choice',
+  { timeout: 200 },
+  async () => {
+    const { calls, deps } = fixture({
+      transactionTimeoutMs: 5,
+      getWindow: async (windowId) => ({ id: windowId, focused: true }),
+      duplicateTab: async () => {
+        await wait(15)
+        return { id: 22 }
+      },
+    })
+
+    await assert.rejects(duplicateTab(params, deps), /native duplicate timed out/)
+    const restoreCallsAfterTimeout = calls.filter((call) => call[0] === 'activate').length
+    await wait(20)
+
+    assert.equal(
+      calls.filter((call) => call[0] === 'activate').length,
+      restoreCallsAfterTimeout,
+    )
+  },
+)
+
+test('duplicate setup stages share one transaction deadline', { timeout: 500 }, async () => {
+  const { calls, deps } = fixture({
+    transactionTimeoutMs: 30,
+    duplicateTab: async () => {
+      await wait(20)
+      return { id: 22 }
+    },
+    groupTabInto: async () => {
+      await wait(20)
+    },
+  })
+
+  await assert.rejects(duplicateTab(params, deps), /tab grouping timed out/)
+  assert.ok(calls.some((call) => call[0] === 'remove' && call[1] === 22))
+})
+
+test('late debugger attach observes that its duplicate transaction was cancelled', async () => {
+  const { calls, deps } = fixture({
+    transactionTimeoutMs: 5,
+    attachTab: async (tabId, transactionIsActive) => {
+      await wait(15)
+      calls.push(['attachActive', tabId, transactionIsActive?.()])
+      if (!transactionIsActive?.()) throw new Error('attach cancelled')
+      return { targetId: 'duplicate-target' }
+    },
+  })
+
+  await assert.rejects(duplicateTab(params, deps), /debugger attach timed out/)
+  await wait(20)
+
+  assert.ok(calls.some((call) => call[0] === 'attachActive' && call[2] === false))
 })
 
 test('native duplicate failure is returned without orphan cleanup', async () => {
@@ -102,6 +276,39 @@ test('rollback continues after tab removal rejects', async () => {
   await assert.rejects(duplicateTab(params, deps), (error) => error === original)
   assert.ok(calls.some((call) => call[0] === 'activate'))
   assert.ok(calls.some((call) => call[0] === 'focusWindow'))
+})
+
+test('failed rollback does not commit the duplicate transaction', async () => {
+  const { calls, deps } = fixture({
+    activateTab: async () => {
+      throw new Error('restore failed')
+    },
+    getTab: async (tabId) => ({
+      id: tabId,
+      windowId: 3,
+      url: 'https://example.com/b',
+      active: false,
+    }),
+    removeTab: async () => {
+      throw new Error('remove failed')
+    },
+  })
+
+  await assert.rejects(duplicateTab(params, deps), /restore failed/)
+  assert.ok(!calls.some((call) => call[0] === 'complete'))
+})
+
+test('rollback isolates the duplicate before a stalled removal', { timeout: 200 }, async () => {
+  const { calls, deps } = fixture({
+    cleanupTimeoutMs: 5,
+    groupTabInto: async () => {
+      throw new Error('group failed')
+    },
+    removeTab: () => new Promise(() => {}),
+  })
+
+  await assert.rejects(duplicateTab(params, deps), /group failed/)
+  assert.ok(calls.some((call) => call[0] === 'isolate' && call[1] === 22))
 })
 
 test('rollback focuses the previous window after tab activation rejects', async () => {

--- a/extensions/ab-connect/tab-duplicate.test.js
+++ b/extensions/ab-connect/tab-duplicate.test.js
@@ -34,6 +34,14 @@ function fixture(overrides = {}) {
 
 const params = { sourceTargetId: 'source-target', agentGroup: 'agent-a' }
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+async function waitUntil(predicate, timeoutMs = 250) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await wait(5)
+  }
+  return predicate()
+}
 
 test('native duplicate is grouped, attached, owned, and restores the foreground tab', async () => {
   const { calls, deps } = fixture()
@@ -174,9 +182,9 @@ test('late native duplicate is removed after the transaction times out', async (
   })
 
   await assert.rejects(duplicateTab(params, deps), /native duplicate timed out/)
-  await wait(20)
-
-  assert.ok(calls.some((call) => call[0] === 'remove' && call[1] === 22))
+  assert.ok(
+    await waitUntil(() => calls.some((call) => call[0] === 'remove' && call[1] === 22)),
+  )
 })
 
 test(
@@ -194,7 +202,9 @@ test(
 
     await assert.rejects(duplicateTab(params, deps), /native duplicate timed out/)
     const restoreCallsAfterTimeout = calls.filter((call) => call[0] === 'activate').length
-    await wait(20)
+    assert.ok(
+      await waitUntil(() => calls.some((call) => call[0] === 'remove' && call[1] === 22)),
+    )
 
     assert.equal(
       calls.filter((call) => call[0] === 'activate').length,
@@ -231,9 +241,11 @@ test('late debugger attach observes that its duplicate transaction was cancelled
   })
 
   await assert.rejects(duplicateTab(params, deps), /debugger attach timed out/)
-  await wait(20)
-
-  assert.ok(calls.some((call) => call[0] === 'attachActive' && call[2] === false))
+  assert.ok(
+    await waitUntil(() =>
+      calls.some((call) => call[0] === 'attachActive' && call[2] === false),
+    ),
+  )
 })
 
 test('native duplicate failure is returned without orphan cleanup', async () => {
@@ -276,6 +288,43 @@ test('rollback continues after tab removal rejects', async () => {
   await assert.rejects(duplicateTab(params, deps), (error) => error === original)
   assert.ok(calls.some((call) => call[0] === 'activate'))
   assert.ok(calls.some((call) => call[0] === 'focusWindow'))
+})
+
+test('rollback cleanup stages share one aggregate deadline', { timeout: 1000 }, async () => {
+  const stalled = () => new Promise(() => {})
+  const { calls, deps } = fixture({
+    cleanupTimeoutMs: 250,
+    groupTabInto: async () => {
+      throw new Error('group failed')
+    },
+    unmarkOwned: (tabId) => {
+      calls.push(['unmarkOwned', tabId])
+      return stalled()
+    },
+    isolateTab: (tabId) => {
+      calls.push(['isolate', tabId])
+      return stalled()
+    },
+    removeTab: (tabId) => {
+      calls.push(['remove', tabId])
+      return stalled()
+    },
+    activateTab: (tabId) => {
+      calls.push(['activate', tabId])
+      return stalled()
+    },
+    getWindow: stalled,
+    focusWindow: (windowId) => {
+      calls.push(['focusWindow', windowId])
+      return stalled()
+    },
+  })
+
+  await assert.rejects(duplicateTab(params, deps), /group failed/)
+
+  for (const operation of ['unmarkOwned', 'isolate', 'remove', 'activate', 'focusWindow']) {
+    assert.ok(calls.some((call) => call[0] === operation), `${operation} was not attempted`)
+  }
 })
 
 test('failed rollback does not commit the duplicate transaction', async () => {


### PR DESCRIPTION
## Summary

- bound the native duplicate, grouping, debugger attach, and foreground restore stages with one internal transaction deadline
- isolate in-flight and cancelled duplicate tabs from lifecycle reattach paths
- prevent late duplicate or attach completion from registering ghost targets
- make rollback bounded and best-effort while preserving the original error
- add repeated extension-connected Chrome coverage that verifies one registered target per duplicate and cleanup

## Root cause

`ABExt.duplicateTab` shared the CLI's outer timeout with several Chrome extension operations that could remain pending. A late completion could create or attach a tab after the command had already timed out, so the next target resync exposed an extra ghost tab. In a 10-run control smoke, 9 duplicates succeeded and one timed out; the following resync skipped a tab number, confirming that the timed-out transaction completed late.

The extension now owns the transaction deadline and keeps a duplicate tombstone until the full transaction commits or the tab is removed. Lifecycle attach paths respect that tombstone, and rollback detaches the target before attempting bounded tab removal.

## Validation

- `pnpm test:extension` — 25 passed
- `node --check extensions/ab-connect/background.js`
- `node --check extensions/ab-connect/tab-duplicate.js`
- `node --check extensions/ab-connect/tab-duplicate.test.js`
- `cd cli && cargo fmt -- --check`
- `cd cli && cargo test -- --test-threads=1` — 1046 passed, 3 ignored; integration tests 2 passed
- `cd cli && cargo clippy`
- `cd cli && cargo test tab_duplicate --features e2e-tests` — 3 passed, 2 ignored
- `git diff --check`

The full ignored E2E run reached the extension-connected duplicate case and the new test path remained gated because `CHROME_USE_EXTENSION_E2E=1` was not set with this checkout's extension loaded. The run also reproduced three existing environment failures: drag button state, missing FFmpeg, and macOS device pixel ratio. The final parity test later stalled and the run was interrupted.

No version, changelog, or release-note files are changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native tab duplication with transaction-based lifecycle handling, better deadline/timeout enforcement, and reliable rollback/cleanup.
  * Prevented duplicate tabs from reattaching or being processed multiple times, including during debugger attach/detach recovery.
  * Avoided stale tracking after tab removal and ensured late duplicates are handled/removed correctly.
* **Tests**
  * Expanded unit and E2E coverage for cancellation, repeated duplication, reconnect/resync, and advanced timeout/rollback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->