### PR TITLE
fix(fill): verify Monaco model writes

### DIFF
--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1176,11 +1176,24 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
     .await;
     assert_success(&resp);
 
+    let (fixture_port, fixture_server) =
+        spawn_html_server(native_test_fixture_html("monaco_fill_probe").to_string(), 1).await;
+    state
+        .browser
+        .as_ref()
+        .expect("browser should be launched")
+        .grant_permissions(&[
+            "clipboardReadWrite".to_string(),
+            "clipboardSanitizedWrite".to_string(),
+        ])
+        .await
+        .expect("clipboard permissions should be granted for the disposable fixture browser");
+
     let resp = execute_command(
         &json!({
             "id": "2",
             "action": "navigate",
-            "url": native_test_fixture_url("monaco_fill_probe")
+            "url": format!("http://127.0.0.1:{fixture_port}/")
         }),
         &mut state,
     )
@@ -1205,6 +1218,7 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
     let working_ref = ref_for("Working editor content");
     let stuck_ref = ref_for("Stuck editor content");
     let unsupported_ref = ref_for("Unsupported editor content");
+    let clipboard_ref = ref_for("Clipboard editor content");
 
     let yaml = "services:\n  app:\n    image: nginx:latest\n    volumes:\n      - /data:/data\n    ports:\n      - \"5533:80\"";
     let resp = execute_command(
@@ -1236,11 +1250,43 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
         "Monaco fill must preserve multiline YAML indentation exactly"
     );
 
