### PR TITLE
fix(session): restore stop and prune routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Each `--session` gets its **own colored Chrome tab group**, so multiple agents
 can share one real browser concurrently without stepping on each other — or your
 own tabs.
 
+Manage those workers with `chrome-use session list`, stop one gracefully with
+`chrome-use session stop [name]`, or reclaim all session daemons with
+`chrome-use session prune`. Ownership handoff remains available through
+`session handoff`, `session status`, and `session resume`.
+
 ## Why the extension (not a raw debug port)
 
 Other local tools drive Chrome over a raw `--remote-debugging-port` (CDP). Since

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -435,6 +435,15 @@ fn run_session_lifecycle(args: &[String], session: &str, json_mode: bool) {
         // tidies the tabs IT created (its tab group) before exiting.
         Some("stop") => {
             let target = args.get(2).map(|s| s.as_str()).unwrap_or(session);
+            if !validation::is_valid_session_name(target) {
+                let msg = validation::session_name_error(target);
+                if json_mode {
+                    print_json_error_with_type(msg, "invalid_session_name");
+                } else {
+                    eprintln!("{} {}", color::error_indicator(), msg);
+                }
+                exit(1);
+            }
             connection::kill_stale_daemon(target);
             if json_mode {
                 print_json_value(json!({ "success": true, "data": { "stopped": target } }));

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -151,6 +151,22 @@ fn parse_proxy(proxy_str: &str) -> ParsedProxy {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum SessionCommandRoute {
+    Lifecycle,
+    Ownership,
+}
+
+/// Keep daemon lifecycle commands on the lifecycle path while ownership
+/// commands remain CLI-local. This classifier prevents a broad `session`
+/// intercept from making later subcommands unreachable.
+fn session_command_route(sub: Option<&str>) -> SessionCommandRoute {
+    match sub {
+        Some("stop") | Some("prune") => SessionCommandRoute::Lifecycle,
+        _ => SessionCommandRoute::Ownership,
+    }
+}
+
 /// `session <handoff|resume|status|list>` — ownership + human handoff (#89,
 /// ported from ego-lite). CLI-local: only touches the `.owner` sidecar.
 fn run_session_ownership(sub: Option<&str>, session: &str, json_mode: bool) {
@@ -282,7 +298,7 @@ fn run_session_ownership(sub: Option<&str>, session: &str, json_mode: bool) {
         }
         Some(other) => {
             let msg = format!(
-                "unknown `session` subcommand '{other}'. Use: handoff | resume | status | list"
+                "unknown `session` subcommand '{other}'. Use: handoff | resume | status | list | stop | prune"
             );
             if json_mode {
                 print_json_error(&msg);
@@ -410,50 +426,10 @@ fn run_cookies_export(args: &[String], flags: &Flags) {
     }
 }
 
-fn run_session(args: &[String], session: &str, json_mode: bool) {
+fn run_session_lifecycle(args: &[String], session: &str, json_mode: bool) {
     let subcommand = args.get(1).map(|s| s.as_str());
 
     match subcommand {
-        Some("list") => {
-            let sessions: Vec<String> = walk_daemons()
-                .sessions
-                .into_iter()
-                .map(|s| s.name)
-                .collect();
-            // The extension relay drives the user's live Chrome but isn't always
-            // registered as a launched daemon session — without surfacing it,
-            // `session list` says "No active sessions" while open/tab work fine,
-            // and agents misjudge the connection as down (issue #15).
-            let relay_up = connect::relay_url().is_some();
-
-            if json_mode {
-                println!(
-                    r#"{{"success":true,"data":{{"sessions":{},"relay":{}}}}}"#,
-                    serde_json::to_string(&sessions).unwrap_or_default(),
-                    relay_up
-                );
-            } else if sessions.is_empty() && !relay_up {
-                println!("No active sessions");
-            } else {
-                println!("Active sessions:");
-                for s in &sessions {
-                    let marker = if s == session {
-                        color::cyan("→")
-                    } else {
-                        " ".to_string()
-                    };
-                    println!("{} {}", marker, s);
-                }
-                if relay_up && !sessions.iter().any(|s| s == session) {
-                    println!(
-                        "{} {} {}",
-                        color::cyan("→"),
-                        session,
-                        color::dim("(relay/extension → live Chrome)")
-                    );
-                }
-            }
-        }
         // Stop a specific session daemon (issue #48). Graceful: kill_stale_daemon
         // sends SIGTERM first, so the daemon's shutdown handler runs `close()` and
         // tidies the tabs IT created (its tab group) before exiting.
@@ -497,19 +473,7 @@ fn run_session(args: &[String], session: &str, json_mode: bool) {
                 );
             }
         }
-        None | Some(_) => {
-            // Just show current session
-            if json_mode {
-                print_json_value(json!({
-                    "success": true,
-                    "data": {
-                        "session": session,
-                    },
-                }));
-            } else {
-                println!("{}", session);
-            }
-        }
+        _ => unreachable!("session lifecycle route only accepts stop or prune"),
     }
 }
 
@@ -1339,12 +1303,18 @@ fn main() {
         return;
     }
 
-    // `session <handoff|resume|status|list>` — ownership + human handoff
-    // (issue #89, ego-lite model). CLI-local: reads/writes the `.owner`
-    // sidecar, never touches the daemon, so it works even while a session is
-    // handed off (the guard in send_command only blocks browser-driving).
+    // Session management is local and daemon-free. Route stop/prune to daemon
+    // lifecycle handling; keep ownership commands on the `.owner` sidecar path.
     if clean.first().map(|s| s.as_str()) == Some("session") {
-        run_session_ownership(clean.get(1).map(|s| s.as_str()), &flags.session, flags.json);
+        let sub = clean.get(1).map(|s| s.as_str());
+        match session_command_route(sub) {
+            SessionCommandRoute::Lifecycle => {
+                run_session_lifecycle(&clean, &flags.session, flags.json)
+            }
+            SessionCommandRoute::Ownership => {
+                run_session_ownership(sub, &flags.session, flags.json)
+            }
+        }
         return;
     }
 
@@ -1593,12 +1563,6 @@ fn main() {
                 }
             }
         }
-    }
-
-    // Handle session separately (doesn't need daemon)
-    if clean.first().map(|s| s.as_str()) == Some("session") {
-        run_session(&clean, &flags.session, flags.json);
-        return;
     }
 
     // Handle daemon management (doesn't talk to a daemon — it manages them).
@@ -2748,6 +2712,35 @@ mod tests {
         assert_eq!(result.server, "http://proxy.com:8080");
         assert_eq!(result.username.as_deref(), Some("user"));
         assert_eq!(result.password.as_deref(), Some("p@ss:w0rd"));
+    }
+
+    #[test]
+    fn test_session_lifecycle_commands_are_not_intercepted_by_ownership() {
+        assert_eq!(
+            session_command_route(Some("stop")),
+            SessionCommandRoute::Lifecycle
+        );
+        assert_eq!(
+            session_command_route(Some("prune")),
+            SessionCommandRoute::Lifecycle
+        );
+    }
+
+    #[test]
+    fn test_session_ownership_commands_remain_cli_local() {
+        for sub in [
+            None,
+            Some("handoff"),
+            Some("resume"),
+            Some("status"),
+            Some("list"),
+        ] {
+            assert_eq!(
+                session_command_route(sub),
+                SessionCommandRoute::Ownership,
+                "unexpected route for {sub:?}"
+            );
+        }
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3095,7 +3095,9 @@ Examples:
             r##"
 chrome-use session - Manage sessions
 
-Usage: chrome-use session [operation] [name]
+Usage:
+  chrome-use session [status|handoff|resume|list|prune]
+  chrome-use session stop [name]
 
 Manage isolated browser sessions, daemon lifecycle, and ownership handoff.
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3095,14 +3095,18 @@ Examples:
             r##"
 chrome-use session - Manage sessions
 
-Usage: chrome-use session [operation]
+Usage: chrome-use session [operation] [name]
 
-Manage isolated browser sessions. Each session has its own browser
-instance with separate cookies, storage, and state.
+Manage isolated browser sessions, daemon lifecycle, and ownership handoff.
 
 Operations:
-  (none)               Show current session name
-  list                 List all active sessions
+  (none)               Show the current session owner
+  list                 List active sessions and their owners
+  status               Show the current session owner
+  handoff              Hand control to the user
+  resume               Return control to the agent
+  stop [name]          Stop one session daemon (default: current)
+  prune                Stop all session daemons
 
 Environment:
   AGENT_BROWSER_SESSION    Default session name
@@ -3114,6 +3118,12 @@ Global Options:
 Examples:
   chrome-use session
   chrome-use session list
+  chrome-use session status
+  chrome-use session handoff
+  chrome-use session resume
+  chrome-use session stop
+  chrome-use session stop test
+  chrome-use session prune
   chrome-use --session test open example.com
 "##
         }
@@ -3813,8 +3823,11 @@ Confirmation:
   deny <id>                  Deny a pending action
 
 Sessions:
-  session                    Show current session name
-  session list               List active sessions
+  session                    Show current session owner
+  session list               List active sessions and their owners
+  session status             Show current session owner
+  session handoff            Hand control to the user
+  session resume             Return control to the agent
   session stop [name]        Stop one session daemon (default: current) — graceful,
                              closes the tabs it created
   session prune              Stop ALL session daemons now (closes their tabs; they

--- a/docs/en/sessions.html
+++ b/docs/en/sessions.html
@@ -251,6 +251,12 @@
 <pre><code><span class="du-cmt"># List running session daemons (with relay status)</span>
 <span class="du-prompt">$</span> chrome-use daemon status
 
+<span class="du-cmt"># Stop one daemon gracefully (defaults to the current session)</span>
+<span class="du-prompt">$</span> chrome-use session stop [name]
+
+<span class="du-cmt"># Stop every active session daemon gracefully</span>
+<span class="du-prompt">$</span> chrome-use session prune
+
 <span class="du-cmt"># Kill all session daemon workers</span>
 <span class="du-prompt">$</span> chrome-use daemon restart</code></pre>
       </div>

--- a/docs/sessions.html
+++ b/docs/sessions.html
@@ -234,6 +234,12 @@
 <pre><code><span class="du-cmt"># 列出运行中的会话守护进程（含 relay 状态）</span>
 <span class="du-prompt">$</span> chrome-use daemon status
 
+<span class="du-cmt"># 优雅停止一个守护进程（默认当前会话）</span>
+<span class="du-prompt">$</span> chrome-use session stop [name]
+
+<span class="du-cmt"># 优雅停止所有活动会话守护进程</span>
+<span class="du-prompt">$</span> chrome-use session prune
+
 <span class="du-cmt"># 杀掉所有会话守护进程 worker</span>
 <span class="du-prompt">$</span> chrome-use daemon restart</code></pre>
       </div>

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -797,6 +797,10 @@ and drives every session by default, autonomous login included. Check state with
 `chrome-use session status`; `chrome-use session list` shows every session's owner.
 Never call `session resume` on your own to grab control back — wait for the user.
 
+To reclaim daemon workers without restarting every browser connection, use
+`chrome-use session stop [name]` for one session or `chrome-use session prune`
+for all active session daemons. Both commands stop workers gracefully.
+
 ### Persist session across runs
 
 ```bash

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -152,6 +152,15 @@ chrome-use --session auth close
 
 # List active sessions
 chrome-use session list
+
+# Stop the current session daemon gracefully
+chrome-use session stop
+
+# Stop a named session daemon
+chrome-use session stop auth
+
+# Stop all session daemons
+chrome-use session prune
 ```
 
 ## Best Practices


### PR DESCRIPTION
## Summary
- route `session stop` and `session prune` to the daemon lifecycle handler instead of the ownership handler
- keep handoff, resume, status, and owner-aware list behavior unchanged
- document the full session command surface and add routing regression tests

## Validation
- `cargo test --manifest-path cli/Cargo.toml` (1053 unit tests + 2 doctor CLI tests)
- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
- isolated live CLI checks for `session stop`, `session prune`, and JSON output
- `git diff --check`

Fixes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to gracefully stop a specific session daemon or prune all active session daemons.
  * Expanded session management support for listing, checking status, handing off, and resuming sessions.
  * Improved CLI help text with the complete set of session operations.

* **Documentation**
  * Updated guides and examples to explain session cleanup, daemon management, and ownership workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->