### PR TITLE
fix: address PR #159 review feedback

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2232,10 +2232,18 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     Ok(cmd)
                 }
                 Some("select") => {
-                    let tab_ref = rest.get(1).ok_or(ParseError::MissingArguments {
-                        context: "tab select".to_string(),
-                        usage: "tab select <ref> [--activate]",
-                    })?;
+                    let subcommand_index = rest
+                        .iter()
+                        .position(|arg| *arg == "select")
+                        .unwrap_or_default();
+                    let tab_ref = rest
+                        .iter()
+                        .skip(subcommand_index + 1)
+                        .find(|arg| !arg.starts_with("--"))
+                        .ok_or(ParseError::MissingArguments {
+                            context: "tab select".to_string(),
+                            usage: "tab select <ref> [--activate]",
+                        })?;
                     let mut cmd = json!({ "id": id, "action": "tab_switch", "tabId": tab_ref });
                     if rest.iter().any(|a| *a == "--activate" || *a == "--front") {
                         cmd["activate"] = json!(true);
@@ -2243,17 +2251,33 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     Ok(cmd)
                 }
                 Some("adopt") => {
-                    let spec = rest.get(1).ok_or(ParseError::MissingArguments {
-                        context: "tab adopt".to_string(),
-                        usage: "tab adopt <url-substring|targetId>",
-                    })?;
+                    let subcommand_index = rest
+                        .iter()
+                        .position(|arg| *arg == "adopt")
+                        .unwrap_or_default();
+                    let spec = rest
+                        .iter()
+                        .skip(subcommand_index + 1)
+                        .find(|arg| !arg.starts_with("--"))
+                        .ok_or(ParseError::MissingArguments {
+                            context: "tab adopt".to_string(),
+                            usage: "tab adopt <url-substring|targetId>",
+                        })?;
                     Ok(json!({ "id": id, "action": "tab_adopt", "spec": spec }))
                 }
                 Some("inspect") => {
-                    let tab_ref = rest.get(1).ok_or(ParseError::MissingArguments {
-                        context: "tab inspect".to_string(),
-                        usage: "tab inspect <ref>",
-                    })?;
+                    let subcommand_index = rest
+                        .iter()
+                        .position(|arg| *arg == "inspect")
+                        .unwrap_or_default();
+                    let tab_ref = rest
+                        .iter()
+                        .skip(subcommand_index + 1)
+                        .find(|arg| !arg.starts_with("--"))
+                        .ok_or(ParseError::MissingArguments {
+                            context: "tab inspect".to_string(),
+                            usage: "tab inspect <ref>",
+                        })?;
                     Ok(json!({ "id": id, "action": "tab_inspect", "tabId": tab_ref }))
                 }
                 Some("close") => {
@@ -5848,6 +5872,16 @@ mod tests {
         let cmd = parse_command(&args("tab select t4"), &default_flags()).unwrap();
         assert_eq!(cmd["action"], "tab_switch");
         assert_eq!(cmd["tabId"], "t4");
+
+        let flag_before_ref =
+            parse_command(&args("tab select --activate t4"), &default_flags()).unwrap();
+        assert_eq!(flag_before_ref["tabId"], "t4");
+        assert_eq!(flag_before_ref["activate"], true);
+
+        let flag_before_subcommand =
+            parse_command(&args("tab --activate select t4"), &default_flags()).unwrap();
+        assert_eq!(flag_before_subcommand["tabId"], "t4");
+        assert_eq!(flag_before_subcommand["activate"], true);
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -6761,8 +6761,23 @@ async fn handle_tab_adopt(cmd: &Value, state: &mut DaemonState) -> Result<Value,
         .get("spec")
         .and_then(|value| value.as_str())
         .ok_or("Missing 'spec' parameter (expected a URL substring or targetId)")?;
-    let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-    let result = mgr.tab_adopt(spec).await?;
+    let result = match state.browser.as_mut() {
+        Some(mgr) => mgr.tab_adopt(spec).await,
+        None => Err("Browser not launched".to_string()),
+    };
+    finish_tab_adopt(result, state)
+}
+
+/// Commit the per-tab context reset only after the browser accepted an adopt.
+///
+/// Keeping the fallible browser result outside this state transition gives
+/// tests a direct seam for the post-manager failure path without constructing a
+/// live CDP client.
+fn finish_tab_adopt(
+    result: Result<Value, String>,
+    state: &mut DaemonState,
+) -> Result<Value, String> {
+    let result = result?;
     state.ref_map.clear();
     state.iframe_sessions.clear();
     state.active_frame_id = None;
@@ -12525,8 +12540,8 @@ mod tests {
         assert_eq!(state.active_frame_id.as_deref(), Some("frame-1"));
     }
 
-    #[tokio::test]
-    async fn tab_adopt_failure_preserves_active_tab_context() {
+    #[test]
+    fn tab_adopt_failure_preserves_active_tab_context() {
         let mut state = DaemonState::new();
         state
             .ref_map
@@ -12536,23 +12551,34 @@ mod tests {
             .insert("frame-1".to_string(), "session-1".to_string());
         state.active_frame_id = Some("frame-1".to_string());
 
-        let response = execute_command(
-            &json!({
-                "id": "adopt-failure",
-                "action": "tab_adopt",
-                "spec": "missing-target"
-            }),
-            &mut state,
-        )
-        .await;
+        let result = finish_tab_adopt(Err("target not found".to_string()), &mut state);
 
-        assert_eq!(response["success"], false);
+        assert_eq!(result.unwrap_err(), "target not found");
         assert!(state.ref_map.get("e1").is_some());
         assert_eq!(
             state.iframe_sessions.get("frame-1").map(String::as_str),
             Some("session-1")
         );
         assert_eq!(state.active_frame_id.as_deref(), Some("frame-1"));
+    }
+
+    #[test]
+    fn tab_adopt_success_clears_previous_tab_context() {
+        let mut state = DaemonState::new();
+        state
+            .ref_map
+            .add("e1".to_string(), Some(42), "button", "Old", None);
+        state
+            .iframe_sessions
+            .insert("frame-1".to_string(), "session-1".to_string());
+        state.active_frame_id = Some("frame-1".to_string());
+
+        let result = finish_tab_adopt(Ok(json!({ "adopted": true })), &mut state).unwrap();
+
+        assert_eq!(result["adopted"], true);
+        assert!(state.ref_map.get("e1").is_none());
+        assert!(state.iframe_sessions.is_empty());
+        assert!(state.active_frame_id.is_none());
     }
     use crate::test_utils::EnvGuard;
     use std::fs;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -6761,11 +6761,12 @@ async fn handle_tab_adopt(cmd: &Value, state: &mut DaemonState) -> Result<Value,
         .get("spec")
         .and_then(|value| value.as_str())
         .ok_or("Missing 'spec' parameter (expected a URL substring or targetId)")?;
+    let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
+    let result = mgr.tab_adopt(spec).await?;
     state.ref_map.clear();
     state.iframe_sessions.clear();
     state.active_frame_id = None;
-    let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
-    mgr.tab_adopt(spec).await
+    Ok(result)
 }
 
 async fn handle_tab_inspect(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
@@ -12511,6 +12512,36 @@ mod tests {
 
         let response = execute_command(
             &json!({ "id": "duplicate-failure", "action": "tab_duplicate" }),
+            &mut state,
+        )
+        .await;
+
+        assert_eq!(response["success"], false);
+        assert!(state.ref_map.get("e1").is_some());
+        assert_eq!(
+            state.iframe_sessions.get("frame-1").map(String::as_str),
+            Some("session-1")
+        );
+        assert_eq!(state.active_frame_id.as_deref(), Some("frame-1"));
+    }
+
+    #[tokio::test]
+    async fn tab_adopt_failure_preserves_active_tab_context() {
+        let mut state = DaemonState::new();
+        state
+            .ref_map
+            .add("e1".to_string(), Some(42), "button", "Keep", None);
+        state
+            .iframe_sessions
+            .insert("frame-1".to_string(), "session-1".to_string());
+        state.active_frame_id = Some("frame-1".to_string());
+
+        let response = execute_command(
+            &json!({
+                "id": "adopt-failure",
+                "action": "tab_adopt",
+                "spec": "missing-target"
+            }),
             &mut state,
         )
         .await;

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -2874,7 +2874,8 @@ impl BrowserManager {
         // Relay resync may prune an unrelated earlier tab while reattaching,
         // shifting vector positions. Resolve the selected tab again through its
         // pinned target id instead of reusing the now-stale caller index.
-        let index = self.resolved_active_index();
+        self.active_page_index = self.resolved_active_index();
+        let index = self.active_page_index;
 
         // Silent: switching the agent's *internal* active page must not yank the
         // user's foreground tab. The page is driven in the background (focus is

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -2871,6 +2871,11 @@ impl BrowserManager {
             self.enable_domains(&session_id).await?;
         }
 
+        // Relay resync may prune an unrelated earlier tab while reattaching,
+        // shifting vector positions. Resolve the selected tab again through its
+        // pinned target id instead of reusing the now-stale caller index.
+        let index = self.resolved_active_index();
+
         // Silent: switching the agent's *internal* active page must not yank the
         // user's foreground tab. The page is driven in the background (focus is
         // emulated in enable_domains); the explicit `bringToFront` command is the

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -4089,6 +4089,7 @@ async fn e2e_snapshot_cursor_interactive() {
     //  - <div tabindex=0> (focusable – cursor section)
     //  - <span cursor:pointer> (clickable – cursor section)
     //  - <span cursor:pointer> child of <div cursor:pointer> (inherited – skip)
+    //  - <div cursor:not-allowed> (disabled affordance – skip)
     let html = concat!(
         "<html><body>",
         "<a href='#'>Link</a>",
@@ -4098,6 +4099,7 @@ async fn e2e_snapshot_cursor_interactive() {
         "<span style='cursor:pointer'>PointerSpan</span>",
         "<div style='cursor:pointer'><span>InheritChild</span></div>",
         "<div id='drag-handle' class='address-tag sort-handle' data-testid='address-sort' style='cursor:grab'>DragRule</div>",
+        "<div style='cursor:not-allowed'>DisabledCustomControl</div>",
         "</body></html>",
     );
 
@@ -4141,6 +4143,11 @@ async fn e2e_snapshot_cursor_interactive() {
             && snapshot.contains("testid=address-sort")
             && snapshot.contains("class=address-tag.sort-handle"),
         "Expected meaningful cursor and stable DOM anchors for an unlabeled generic:\n{}",
+        snapshot,
+    );
+    assert!(
+        !snapshot.contains("DisabledCustomControl"),
+        "cursor:not-allowed must not promote a disabled-looking custom control:\n{}",
         snapshot,
     );
 

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -1079,7 +1079,8 @@ async fn find_cursor_interactive_elements(
         var computedStyle = getComputedStyle(el);
         var cursor = computedStyle.cursor || 'auto';
         var hasCursorPointer = cursor === 'pointer';
-        var hasMeaningfulCursor = cursor !== 'auto' && cursor !== 'default' && cursor !== 'none';
+        var hasMeaningfulCursor = cursor !== 'auto' && cursor !== 'default'
+            && cursor !== 'none' && cursor !== 'not-allowed';
         var hasOnClick = el.hasAttribute('onclick') || el.onclick !== null;
         var tabIndex = el.getAttribute('tabindex');
         var hasTabIndex = tabIndex !== null && tabIndex !== '-1';

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3820,7 +3820,8 @@ Anti-bot:  chrome-use stealth | cf-status
   cf-status       Cloudflare challenge + cf_clearance preflight (skip re-solving)
 
 Find Elements:
-  chrome-use find "<description>" | query "<description>"   # ranked, no action
+  chrome-use find "<description>"                  # ranked, no action
+  chrome-use find query "<description>"            # ranked, no action
   chrome-use find <locator> <value> <action> [text]
   role, text, label, placeholder, alt, title, testid, first, last, nth
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3819,7 +3819,9 @@ Anti-bot:  chrome-use stealth | cf-status
   stealth         stealth self-check (webdriver/UA/plugins + overrides)
   cf-status       Cloudflare challenge + cf_clearance preflight (skip re-solving)
 
-Find Elements:  chrome-use find <locator> <value> <action> [text]
+Find Elements:
+  chrome-use find "<description>" | query "<description>"   # ranked, no action
+  chrome-use find <locator> <value> <action> [text]
   role, text, label, placeholder, alt, title, testid, first, last, nth
 
 Mouse:  chrome-use mouse <action> [args]

--- a/docs/en/troubleshooting.html
+++ b/docs/en/troubleshooting.html
@@ -188,7 +188,7 @@
       </div>
 
       <div class="du-callout note">
-        <div class="du-callout-title">ℹ️ Note</div>
+        <div class="du-callout-title">Note</div>
         If <code>tab list</code> still shows the white-screen or frozen tab, preserve it with <code>tab select</code>
         or <code>tab adopt</code>, then use <code>tab inspect</code> for browser-level state. A
         <code>relay timeout</code> means the renderer/debugger did not answer in time; it does not mean the tab

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -180,7 +180,7 @@
       </div>
 
       <div class="du-callout note">
-        <div class="du-callout-title">ℹ️ 说明</div>
+        <div class="du-callout-title">说明</div>
         如果 <code>tab list</code> 仍列得出白屏或卡死标签，先用 <code>tab select</code> 或
         <code>tab adopt</code> 保留现场，再用 <code>tab inspect</code> 读取浏览器级状态。
         <code>relay timeout</code> 表示 renderer/debugger 没有及时回答，不代表标签已经消失。


### PR DESCRIPTION
## Summary

- parse `tab select`, `tab adopt`, and `tab inspect` values independently of flag placement
- preserve refs and iframe state when `tab adopt` fails
- re-resolve the selected tab after relay resync can shift page indices
- exclude `cursor:not-allowed` custom controls from interactive snapshot promotion
- document natural-language `find` in top-level help and remove the newly-added emoji callout marker
- add parser, state-preservation, and browser-backed cursor regression coverage

## Validation

- `cargo test --quiet` (1069 passed, 3 ignored)
- `cargo clippy --quiet -- -D warnings`
- `AGENT_BROWSER_ALLOW_HEADLESS=1 cargo test --features e2e-tests e2e_snapshot_cursor_interactive -- --ignored --test-threads=1`
- `cargo fmt -- --check`
- `git diff --check`

## Review finding checked but not changed

The release metadata finding is not applicable to this fork: `cli/Cargo.lock` is tracked and already contains `chrome-use` 1.5.85, while `packages/dashboard/package.json` is not part of this repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab command parsing when flags appear before references or subcommands.
  * Preserved the active tab context when tab adoption fails.
  * Prevented incorrect tab selection after browser session resynchronization.
  * Excluded controls marked `cursor: not-allowed` from interactive snapshots.

* **Documentation**
  * Clarified `find` command help for natural-language and ranked searches.
  * Simplified stale-session troubleshooting callout labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->