+    // DSM-like Monaco can hide its model API while still handling trusted
+    // clipboard commands through textarea.inputarea. That fallback must remain
+    // atomic and must verify the copied model value before succeeding.
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "fill",
+            "selector": clipboard_ref,
+            "value": yaml
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["engine"], "monaco-clipboard");
+
+    let resp = execute_command(
+        &json!({
+            "id": "6b",
+            "action": "inputvalue",
+            "selector": clipboard_ref
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["value"],
+        yaml,
+        "clipboard-backed Monaco readback must preserve multiline YAML exactly"
+    );
+
     // A Monaco model that ignores setValue must fail the fill verification.
     // Returning success here would recreate the dangerous DSM false positive.
     let resp = execute_command(
         &json!({
-            "id": "6",
+            "id": "7",
             "action": "fill",
             "selector": stuck_ref,
             "value": yaml
@@ -1261,7 +1307,7 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
     // before attempting any hidden-textarea fallback.
     let resp = execute_command(
         &json!({
-            "id": "7",
+            "id": "8",
             "action": "fill",
             "selector": unsupported_ref,
             "value": yaml
@@ -1274,14 +1320,14 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
         resp["error"]
             .as_str()
             .unwrap_or("")
-            .contains("model API is not accessible"),
+            .contains("not handled as a trusted editor operation"),
         "failure should explain why Monaco cannot be filled safely: {resp}"
     );
 
     // Plain inputs still use the native setter path and are verified too.
     let resp = execute_command(
         &json!({
-            "id": "8",
+            "id": "9",
             "action": "fill",
             "selector": "#plain-input",
             "value": "ordinary value"
@@ -1293,7 +1339,7 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
     assert_eq!(get_data(&resp)["engine"], "input");
     let resp = execute_command(
         &json!({
-            "id": "9",
+            "id": "10",
             "action": "inputvalue",
             "selector": "#plain-input"
         }),
@@ -1305,6 +1351,9 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);
+    fixture_server
+        .await
+        .expect("Monaco fixture server should shut down");
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -1211,14 +1211,17 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
         snapshot
             .lines()
             .find(|line| line.contains(accessible_name))
-            .and_then(|line| line.split("ref=").nth(1))
-            .map(|value| format!("@{}", value.trim_end_matches(']').trim()))
+            .and_then(|line| line.split_once("[ref="))
+            .and_then(|(_, rest)| rest.split(']').next())
+            .map(|value| format!("@{}", value.trim()))
             .unwrap_or_else(|| panic!("{accessible_name} not found in snapshot:\n{snapshot}"))
     };
     let working_ref = ref_for("Working editor content");
     let stuck_ref = ref_for("Stuck editor content");
     let unsupported_ref = ref_for("Unsupported editor content");
     let clipboard_ref = ref_for("Clipboard editor content");
+    let global_ref = ref_for("Global editor content");
+    let default_ref = ref_for("Default editor content");
 
     let yaml = "services:\n  app:\n    image: nginx:latest\n    volumes:\n      - /data:/data\n    ports:\n      - \"5533:80\"";
     let resp = execute_command(
@@ -1248,6 +1251,66 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
         get_data(&resp)["value"],
         yaml,
         "Monaco fill must preserve multiline YAML indentation exactly"
+    );
+
+    // The same shared resolver must also follow window.monaco and nested
+    // default.monaco exports, rather than succeeding only through AMD require.
+    let resp = execute_command(
+        &json!({
+            "id": "5c",
+            "action": "fill",
+            "selector": global_ref,
+            "value": yaml
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["engine"], "monaco");
+
+    let resp = execute_command(
+        &json!({
+            "id": "5d",
+            "action": "inputvalue",
+            "selector": global_ref
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["value"],
+        yaml,
+        "global Monaco readback must preserve multiline YAML exactly"
+    );
+
+    let resp = execute_command(
+        &json!({
+            "id": "5e",
+            "action": "fill",
+            "selector": default_ref,
+            "value": yaml
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["engine"], "monaco");
+
+    let resp = execute_command(
+        &json!({
+            "id": "5f",
+            "action": "inputvalue",
+            "selector": default_ref
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["value"],
+        yaml,
+        "default-wrapped Monaco readback must preserve multiline YAML exactly"
     );
 
     // DSM-like Monaco can hide its model API while still handling trusted
@@ -1295,12 +1358,14 @@ async fn e2e_fill_monaco_is_atomic_and_verified() {
     )
     .await;
     assert_eq!(resp["success"], false, "empty Monaco readback must fail");
+    let error = resp["error"].as_str().unwrap_or("");
     assert!(
-        resp["error"]
-            .as_str()
-            .unwrap_or("")
-            .contains("read back an empty value"),
-        "failure should explain the failed post-condition: {resp}"
+        error.contains("fill verification failed"),
+        "failure should report the verification boundary: {resp}"
+    );
+    assert!(
+        error.contains("monaco"),
+        "failure should identify the Monaco engine: {resp}"
     );
 
     // A Monaco-looking textbox without a resolvable editor/model must fail

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -37,6 +37,7 @@ fn native_test_fixture_html(name: &str) -> &'static str {
         "upload_probe" => include_str!("test_fixtures/upload_probe.html"),
         "hidden_upload_probe" => include_str!("test_fixtures/hidden_upload_probe.html"),
         "iframe_button_probe" => include_str!("test_fixtures/iframe_button_probe.html"),
+        "monaco_fill_probe" => include_str!("test_fixtures/monaco_fill_probe.html"),
         _ => panic!("Unknown native test fixture: {}", name),
     }
 }
@@ -1155,6 +1156,152 @@ async fn e2e_form_interaction() {
     );
     assert!(snap.contains("textbox"), "Snapshot should show textbox");
     assert!(snap.contains("button"), "Snapshot should show button");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Regression coverage for issue #138. Synology DSM exposes Monaco's hidden
+/// textarea as a textbox, so the command must resolve the owning model, replace
+/// multiline content atomically, and verify the exact value before succeeding.
+#[tokio::test]
+#[ignore]
+async fn e2e_fill_monaco_is_atomic_and_verified() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": native_test_fixture_url("monaco_fill_probe")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let snapshot = get_data(&resp)["snapshot"].as_str().unwrap_or("");
+    let ref_for = |accessible_name: &str| {
+        snapshot
+            .lines()
+            .find(|line| line.contains(accessible_name))
+            .and_then(|line| line.split("ref=").nth(1))
+            .map(|value| format!("@{}", value.trim_end_matches(']').trim()))
+            .unwrap_or_else(|| panic!("{accessible_name} not found in snapshot:\n{snapshot}"))
+    };
+    let working_ref = ref_for("Working editor content");
+    let stuck_ref = ref_for("Stuck editor content");
+    let unsupported_ref = ref_for("Unsupported editor content");
+
+    let yaml = "services:\n  app:\n    image: nginx:latest\n    volumes:\n      - /data:/data\n    ports:\n      - \"5533:80\"";
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "fill",
+            "selector": working_ref,
+            "value": yaml
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["engine"], "monaco");
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "inputvalue",
+            "selector": working_ref
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["value"],
+        yaml,
+        "Monaco fill must preserve multiline YAML indentation exactly"
+    );
+
+    // A Monaco model that ignores setValue must fail the fill verification.
+    // Returning success here would recreate the dangerous DSM false positive.
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "fill",
+            "selector": stuck_ref,
+            "value": yaml
+        }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false, "empty Monaco readback must fail");
+    assert!(
+        resp["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("read back an empty value"),
+        "failure should explain the failed post-condition: {resp}"
+    );
+
+    // A Monaco-looking textbox without a resolvable editor/model must fail
+    // before attempting any hidden-textarea fallback.
+    let resp = execute_command(
+        &json!({
+            "id": "7",
+            "action": "fill",
+            "selector": unsupported_ref,
+            "value": yaml
+        }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false, "unsupported Monaco must fail");
+    assert!(
+        resp["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("model API is not accessible"),
+        "failure should explain why Monaco cannot be filled safely: {resp}"
+    );
+
+    // Plain inputs still use the native setter path and are verified too.
+    let resp = execute_command(
+        &json!({
+            "id": "8",
+            "action": "fill",
+            "selector": "#plain-input",
+            "value": "ordinary value"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["engine"], "input");
+    let resp = execute_command(
+        &json!({
+            "id": "9",
+            "action": "inputvalue",
+            "selector": "#plain-input"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["value"], "ordinary value");
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -6,6 +6,88 @@ use super::adaptive::{self, ElementFingerprint};
 use super::cdp::client::CdpClient;
 use super::cdp::types::*;
 
+/// Read the value represented by an editable element.
+///
+/// Rich editors keep their authoritative value outside the DOM node exposed by
+/// the accessibility tree. In particular, Monaco snapshots its hidden
+/// `textarea.inputarea` as a textbox even though the textarea value is not the
+/// editor model. Resolve the owning editor and return the model value so callers
+/// can verify writes instead of treating an empty textarea as success.
+pub(crate) const READ_EDITABLE_VALUE_FUNCTION: &str = r#"function() {
+    let el = this;
+
+    const monacoRoot = (el.closest && el.closest('.monaco-editor'))
+        || (el.querySelector && el.querySelector('.monaco-editor'));
+    if (monacoRoot) {
+        const candidates = [];
+        const seen = new Set();
+        const add = value => {
+            if (!value || seen.has(value)) return;
+            seen.add(value);
+            if (value.editor) candidates.push(value.editor);
+            if (value.monaco && value.monaco.editor) candidates.push(value.monaco.editor);
+            if (value.default) add(value.default);
+        };
+        add(window.monaco);
+        if (typeof window.require === 'function') {
+            for (const id of ['vs/editor/editor.api', 'vs/editor/editor.main']) {
+                try { add(window.require(id)); } catch (e) {}
+            }
+        }
+
+        for (const api of candidates) {
+            try {
+                const editors = api.getEditors ? api.getEditors() : [];
+                const editor = editors.find(candidate => {
+                    const node = candidate.getDomNode && candidate.getDomNode();
+                    return node && (node === monacoRoot || node.contains(el));
+                });
+                if (editor && editor.getValue) {
+                    return { ok: true, engine: 'monaco', value: editor.getValue() };
+                }
+
+                const models = api.getModels ? api.getModels() : [];
+                const roots = document.querySelectorAll('.monaco-editor');
+                if (models.length === 1 && roots.length === 1 && models[0].getValue) {
+                    return { ok: true, engine: 'monaco', value: models[0].getValue() };
+                }
+            } catch (e) {}
+        }
+
+        return {
+            ok: false,
+            engine: 'monaco',
+            error: 'Monaco model API is not accessible for this editor'
+        };
+    }
+
+    const cm5 = (el.closest && el.closest('.CodeMirror'))
+        || (el.querySelector && el.querySelector('.CodeMirror'));
+    if (cm5 && cm5.CodeMirror) {
+        return { ok: true, engine: 'codemirror5', value: cm5.CodeMirror.getValue() };
+    }
+
+    const editable = node => node && (
+        node.tagName === 'INPUT'
+        || node.tagName === 'TEXTAREA'
+        || node.tagName === 'SELECT'
+        || node.isContentEditable
+    );
+    if (!editable(el) && el.querySelector) {
+        const inner = el.querySelector('input, textarea, select, [contenteditable]');
+        if (inner) el = inner;
+    }
+
+    if (typeof el.value === 'string') {
+        const engine = el.tagName === 'SELECT' ? 'select' : 'input';
+        return { ok: true, engine, value: el.value };
+    }
+    if (el.isContentEditable) {
+        return { ok: true, engine: 'contenteditable', value: el.innerText };
+    }
+    return { ok: false, engine: 'unknown', error: 'Element does not expose an editable value' };
+}"#;
+
 #[derive(Debug, Clone)]
 pub struct RefEntry {
     pub backend_node_id: Option<i64>,
@@ -1636,27 +1718,7 @@ pub async fn get_element_input_value(
         .send_command_typed(
             "Runtime.callFunctionOn",
             &CallFunctionOnParams {
-                // Read rich-editor content too (issue #41): CodeMirror 5 / Monaco
-                // keep their text in a model, not `.value`; contenteditable keeps
-                // it as innerText. Falls back to `.value` for plain inputs.
-                function_declaration: r#"function() {
-                    const el = this;
-                    const cm5 = el.closest && el.closest('.CodeMirror');
-                    if (cm5 && cm5.CodeMirror) return cm5.CodeMirror.getValue();
-                    if (window.monaco && monaco.editor) {
-                        try {
-                            const eds = monaco.editor.getEditors ? monaco.editor.getEditors() : [];
-                            const ed = eds.find(e => e.getDomNode && e.getDomNode().contains(el)) || eds[0];
-                            if (ed) return ed.getValue();
-                            const m = monaco.editor.getModels ? monaco.editor.getModels() : [];
-                            if (m[0]) return m[0].getValue();
-                        } catch (e) {}
-                    }
-                    if (typeof el.value === 'string') return el.value;
-                    if (el.isContentEditable) return el.innerText;
-                    return '';
-                }"#
-                .to_string(),
+                function_declaration: READ_EDITABLE_VALUE_FUNCTION.to_string(),
                 object_id: Some(object_id),
                 arguments: None,
                 return_by_value: Some(true),
@@ -1666,11 +1728,23 @@ pub async fn get_element_input_value(
         )
         .await?;
 
-    Ok(result
-        .result
-        .value
-        .and_then(|v| v.as_str().map(|s| s.to_string()))
-        .unwrap_or_default())
+    if let Some(ex) = result.exception_details {
+        return Err(format!("get value failed: {}", ex.text));
+    }
+
+    let data = result.result.value.unwrap_or(Value::Null);
+    if !data.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        return Err(data
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("Element does not expose a readable value")
+            .to_string());
+    }
+
+    data.get("value")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| "Element value was not returned as text".to_string())
 }
 
 pub async fn set_element_value(

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -6,6 +6,29 @@ use super::adaptive::{self, ElementFingerprint};
 use super::cdp::client::CdpClient;
 use super::cdp::types::*;
 
+/// Discover Monaco editor APIs exposed through the global object or AMD loader.
+///
+/// Keep this as the single source for both reads and writes so the two paths
+/// cannot silently diverge when Monaco's public surface changes.
+pub(crate) const MONACO_CANDIDATES_FUNCTION: &str = r#"function() {
+    const candidates = [];
+    const seen = new Set();
+    const add = value => {
+        if (!value || seen.has(value)) return;
+        seen.add(value);
+        if (value.editor) candidates.push(value.editor);
+        if (value.monaco && value.monaco.editor) candidates.push(value.monaco.editor);
+        if (value.default) add(value.default);
+    };
+    add(window.monaco);
+    if (typeof window.require === 'function') {
+        for (const id of ['vs/editor/editor.api', 'vs/editor/editor.main']) {
+            try { add(window.require(id)); } catch (e) {}
+        }
+    }
+    return candidates;
+}"#;
+
 /// Read the value represented by an editable element.
 ///
 /// Rich editors keep their authoritative value outside the DOM node exposed by
@@ -13,29 +36,14 @@ use super::cdp::types::*;
 /// `textarea.inputarea` as a textbox even though the textarea value is not the
 /// editor model. Resolve the owning editor and return the model value so callers
 /// can verify writes instead of treating an empty textarea as success.
-pub(crate) const READ_EDITABLE_VALUE_FUNCTION: &str = r#"function() {
+const READ_EDITABLE_VALUE_TEMPLATE: &str = r#"function() {
     let el = this;
+    const monacoCandidates = __CHROME_USE_MONACO_CANDIDATES__;
 
     const monacoRoot = (el.closest && el.closest('.monaco-editor'))
         || (el.querySelector && el.querySelector('.monaco-editor'));
     if (monacoRoot) {
-        const candidates = [];
-        const seen = new Set();
-        const add = value => {
-            if (!value || seen.has(value)) return;
-            seen.add(value);
-            if (value.editor) candidates.push(value.editor);
-            if (value.monaco && value.monaco.editor) candidates.push(value.monaco.editor);
-            if (value.default) add(value.default);
-        };
-        add(window.monaco);
-        if (typeof window.require === 'function') {
-            for (const id of ['vs/editor/editor.api', 'vs/editor/editor.main']) {
-                try { add(window.require(id)); } catch (e) {}
-            }
-        }
-
-        for (const api of candidates) {
+        for (const api of monacoCandidates()) {
             try {
                 const editors = api.getEditors ? api.getEditors() : [];
                 const editor = editors.find(candidate => {
@@ -87,6 +95,13 @@ pub(crate) const READ_EDITABLE_VALUE_FUNCTION: &str = r#"function() {
     }
     return { ok: false, engine: 'unknown', error: 'Element does not expose an editable value' };
 }"#;
+
+pub(crate) fn read_editable_value_function() -> String {
+    READ_EDITABLE_VALUE_TEMPLATE.replace(
+        "__CHROME_USE_MONACO_CANDIDATES__",
+        MONACO_CANDIDATES_FUNCTION,
+    )
+}
 
 #[derive(Debug, Clone)]
 pub struct RefEntry {
@@ -1718,7 +1733,7 @@ pub async fn get_element_input_value(
         .send_command_typed(
             "Runtime.callFunctionOn",
             &CallFunctionOnParams {
-                function_declaration: READ_EDITABLE_VALUE_FUNCTION.to_string(),
+                function_declaration: read_editable_value_function(),
                 object_id: Some(object_id.clone()),
                 arguments: None,
                 return_by_value: Some(true),

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -1719,7 +1719,7 @@ pub async fn get_element_input_value(
             "Runtime.callFunctionOn",
             &CallFunctionOnParams {
                 function_declaration: READ_EDITABLE_VALUE_FUNCTION.to_string(),
-                object_id: Some(object_id),
+                object_id: Some(object_id.clone()),
                 arguments: None,
                 return_by_value: Some(true),
                 await_promise: Some(false),
@@ -1733,6 +1733,17 @@ pub async fn get_element_input_value(
     }
 
     let data = result.result.value.unwrap_or(Value::Null);
+    if !data.get("ok").and_then(Value::as_bool).unwrap_or(false)
+        && data.get("engine").and_then(Value::as_str) == Some("monaco")
+    {
+        return super::interaction::read_monaco_via_clipboard(
+            client,
+            &effective_session_id,
+            &object_id,
+        )
+        .await;
+    }
+
     if !data.get("ok").and_then(Value::as_bool).unwrap_or(false) {
         return Err(data
             .get("error")

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -4,7 +4,10 @@ use serde_json::Value;
 
 use super::cdp::client::CdpClient;
 use super::cdp::types::*;
-use super::element::{parse_ref, resolve_element_center, resolve_element_object_id, RefMap};
+use super::element::{
+    parse_ref, resolve_element_center, resolve_element_object_id, RefMap,
+    READ_EDITABLE_VALUE_FUNCTION,
+};
 use super::humanize;
 
 /// Whether a pointer interaction should be DOM-dispatched (invoke the event on
@@ -603,11 +606,58 @@ pub async fn fill(
         r#"function() {{
             let el = this;
             const v = {val};
+            const monacoRoot = (el.closest && el.closest('.monaco-editor'))
+                || (el.querySelector && el.querySelector('.monaco-editor'));
+
+            // Monaco: only use its authoritative model API. The hidden
+            // textarea.inputarea surfaced by the accessibility tree is an input
+            // transport, not the model. Synthetic paste events on it are untrusted
+            // and may be ignored while still looking successful (#138).
+            if (monacoRoot) {{
+                const candidates = [];
+                const seen = new Set();
+                const add = value => {{
+                    if (!value || seen.has(value)) return;
+                    seen.add(value);
+                    if (value.editor) candidates.push(value.editor);
+                    if (value.monaco && value.monaco.editor) candidates.push(value.monaco.editor);
+                    if (value.default) add(value.default);
+                }};
+                add(window.monaco);
+                if (typeof window.require === 'function') {{
+                    for (const id of ['vs/editor/editor.api', 'vs/editor/editor.main']) {{
+                        try {{ add(window.require(id)); }} catch (e) {{}}
+                    }}
+                }}
+
+                for (const api of candidates) {{
+                    try {{
+                        const editors = api.getEditors ? api.getEditors() : [];
+                        const editor = editors.find(candidate => {{
+                            const node = candidate.getDomNode && candidate.getDomNode();
+                            return node && (node === monacoRoot || node.contains(el));
+                        }});
+                        if (editor && editor.setValue && editor.getValue) {{
+                            editor.setValue(v);
+                            return 'monaco';
+                        }}
+
+                        const models = api.getModels ? api.getModels() : [];
+                        const roots = document.querySelectorAll('.monaco-editor');
+                        if (models.length === 1 && roots.length === 1
+                            && models[0].setValue && models[0].getValue) {{
+                            models[0].setValue(v);
+                            return 'monaco';
+                        }}
+                    }} catch (e) {{}}
+                }}
+                return 'monaco-unsupported';
+            }}
+
             // If the ref anchored a WRAPPER rather than the field itself (common when
             // a controlled input lives inside a shadow/portal and snapshot pinned the
             // host), retarget to the nested editable so the native setter lands on the
-            // real input instead of no-op'ing on a div (#105.2). Also lets a Monaco
-            // container resolve down to its `textarea.inputarea`.
+            // real input instead of no-op'ing on a div (#105.2).
             const editable = n => n && (n.tagName === 'INPUT' || n.tagName === 'TEXTAREA' || n.tagName === 'SELECT' || n.isContentEditable);
             if (!editable(el) && el.querySelector) {{
                 const inner = el.querySelector('input, textarea, select, [contenteditable]');
@@ -620,36 +670,6 @@ pub async fn fill(
             // CodeMirror 5: a hidden <textarea> inside .CodeMirror with a live instance.
             const cm5 = el.closest && el.closest('.CodeMirror');
             if (cm5 && cm5.CodeMirror) {{ cm5.CodeMirror.setValue(v); return 'codemirror5'; }}
-
-            // Monaco: global `monaco`; prefer the editor whose DOM contains el.
-            if (window.monaco && monaco.editor) {{
-                try {{
-                    const eds = monaco.editor.getEditors ? monaco.editor.getEditors() : [];
-                    const ed = eds.find(e => e.getDomNode && e.getDomNode().contains(el)) || eds[0];
-                    if (ed) {{ ed.setValue(v); return 'monaco'; }}
-                    const models = monaco.editor.getModels ? monaco.editor.getModels() : [];
-                    if (models[0]) {{ models[0].setValue(v); return 'monaco'; }}
-                }} catch (e) {{}}
-            }}
-
-            // Monaco whose runtime isn't exposed on `window.monaco` (bundled inside a
-            // module scope — e.g. Cloudflare Zaraz's Custom-HTML editor, #105.3): the
-            // model can't be reached, and setting the hidden `textarea.inputarea`'s
-            // `.value` does nothing (Monaco ignores it). Drive it the way a human
-            // paste does — a synthetic `paste` ClipboardEvent on the inputarea, which
-            // Monaco's paste handler applies to the model and fires its own events.
-            const mon = el.closest && el.closest('.monaco-editor');
-            const ta = (mon && mon.querySelector('textarea.inputarea'))
-                || ((el.matches && el.matches('textarea.inputarea')) ? el : null);
-            if (ta) {{
-                try {{
-                    ta.focus();
-                    const dt = new DataTransfer();
-                    dt.setData('text/plain', v);
-                    ta.dispatchEvent(new ClipboardEvent('paste', {{ bubbles: true, cancelable: true, clipboardData: dt }}));
-                    return 'monaco-paste';
-                }} catch (e) {{}}
-            }}
 
             if (tag === 'SELECT') {{ el.value = v; fire('input'); fire('change'); return 'select'; }}
 
@@ -703,11 +723,23 @@ pub async fn fill(
         )
         .await?;
 
-    let engine = result
+    if let Some(ex) = result.exception_details {
+        return Err(format!("fill failed: {}", ex.text));
+    }
+
+    let mut engine = result
         .result
         .value
         .and_then(|v| v.as_str().map(String::from))
         .unwrap_or_else(|| "input".to_string());
+
+    if engine == "monaco-unsupported" {
+        return Err(
+            "fill cannot safely replace this Monaco editor because its model API is not \
+             accessible; no text was written"
+                .to_string(),
+        );
+    }
 
     // Contenteditable rich editors (DraftJS / Lexical / ProseMirror): the JS above
     // only focused + selected-all. Do the actual edit through CDP so the events are
@@ -739,7 +771,7 @@ pub async fn fill(
                         "Runtime.callFunctionOn",
                         &CallFunctionOnParams {
                             function_declaration: "function() { try { this.dispatchEvent(new Event('change', { bubbles: true })); this.dispatchEvent(new Event('focusout', { bubbles: true })); } catch (e) {} }".to_string(),
-                            object_id: Some(object_id),
+                            object_id: Some(object_id.clone()),
                             arguments: None,
                             return_by_value: Some(true),
                             await_promise: Some(false),
@@ -747,7 +779,6 @@ pub async fn fill(
                         Some(&effective_session_id),
                     )
                     .await;
-                return Ok("contenteditable".to_string());
             }
             Err(_) => {
                 // CDP insert unavailable (rare: some Electron webviews). Fall back to
@@ -768,7 +799,7 @@ pub async fn fill(
                         "Runtime.callFunctionOn",
                         &CallFunctionOnParams {
                             function_declaration: fallback_js,
-                            object_id: Some(object_id),
+                            object_id: Some(object_id.clone()),
                             arguments: None,
                             return_by_value: Some(true),
                             await_promise: Some(false),
@@ -776,16 +807,84 @@ pub async fn fill(
                         Some(&effective_session_id),
                     )
                     .await?;
-                return Ok(fb
+                engine = fb
                     .result
                     .value
                     .and_then(|v| v.as_str().map(String::from))
-                    .unwrap_or_else(|| "contenteditable-fallback".to_string()));
+                    .unwrap_or_else(|| "contenteditable-fallback".to_string());
             }
         }
     }
 
+    verify_fill_value(client, &effective_session_id, &object_id, value, &engine).await?;
+
     Ok(engine)
+}
+
+async fn verify_fill_value(
+    client: &CdpClient,
+    session_id: &str,
+    object_id: &str,
+    expected: &str,
+    engine: &str,
+) -> Result<(), String> {
+    // Let framework-controlled inputs and editor models finish their synchronous
+    // update plus the next paint before reading the authoritative value back.
+    wait_for_paint_settled(client, session_id).await;
+
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: READ_EDITABLE_VALUE_FUNCTION.to_string(),
+                object_id: Some(object_id.to_string()),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(session_id),
+        )
+        .await?;
+
+    if let Some(ex) = result.exception_details {
+        return Err(format!(
+            "fill verification failed for {engine}: {}",
+            ex.text
+        ));
+    }
+
+    let data = result.result.value.unwrap_or(Value::Null);
+    if !data.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        let reason = data
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("the edited value could not be read back");
+        return Err(format!("fill verification failed for {engine}: {reason}"));
+    }
+
+    let actual = data
+        .get("value")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("fill verification failed for {engine}: no text was read back"))?;
+
+    // HTML text controls normalize CRLF to LF. Compare that standardized form
+    // while preserving every other byte, including leading spaces in YAML.
+    let normalized_expected = expected.replace("\r\n", "\n");
+    let normalized_actual = actual.replace("\r\n", "\n");
+    if normalized_actual != normalized_expected {
+        let detail = if actual.is_empty() && !expected.is_empty() {
+            "read back an empty value".to_string()
+        } else {
+            format!(
+                "read back {} characters after writing {}",
+                actual.chars().count(),
+                expected.chars().count()
+            )
+        };
+        return Err(format!("fill verification failed for {engine}: {detail}"));
+    }
+
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 use super::cdp::client::CdpClient;
 use super::cdp::types::*;
 use super::element::{
-    parse_ref, resolve_element_center, resolve_element_object_id, RefMap,
-    READ_EDITABLE_VALUE_FUNCTION,
+    parse_ref, read_editable_value_function, resolve_element_center, resolve_element_object_id,
+    RefMap, MONACO_CANDIDATES_FUNCTION,
 };
 use super::humanize;
 
@@ -606,6 +606,7 @@ pub async fn fill(
         r#"function() {{
             let el = this;
             const v = {val};
+            const monacoCandidates = {monaco_candidates};
             const monacoRoot = (el.closest && el.closest('.monaco-editor'))
                 || (el.querySelector && el.querySelector('.monaco-editor'));
 
@@ -614,23 +615,7 @@ pub async fn fill(
             // transport, not the model. Synthetic paste events on it are untrusted
             // and may be ignored while still looking successful (#138).
             if (monacoRoot) {{
-                const candidates = [];
-                const seen = new Set();
-                const add = value => {{
-                    if (!value || seen.has(value)) return;
-                    seen.add(value);
-                    if (value.editor) candidates.push(value.editor);
-                    if (value.monaco && value.monaco.editor) candidates.push(value.monaco.editor);
-                    if (value.default) add(value.default);
-                }};
-                add(window.monaco);
-                if (typeof window.require === 'function') {{
-                    for (const id of ['vs/editor/editor.api', 'vs/editor/editor.main']) {{
-                        try {{ add(window.require(id)); }} catch (e) {{}}
-                    }}
-                }}
-
-                for (const api of candidates) {{
+                for (const api of monacoCandidates()) {{
                     try {{
                         const editors = api.getEditors ? api.getEditors() : [];
                         const editor = editors.find(candidate => {{
@@ -706,7 +691,8 @@ pub async fn fill(
             fire('focusout');                          // blur-triggered lookups/validation
             return 'input';
         }}"#,
-        val = serde_json::to_string(value).unwrap_or_default()
+        val = serde_json::to_string(value).unwrap_or_default(),
+        monaco_candidates = MONACO_CANDIDATES_FUNCTION,
     );
 
     let result: EvaluateResult = client
@@ -1303,7 +1289,7 @@ async fn verify_fill_value(
         .send_command_typed(
             "Runtime.callFunctionOn",
             &CallFunctionOnParams {
-                function_declaration: READ_EDITABLE_VALUE_FUNCTION.to_string(),
+                function_declaration: read_editable_value_function(),
                 object_id: Some(object_id.to_string()),
                 arguments: None,
                 return_by_value: Some(true),
@@ -1336,9 +1322,7 @@ async fn verify_fill_value(
 
     // HTML text controls normalize CRLF to LF. Compare that standardized form
     // while preserving every other byte, including leading spaces in YAML.
-    let normalized_expected = expected.replace("\r\n", "\n");
-    let normalized_actual = actual.replace("\r\n", "\n");
-    if normalized_actual != normalized_expected {
+    if !fill_values_match(expected, actual, engine) {
         let detail = if actual.is_empty() && !expected.is_empty() {
             "read back an empty value".to_string()
         } else {
@@ -1352,6 +1336,21 @@ async fn verify_fill_value(
     }
 
     Ok(())
+}
+
+fn fill_values_match(expected: &str, actual: &str, engine: &str) -> bool {
+    let normalized_expected = expected.replace("\r\n", "\n");
+    let normalized_actual = actual.replace("\r\n", "\n");
+    if engine.starts_with("contenteditable") {
+        // Rich editors may render text as nested blocks, and innerText follows
+        // layout whitespace rules. Validate the same non-whitespace content and
+        // ordering without rejecting a successful edit over cosmetic line breaks.
+        normalized_actual
+            .split_whitespace()
+            .eq(normalized_expected.split_whitespace())
+    } else {
+        normalized_actual == normalized_expected
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2554,6 +2553,40 @@ fn named_key_info(key: &str) -> (String, String, i32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_fill_verification_tolerates_contenteditable_layout_whitespace() {
+        assert!(fill_values_match(
+            "first line\nsecond line",
+            "first line\n\n  second line\n",
+            "contenteditable"
+        ));
+        assert!(fill_values_match(
+            "first line second line",
+            "first line\nsecond line",
+            "contenteditable-fallback"
+        ));
+        assert!(!fill_values_match(
+            "first line second line",
+            "first line different line",
+            "contenteditable"
+        ));
+    }
+
+    #[test]
+    fn test_fill_verification_remains_exact_for_value_backed_engines() {
+        assert!(fill_values_match(
+            "first\r\nsecond",
+            "first\nsecond",
+            "monaco"
+        ));
+        assert!(!fill_values_match(
+            "first second",
+            "first\nsecond",
+            "monaco"
+        ));
+        assert!(!fill_values_match("  yaml", " yaml", "input"));
+    }
 
     /// Verify that `char_to_key_info` returns the correct (key, code,
     /// windowsVirtualKeyCode) triple for every character in Playwright's

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -734,11 +734,7 @@ pub async fn fill(
         .unwrap_or_else(|| "input".to_string());
 
     if engine == "monaco-unsupported" {
-        return Err(
-            "fill cannot safely replace this Monaco editor because its model API is not \
-             accessible; no text was written"
-                .to_string(),
-        );
+        return fill_monaco_via_clipboard(client, &effective_session_id, &object_id, value).await;
     }
 
     // Contenteditable rich editors (DraftJS / Lexical / ProseMirror): the JS above
@@ -819,6 +815,477 @@ pub async fn fill(
     verify_fill_value(client, &effective_session_id, &object_id, value, &engine).await?;
 
     Ok(engine)
+}
+
+async fn fill_monaco_via_clipboard(
+    client: &CdpClient,
+    session_id: &str,
+    object_id: &str,
+    expected: &str,
+) -> Result<String, String> {
+    const TRANSACTION_KEY: &str = "__chromeUseMonacoClipboardFill";
+    let prepare_js = format!(
+        r#"async function() {{
+            const anchor = this;
+            const root = (anchor.closest && anchor.closest('.monaco-editor'))
+                || (anchor.querySelector && anchor.querySelector('.monaco-editor'));
+            const input = root && root.querySelector('textarea.inputarea');
+            if (!input) return {{ ok: false, error: 'Monaco textarea.inputarea was not found' }};
+
+            const clipboard = input.ownerDocument.defaultView.navigator.clipboard;
+            if (!clipboard || !clipboard.read || !clipboard.readText
+                || !clipboard.write || !clipboard.writeText) {{
+                return {{ ok: false, error: 'browser clipboard read/write APIs are unavailable' }};
+            }}
+
+            let backup;
+            let backupText;
+            try {{
+                backup = await clipboard.read();
+                backupText = await clipboard.readText();
+            }} catch (error) {{
+                return {{
+                    ok: false,
+                    error: 'browser clipboard backup was denied: ' + String(error && error.message || error)
+                }};
+            }}
+
+            const state = {{ paste: null, copy: null }};
+            const onPaste = event => {{
+                queueMicrotask(() => {{
+                    state.paste = {{
+                        trusted: event.isTrusted,
+                        prevented: event.defaultPrevented
+                    }};
+                }});
+            }};
+            const onCopy = event => {{
+                queueMicrotask(() => {{
+                    state.copy = {{
+                        trusted: event.isTrusted,
+                        prevented: event.defaultPrevented,
+                        text: event.clipboardData ? event.clipboardData.getData('text/plain') : ''
+                    }};
+                }});
+            }};
+            input.addEventListener('paste', onPaste);
+            input.addEventListener('copy', onCopy);
+            anchor[{key}] = {{ input, clipboard, backup, backupText, state, onPaste, onCopy }};
+
+            try {{
+                await clipboard.writeText({value});
+            }} catch (error) {{
+                input.removeEventListener('paste', onPaste);
+                input.removeEventListener('copy', onCopy);
+                delete anchor[{key}];
+                return {{
+                    ok: false,
+                    error: 'browser clipboard staging was denied: ' + String(error && error.message || error)
+                }};
+            }}
+
+            input.focus();
+            return {{ ok: true }};
+        }}"#,
+        key = serde_json::to_string(TRANSACTION_KEY).unwrap_or_default(),
+        value = serde_json::to_string(expected).unwrap_or_default(),
+    );
+
+    let prepared: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: prepare_js,
+                object_id: Some(object_id.to_string()),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(true),
+            },
+            Some(session_id),
+        )
+        .await?;
+    if let Some(ex) = prepared.exception_details {
+        return Err(format!("Monaco clipboard fill setup failed: {}", ex.text));
+    }
+    let prepared_data = prepared.result.value.unwrap_or(Value::Null);
+    if !prepared_data
+        .get("ok")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let reason = prepared_data
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("clipboard transaction could not start");
+        return Err(format!(
+            "fill cannot safely replace this Monaco editor because its model API is not \
+             accessible and {reason}; no text was written"
+        ));
+    }
+
+    let modifier = if cfg!(target_os = "macos") { 4 } else { 2 };
+    let operation = async {
+        dispatch_editor_command(client, session_id, "a", modifier, "selectAll").await?;
+        dispatch_editor_command(client, session_id, "v", modifier, "paste").await?;
+        wait_for_paint_settled(client, session_id).await;
+
+        let paste_check: EvaluateResult = client
+            .send_command_typed(
+                "Runtime.callFunctionOn",
+                &CallFunctionOnParams {
+                    function_declaration: format!(
+                        "function() {{ return this[{}]?.state.paste || null; }}",
+                        serde_json::to_string(TRANSACTION_KEY).unwrap_or_default()
+                    ),
+                    object_id: Some(object_id.to_string()),
+                    arguments: None,
+                    return_by_value: Some(true),
+                    await_promise: Some(false),
+                },
+                Some(session_id),
+            )
+            .await?;
+        let paste = paste_check.result.value.unwrap_or(Value::Null);
+        if !paste
+            .get("trusted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            || !paste
+                .get("prevented")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        {
+            return Err(format!(
+                "Monaco clipboard paste was not handled as a trusted editor operation \
+                 (trusted={}, prevented={})",
+                paste
+                    .get("trusted")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                paste
+                    .get("prevented")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            ));
+        }
+
+        dispatch_editor_command(client, session_id, "a", modifier, "selectAll").await?;
+        dispatch_editor_command(client, session_id, "c", modifier, "copy").await?;
+
+        let copy_check: EvaluateResult = client
+            .send_command_typed(
+                "Runtime.callFunctionOn",
+                &CallFunctionOnParams {
+                    function_declaration: format!(
+                        "function() {{ return this[{}]?.state.copy || null; }}",
+                        serde_json::to_string(TRANSACTION_KEY).unwrap_or_default()
+                    ),
+                    object_id: Some(object_id.to_string()),
+                    arguments: None,
+                    return_by_value: Some(true),
+                    await_promise: Some(false),
+                },
+                Some(session_id),
+            )
+            .await?;
+        let copy = copy_check.result.value.unwrap_or(Value::Null);
+        if !copy
+            .get("trusted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            || !copy
+                .get("prevented")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        {
+            return Err(
+                "Monaco clipboard readback was not produced by the editor model".to_string(),
+            );
+        }
+
+        let actual = copy.get("text").and_then(Value::as_str).unwrap_or("");
+        let normalized_expected = expected.replace("\r\n", "\n");
+        let normalized_actual = actual.replace("\r\n", "\n");
+        if normalized_actual != normalized_expected {
+            let detail = if actual.is_empty() && !expected.is_empty() {
+                "read back an empty value".to_string()
+            } else {
+                format!(
+                    "read back {} characters after writing {}",
+                    actual.chars().count(),
+                    expected.chars().count()
+                )
+            };
+            return Err(format!(
+                "fill verification failed for monaco-clipboard: {detail}"
+            ));
+        }
+
+        Ok(())
+    }
+    .await;
+
+    let restore_js = format!(
+        r#"async function() {{
+            const tx = this[{key}];
+            if (!tx) return {{ ok: false, error: 'clipboard transaction state was lost' }};
+            tx.input.removeEventListener('paste', tx.onPaste);
+            tx.input.removeEventListener('copy', tx.onCopy);
+            delete this[{key}];
+            try {{
+                await tx.clipboard.write(tx.backup);
+                return {{ ok: true }};
+            }} catch (error) {{
+                try {{ await tx.clipboard.writeText(tx.backupText); }} catch (ignored) {{}}
+                return {{
+                    ok: false,
+                    error: 'original browser clipboard could not be fully restored: '
+                        + String(error && error.message || error)
+                }};
+            }}
+        }}"#,
+        key = serde_json::to_string(TRANSACTION_KEY).unwrap_or_default(),
+    );
+    let restored: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: restore_js,
+                object_id: Some(object_id.to_string()),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(true),
+            },
+            Some(session_id),
+        )
+        .await?;
+    let restore_data = restored.result.value.unwrap_or(Value::Null);
+    if !restore_data
+        .get("ok")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let reason = restore_data
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("original browser clipboard could not be restored");
+        return Err(format!("Monaco clipboard fill failed: {reason}"));
+    }
+
+    operation?;
+    Ok("monaco-clipboard".to_string())
+}
+
+pub(crate) async fn read_monaco_via_clipboard(
+    client: &CdpClient,
+    session_id: &str,
+    object_id: &str,
+) -> Result<String, String> {
+    const TRANSACTION_KEY: &str = "__chromeUseMonacoClipboardRead";
+    let prepare_js = format!(
+        r#"async function() {{
+            const anchor = this;
+            const root = (anchor.closest && anchor.closest('.monaco-editor'))
+                || (anchor.querySelector && anchor.querySelector('.monaco-editor'));
+            const input = root && root.querySelector('textarea.inputarea');
+            if (!input) return {{ ok: false, error: 'Monaco textarea.inputarea was not found' }};
+
+            const clipboard = input.ownerDocument.defaultView.navigator.clipboard;
+            if (!clipboard || !clipboard.read || !clipboard.readText
+                || !clipboard.write || !clipboard.writeText) {{
+                return {{ ok: false, error: 'browser clipboard read/write APIs are unavailable' }};
+            }}
+
+            let backup;
+            let backupText;
+            try {{
+                backup = await clipboard.read();
+                backupText = await clipboard.readText();
+            }} catch (error) {{
+                return {{
+                    ok: false,
+                    error: 'browser clipboard backup was denied: ' + String(error && error.message || error)
+                }};
+            }}
+
+            const state = {{ copy: null }};
+            const onCopy = event => {{
+                queueMicrotask(() => {{
+                    state.copy = {{
+                        trusted: event.isTrusted,
+                        prevented: event.defaultPrevented,
+                        text: event.clipboardData ? event.clipboardData.getData('text/plain') : ''
+                    }};
+                }});
+            }};
+            input.addEventListener('copy', onCopy);
+            anchor[{key}] = {{ input, clipboard, backup, backupText, state, onCopy }};
+            input.focus();
+            return {{ ok: true }};
+        }}"#,
+        key = serde_json::to_string(TRANSACTION_KEY).unwrap_or_default(),
+    );
+
+    let prepared: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: prepare_js,
+                object_id: Some(object_id.to_string()),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(true),
+            },
+            Some(session_id),
+        )
+        .await?;
+    if let Some(ex) = prepared.exception_details {
+        return Err(format!("Monaco clipboard read setup failed: {}", ex.text));
+    }
+    let prepared_data = prepared.result.value.unwrap_or(Value::Null);
+    if !prepared_data
+        .get("ok")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let reason = prepared_data
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("clipboard transaction could not start");
+        return Err(format!("Monaco model API is not accessible and {reason}"));
+    }
+
+    let modifier = if cfg!(target_os = "macos") { 4 } else { 2 };
+    let operation = async {
+        dispatch_editor_command(client, session_id, "a", modifier, "selectAll").await?;
+        dispatch_editor_command(client, session_id, "c", modifier, "copy").await?;
+
+        let copy_check: EvaluateResult = client
+            .send_command_typed(
+                "Runtime.callFunctionOn",
+                &CallFunctionOnParams {
+                    function_declaration: format!(
+                        "function() {{ return this[{}]?.state.copy || null; }}",
+                        serde_json::to_string(TRANSACTION_KEY).unwrap_or_default()
+                    ),
+                    object_id: Some(object_id.to_string()),
+                    arguments: None,
+                    return_by_value: Some(true),
+                    await_promise: Some(false),
+                },
+                Some(session_id),
+            )
+            .await?;
+        let copy = copy_check.result.value.unwrap_or(Value::Null);
+        if !copy
+            .get("trusted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            || !copy
+                .get("prevented")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        {
+            return Err(
+                "Monaco clipboard readback was not produced by the editor model".to_string(),
+            );
+        }
+
+        Ok(copy
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .replace("\r\n", "\n"))
+    }
+    .await;
+
+    let restore_js = format!(
+        r#"async function() {{
+            const tx = this[{key}];
+            if (!tx) return {{ ok: false, error: 'clipboard transaction state was lost' }};
+            tx.input.removeEventListener('copy', tx.onCopy);
+            delete this[{key}];
+            try {{
+                await tx.clipboard.write(tx.backup);
+                return {{ ok: true }};
+            }} catch (error) {{
+                try {{ await tx.clipboard.writeText(tx.backupText); }} catch (ignored) {{}}
+                return {{
+                    ok: false,
+                    error: 'original browser clipboard could not be fully restored: '
+                        + String(error && error.message || error)
+                }};
+            }}
+        }}"#,
+        key = serde_json::to_string(TRANSACTION_KEY).unwrap_or_default(),
+    );
+    let restored: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: restore_js,
+                object_id: Some(object_id.to_string()),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(true),
+            },
+            Some(session_id),
+        )
+        .await?;
+    let restore_data = restored.result.value.unwrap_or(Value::Null);
+    if !restore_data
+        .get("ok")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let reason = restore_data
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("original browser clipboard could not be restored");
+        return Err(format!("Monaco clipboard read failed: {reason}"));
+    }
+
+    operation
+}
+
+async fn dispatch_editor_command(
+    client: &CdpClient,
+    session_id: &str,
+    key: &str,
+    modifiers: i32,
+    command: &str,
+) -> Result<(), String> {
+    let (key_name, code, key_code) = named_key_info(key);
+    client
+        .send_command(
+            "Input.dispatchKeyEvent",
+            Some(serde_json::json!({
+                "type": "keyDown",
+                "key": key_name,
+                "code": code,
+                "windowsVirtualKeyCode": key_code,
+                "nativeVirtualKeyCode": key_code,
+                "modifiers": modifiers,
+                "commands": [command],
+            })),
+            Some(session_id),
+        )
+        .await?;
+    client
+        .send_command(
+            "Input.dispatchKeyEvent",
+            Some(serde_json::json!({
+                "type": "keyUp",
+                "key": key_name,
+                "code": code,
+                "windowsVirtualKeyCode": key_code,
+                "nativeVirtualKeyCode": key_code,
+                "modifiers": modifiers,
+            })),
+            Some(session_id),
+        )
+        .await?;
+    Ok(())
 }
 
 async fn verify_fill_value(

--- a/cli/src/native/test_fixtures/monaco_fill_probe.html
+++ b/cli/src/native/test_fixtures/monaco_fill_probe.html
@@ -36,12 +36,30 @@
     ></textarea>
   </div>
 
+  <div id="global-editor" class="monaco-editor">
+    <textarea
+      class="inputarea"
+      aria-label="Global editor content;Press Alt+F1 for Accessibility Options."
+    ></textarea>
+  </div>
+
+  <div id="default-editor" class="monaco-editor">
+    <textarea
+      class="inputarea"
+      aria-label="Default editor content;Press Alt+F1 for Accessibility Options."
+    ></textarea>
+  </div>
+
   <script>
     (() => {
       let workingValue = '';
       let stuckValue = '';
+      let globalValue = '';
+      let defaultValue = '';
       const workingRoot = document.getElementById('working-editor');
       const stuckRoot = document.getElementById('stuck-editor');
+      const globalRoot = document.getElementById('global-editor');
+      const defaultRoot = document.getElementById('default-editor');
 
       const workingEditor = {
         getDomNode: () => workingRoot,
@@ -52,6 +70,16 @@
         getDomNode: () => stuckRoot,
         setValue: () => {},
         getValue: () => stuckValue
+      };
+      const globalEditor = {
+        getDomNode: () => globalRoot,
+        setValue: value => { globalValue = value; },
+        getValue: () => globalValue
+      };
+      const defaultEditor = {
+        getDomNode: () => defaultRoot,
+        setValue: value => { defaultValue = value; },
+        getValue: () => defaultValue
       };
 
       const moduleScopedMonaco = {
@@ -65,6 +93,20 @@
           return moduleScopedMonaco;
         }
         throw new Error(`Unknown module: ${id}`);
+      };
+      window.monaco = {
+        editor: {
+          getEditors: () => [globalEditor],
+          getModels: () => []
+        },
+        default: {
+          monaco: {
+            editor: {
+              getEditors: () => [defaultEditor],
+              getModels: () => []
+            }
+          }
+        }
       };
 
       let clipboardModelValue = '';

--- a/cli/src/native/test_fixtures/monaco_fill_probe.html
+++ b/cli/src/native/test_fixtures/monaco_fill_probe.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Monaco fill probe</title>
+</head>
+<body>
+  <label for="plain-input">Plain input</label>
+  <input id="plain-input" value="old">
+
+  <div id="working-editor" class="monaco-editor">
+    <textarea
+      class="inputarea"
+      aria-label="Working editor content;Press Alt+F1 for Accessibility Options."
+    ></textarea>
+  </div>
+
+  <div id="stuck-editor" class="monaco-editor">
+    <textarea
+      class="inputarea"
+      aria-label="Stuck editor content;Press Alt+F1 for Accessibility Options."
+    ></textarea>
+  </div>
+
+  <div id="unsupported-editor" class="monaco-editor">
+    <textarea
+      class="inputarea"
+      aria-label="Unsupported editor content;Press Alt+F1 for Accessibility Options."
+    ></textarea>
+  </div>
+
+  <script>
+    (() => {
+      let workingValue = '';
+      let stuckValue = '';
+      const workingRoot = document.getElementById('working-editor');
+      const stuckRoot = document.getElementById('stuck-editor');
+
+      const workingEditor = {
+        getDomNode: () => workingRoot,
+        setValue: value => { workingValue = value; },
+        getValue: () => workingValue
+      };
+      const stuckEditor = {
+        getDomNode: () => stuckRoot,
+        setValue: () => {},
+        getValue: () => stuckValue
+      };
+
+      const moduleScopedMonaco = {
+        editor: {
+          getEditors: () => [workingEditor, stuckEditor],
+          getModels: () => []
+        }
+      };
+      window.require = id => {
+        if (id === 'vs/editor/editor.api' || id === 'vs/editor/editor.main') {
+          return moduleScopedMonaco;
+        }
+        throw new Error(`Unknown module: ${id}`);
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/cli/src/native/test_fixtures/monaco_fill_probe.html
+++ b/cli/src/native/test_fixtures/monaco_fill_probe.html
@@ -29,6 +29,13 @@
     ></textarea>
   </div>
 
+  <div id="clipboard-editor" class="monaco-editor">
+    <textarea
+      class="inputarea"
+      aria-label="Clipboard editor content;Press Alt+F1 for Accessibility Options."
+    ></textarea>
+  </div>
+
   <script>
     (() => {
       let workingValue = '';
@@ -59,6 +66,30 @@
         }
         throw new Error(`Unknown module: ${id}`);
       };
+
+      let clipboardModelValue = '';
+      let clipboardSelectionAll = false;
+      const clipboardInput = document.querySelector('#clipboard-editor textarea.inputarea');
+      clipboardInput.addEventListener('keydown', event => {
+        if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'a') {
+          clipboardSelectionAll = true;
+          event.preventDefault();
+        }
+      });
+      clipboardInput.addEventListener('paste', event => {
+        if (!event.isTrusted) return;
+        const pasted = event.clipboardData.getData('text/plain');
+        clipboardModelValue = clipboardSelectionAll
+          ? pasted
+          : clipboardModelValue + pasted;
+        clipboardSelectionAll = false;
+        event.preventDefault();
+      });
+      clipboardInput.addEventListener('copy', event => {
+        if (!event.isTrusted || !clipboardSelectionAll) return;
+        event.clipboardData.setData('text/plain', clipboardModelValue);
+        event.preventDefault();
+      });
     })();
   </script>
 </body>

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1593,6 +1593,9 @@ Clears the field and fills it with the text, replacing existing content.
 Works on rich editors too (issue #41): CodeMirror 5, Monaco, ProseMirror and
 plain contenteditable are detected and set via their own API / input events,
 not a raw `.value` write — and the response echoes which `engine` was used.
+The written value is read back from the control or editor model and compared
+exactly before success is reported. If a Monaco model is inaccessible or the
+readback differs, fill fails loudly instead of reporting a false success.
 For framework inputs (React/Vue/Angular) the value goes through the native
 setter so the form registers it (no more "pristine" Save no-ops).
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1594,8 +1594,10 @@ Works on rich editors too (issue #41): CodeMirror 5, Monaco, ProseMirror and
 plain contenteditable are detected and set via their own API / input events,
 not a raw `.value` write — and the response echoes which `engine` was used.
 The written value is read back from the control or editor model and compared
-exactly before success is reported. If a Monaco model is inaccessible or the
-readback differs, fill fails loudly instead of reporting a false success.
+exactly before success is reported. If Monaco hides its model API, fill uses
+one trusted editor paste, reads the selected model back through the editor's
+copy handler, and restores the browser clipboard. If that cannot be verified,
+fill fails loudly instead of reporting a false success.
 For framework inputs (React/Vue/Angular) the value goes through the native
 setter so the form registers it (no more "pristine" Save no-ops).
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -156,7 +156,7 @@
 <span class="du-prompt">$</span> chrome-use download-url https://example.com/file.pdf ./file.pdf
 <span class="du-prompt">$</span> chrome-use downloads <span class="du-flag">--limit</span> 10 <span class="du-flag">--json</span> <span class="du-cmt"># 机器可读的 Chrome 下载记录</span></code></pre>
       </div>
-      <p><code>fill</code> 会在返回成功前回读控件或富编辑器 model，并精确比较结果。Monaco model 无法访问或回读不一致时会报错，不会静默成功。</p>
+      <p><code>fill</code> 会在返回成功前回读控件或富编辑器 model，并精确比较结果。若 Monaco 隐藏了 model API，则通过一次可信的编辑器 paste 写入，再通过编辑器 copy 处理器精确回读，并在结束后恢复浏览器剪贴板。paste 无法校验或回读不一致时会报错，不会静默成功。</p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ 点击"成功但没反应"</div>
         自动补全 / 菜单 <code>&lt;li&gt;</code> 项常在输入框失焦时关闭。若 <code>click</code> 报成功但页面没反应，

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -156,6 +156,7 @@
 <span class="du-prompt">$</span> chrome-use download-url https://example.com/file.pdf ./file.pdf
 <span class="du-prompt">$</span> chrome-use downloads <span class="du-flag">--limit</span> 10 <span class="du-flag">--json</span> <span class="du-cmt"># 机器可读的 Chrome 下载记录</span></code></pre>
       </div>
+      <p><code>fill</code> 会在返回成功前回读控件或富编辑器 model，并精确比较结果。Monaco model 无法访问或回读不一致时会报错，不会静默成功。</p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ 点击"成功但没反应"</div>
         自动补全 / 菜单 <code>&lt;li&gt;</code> 项常在输入框失焦时关闭。若 <code>click</code> 报成功但页面没反应，

--- a/docs/en/commands.html
+++ b/docs/en/commands.html
@@ -162,7 +162,7 @@
 <span class="du-prompt">$</span> chrome-use download-url https://example.com/file.pdf ./file.pdf
 <span class="du-prompt">$</span> chrome-use downloads <span class="du-flag">--limit</span> 10 <span class="du-flag">--json</span> <span class="du-cmt"># machine-readable Chrome downloads</span></code></pre>
       </div>
-      <p><code>fill</code> reads the resulting control or rich-editor model value back and compares it exactly before reporting success. An inaccessible Monaco model or mismatched readback is an error, not a silent success.</p>
+      <p><code>fill</code> reads the resulting control or rich-editor model value back and compares it exactly before reporting success. If Monaco hides its model API, one trusted editor paste is verified through the editor's copy handler and the browser clipboard is restored afterward. An unverifiable paste or mismatched readback is an error, not a silent success.</p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ Click "succeeds but nothing happens"</div>
         Autocomplete / menu <code>&lt;li&gt;</code> items often close when the input loses focus. If <code>click</code>

--- a/docs/en/commands.html
+++ b/docs/en/commands.html
@@ -162,6 +162,7 @@
 <span class="du-prompt">$</span> chrome-use download-url https://example.com/file.pdf ./file.pdf
 <span class="du-prompt">$</span> chrome-use downloads <span class="du-flag">--limit</span> 10 <span class="du-flag">--json</span> <span class="du-cmt"># machine-readable Chrome downloads</span></code></pre>
       </div>
+      <p><code>fill</code> reads the resulting control or rich-editor model value back and compares it exactly before reporting success. An inaccessible Monaco model or mismatched readback is an error, not a silent success.</p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ Click "succeeds but nothing happens"</div>
         Autocomplete / menu <code>&lt;li&gt;</code> items often close when the input loses focus. If <code>click</code>

--- a/docs/en/interacting.html
+++ b/docs/en/interacting.html
@@ -191,8 +191,9 @@
         <strong>error loudly</strong> (listing the visible options) when the option never appears, never silently.
         <code>fill</code> is hardened the same way: it resolves Monaco through its global or AMD model API,
         performs one atomic <code>setValue</code>, and verifies the exact model readback before reporting
-        success. If the model is inaccessible or the value differs, it errors loudly instead of falling back
-        to an unverified synthetic paste. Controlled inputs whose <code>@ref</code> anchored a
+        success. When an app hides that API, it performs one trusted editor <code>paste</code>, verifies the
+        selected model through the editor's own <code>copy</code> handler, and restores the browser clipboard.
+        If those operations cannot be verified or the value differs, it errors loudly. Controlled inputs whose <code>@ref</code> anchored a
         <strong>wrapper</strong> still retarget to the nested editable.
       </div>
 

--- a/docs/en/interacting.html
+++ b/docs/en/interacting.html
@@ -189,11 +189,11 @@
         <code>select</code> used to "return ✓ but change nothing" on custom dropdowns (a silent
         false success) — now fixed: non-native controls go through the portal-aware path and
         <strong>error loudly</strong> (listing the visible options) when the option never appears, never silently.
-        <code>fill</code> is hardened the same way: it fills a <strong>module-scoped Monaco editor</strong>
-        (synthetic paste when <code>window.monaco</code> isn't reachable) and controlled inputs whose
-        <code>@ref</code> anchored a <strong>wrapper</strong> (retargets to the nested editable). Backends like
-        Cloudflare Zaraz (react-select + Monaco + shadow-DOM) now drive with native
-        <code>select</code>/<code>fill</code> — no hand-rolled <code>eval</code>.
+        <code>fill</code> is hardened the same way: it resolves Monaco through its global or AMD model API,
+        performs one atomic <code>setValue</code>, and verifies the exact model readback before reporting
+        success. If the model is inaccessible or the value differs, it errors loudly instead of falling back
+        to an unverified synthetic paste. Controlled inputs whose <code>@ref</code> anchored a
+        <strong>wrapper</strong> still retarget to the nested editable.
       </div>
 
       <hr class="du-divider" />

--- a/docs/en/interacting.html
+++ b/docs/en/interacting.html
@@ -197,6 +197,13 @@
         <strong>wrapper</strong> still retarget to the nested editable.
       </div>
 
+      <div class="du-callout">
+        <div class="du-callout-title">CSP-restricted pages</div>
+        Cloudflare Zaraz and pages with a strict Content Security Policy must not rely on
+        <code>eval</code>. Use the native <code>select</code> and <code>fill</code> commands so the
+        interaction works without requiring <code>unsafe-eval</code>.
+      </div>
+
       <hr class="du-divider" />
 
       <!-- ============ Uploading files ============ -->

--- a/docs/interacting.html
+++ b/docs/interacting.html
@@ -184,9 +184,9 @@
         <div class="du-callout-title">✅ v1.5.72：原生命令扛 shadow-DOM 重站（#105）</div>
         以前 <code>select</code> 对自定义下拉会「返回 ✓ 却没变化」（静默假成功）——现已修复：
         非原生控件走 portal-aware 逻辑，选项始终不出现时<strong>明确报错</strong>并列出可见选项，不再静默。
-        <code>fill</code> 同样加固：能填进<strong>模块作用域内的 Monaco 编辑器</strong>（<code>window.monaco</code> 拿不到时用合成 paste）、
-        以及 <code>@ref</code> 落在<strong>包裹元素</strong>上的受控输入（自动下钻到内部 editable）。像 Cloudflare Zaraz
-        这类 react-select + Monaco + shadow-DOM 的后台，现在原生 <code>select</code>/<code>fill</code> 就能驱动，不用再手搓 <code>eval</code>。
+        <code>fill</code> 同样加固：通过 Monaco 的全局或 AMD model API 做一次原子的
+        <code>setValue</code>，并在返回成功前精确回读 model；model 无法访问或内容不一致时会明确报错，
+        不再回退到无法校验的合成 paste。<code>@ref</code> 落在<strong>包裹元素</strong>上的受控输入仍会自动下钻到内部 editable。
       </div>
 
       <hr class="du-divider" />

--- a/docs/interacting.html
+++ b/docs/interacting.html
@@ -190,6 +190,13 @@
         操作无法校验或内容不一致时会明确报错。<code>@ref</code> 落在<strong>包裹元素</strong>上的受控输入仍会自动下钻到内部 editable。
       </div>
 
+      <div class="du-callout">
+        <div class="du-callout-title">受 CSP 限制的页面</div>
+        Cloudflare Zaraz 和启用严格内容安全策略的页面不能依赖 <code>eval</code>。
+        请使用原生 <code>select</code> 与 <code>fill</code> 命令，以免要求页面开放
+        <code>unsafe-eval</code>。
+      </div>
+
       <hr class="du-divider" />
 
       <!-- ============ 上传文件 ============ -->

--- a/docs/interacting.html
+++ b/docs/interacting.html
@@ -185,8 +185,9 @@
         以前 <code>select</code> 对自定义下拉会「返回 ✓ 却没变化」（静默假成功）——现已修复：
         非原生控件走 portal-aware 逻辑，选项始终不出现时<strong>明确报错</strong>并列出可见选项，不再静默。
         <code>fill</code> 同样加固：通过 Monaco 的全局或 AMD model API 做一次原子的
-        <code>setValue</code>，并在返回成功前精确回读 model；model 无法访问或内容不一致时会明确报错，
-        不再回退到无法校验的合成 paste。<code>@ref</code> 落在<strong>包裹元素</strong>上的受控输入仍会自动下钻到内部 editable。
+        <code>setValue</code>，并在返回成功前精确回读 model。若应用隐藏了该 API，则执行一次可信的编辑器
+        <code>paste</code>，通过编辑器自己的 <code>copy</code> 处理器精确回读，并在结束后恢复浏览器剪贴板；
+        操作无法校验或内容不一致时会明确报错。<code>@ref</code> 落在<strong>包裹元素</strong>上的受控输入仍会自动下钻到内部 editable。
       </div>
 
       <hr class="du-divider" />

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -703,7 +703,10 @@ rejected submit tells you why in the same call. `chrome-use form fill --map
 '{"Email":"a@b.com","Country":"US","Subscribe":true}' --submit "Sign up"`. For
 rich editors (DraftJS/Monaco/CodeMirror) fill those fields with `fill` instead —
 it handles them and verifies the exact editor-model readback before reporting
-success; `form fill` covers standard controls.
+success. Monaco instances that hide their model API use one trusted editor
+paste plus editor-generated copy readback, with the browser clipboard restored
+afterward; if either operation cannot be verified, `fill` fails. `form fill`
+covers standard controls.
 
 **See what an action changed — `--observe`.** Add it to a mutating action
 (`click`/`fill`/`type`/`select`/`check`/`press`/`eval`) and instead of you

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -702,7 +702,8 @@ checkbox), optionally submits (`--submit "<text|selector>"`), and returns
 rejected submit tells you why in the same call. `chrome-use form fill --map
 '{"Email":"a@b.com","Country":"US","Subscribe":true}' --submit "Sign up"`. For
 rich editors (DraftJS/Monaco/CodeMirror) fill those fields with `fill` instead —
-it handles them; `form fill` covers standard controls.
+it handles them and verifies the exact editor-model readback before reporting
+success; `form fill` covers standard controls.
 
 **See what an action changed — `--observe`.** Add it to a mutating action
 (`click`/`fill`/`type`/`select`/`check`/`press`/`eval`) and instead of you


### PR DESCRIPTION
## Summary

- replace Monaco content atomically through the editor/model `setValue` API when the global or AMD API is available
- support DSM-like Monaco instances that hide that API by issuing trusted native `selectAll` / `paste` editor commands
- verify the fallback through the editor's own `copy` handler, compare the complete value exactly, and restore the original browser clipboard
- make `get value` use the same authoritative model lookup or verified editor-copy fallback
- fail loudly when paste, readback, or clipboard restoration cannot be verified
- document the verified fill contract in CLI help, the core skill, and the English and Chinese HTML docs

## Root cause

The old fallback dispatched an untrusted synthetic `paste` event to `textarea.inputarea` and immediately returned `monaco-paste`. Monaco could ignore that event, leaving both the model and textarea empty while the CLI still printed success. Typing multiline YAML character by character was not safe because each newline could trigger Monaco auto-indent.

Some Synology DSM Monaco builds also keep the model API outside page-accessible globals and AMD modules. In that case, direct `setValue` cannot be used even though Monaco still accepts native editor paste/copy commands.

## Fallback safety

The hidden-model fallback:

1. backs up all browser clipboard items
2. stages the complete input once
3. focuses `textarea.inputarea`
4. dispatches trusted native editor commands for select-all and paste
5. requires Monaco to handle the paste event
6. selects all and copies through Monaco's own handler
7. compares the copied model value exactly after CRLF-to-LF normalization
8. restores the original clipboard before returning

Any untrusted or unhandled operation, mismatched readback, or incomplete clipboard restoration returns an error instead of success.

## Tests

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test` — 1046 passed, 0 failed, 3 ignored; `doctor_cli` 2 passed
- `AGENT_BROWSER_ALLOW_HEADLESS=1 cargo test --features e2e-tests e2e_fill_monaco_is_atomic_and_verified -- --ignored --test-threads=1` — 1 passed

The browser fixture covers:

- Monaco exposed only through AMD `require`
- DSM-like Monaco with a private model and only trusted paste/copy access
- exact multiline Compose YAML indentation through both `fill` and `get value`
- a model that ignores `setValue`, which fails on empty readback
- a Monaco-looking textbox that does not handle trusted paste, which fails closed
- a normal input regression

## Real DSM regression steps

1. Build or install a chrome-use binary from this branch.
2. Open the authenticated Synology DSM Container Manager project wizard.
3. Navigate to the Compose editor and take an interactive snapshot.
4. Run `fill @ref --file compose.yaml` with approved multiline YAML.
5. Confirm the result reports either `monaco` or `monaco-clipboard`.
6. Run `get value @ref` and compare it byte-for-byte with the source after normalizing CRLF to LF.
7. Confirm the rendered YAML has unchanged indentation.
8. Submit only after the model readback and rendered editor both match.

The real authenticated DSM wizard was not submitted by the automated test.

Fixes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved `fill` support for Monaco and other rich-text editors, including more reliable handling when editor APIs aren’t accessible.
  * `fill` now performs an atomic write and exact read-back verification before reporting success.
  * Returns an error (not silent success) when read-back can’t be verified or doesn’t match.
* **Documentation**
  * Updated CLI help and interaction guides to clarify the stricter post-fill verification behavior.
* **Tests**
  * Added an end-to-end regression test covering working, unsupported, and failure cases for Monaco-like editors (including clipboard-backed flows).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->