### PR TITLE
fix: press Enter 不再落空 —— fill 后归还焦点 + press 报告落点 (#167)

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -894,25 +894,58 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         // === Keyboard ===
         "press" | "key" => {
-            let key = rest.iter().find(|a| !a.starts_with("--")).ok_or_else(|| {
-                ParseError::MissingArguments {
-                    context: "press".to_string(),
-                    usage: "press <key> [--hold <ms>]",
+            // Scan positionally so a flag's VALUE is never mistaken for the key
+            // (`press --selector "textarea[name=q]" Enter` must press Enter, not
+            // the selector).
+            let mut key: Option<&str> = None;
+            let mut hold: Option<u64> = None;
+            let mut selector: Option<&str> = None;
+            let mut i = 0;
+            while i < rest.len() {
+                match rest[i] {
+                    // `--hold <ms>`: hold the key down for <ms> then release, timed
+                    // inside the daemon (one round-trip, no shell-sleep jitter) —
+                    // for games and hold-to-charge where keydown+sleep+keyup over 3
+                    // round-trips is too imprecise.
+                    "--hold" => {
+                        hold = Some(rest.get(i + 1).and_then(|s| s.parse::<u64>().ok()).ok_or(
+                            ParseError::MissingArguments {
+                                context: "press --hold".to_string(),
+                                usage: "press <key> --hold <ms>",
+                            },
+                        )?);
+                        i += 2;
+                    }
+                    // `--selector <css|@ref>`: focus the target before the key, so
+                    // the press can't land on whatever the page left focused (#167).
+                    "--selector" | "--on" => {
+                        selector = Some(rest.get(i + 1).copied().ok_or(
+                            ParseError::MissingArguments {
+                                context: "press --selector".to_string(),
+                                usage: "press <key> --selector <css|@ref>",
+                            },
+                        )?);
+                        i += 2;
+                    }
+                    arg if arg.starts_with("--") => i += 1,
+                    arg => {
+                        if key.is_none() {
+                            key = Some(arg);
+                        }
+                        i += 1;
+                    }
                 }
+            }
+            let key = key.ok_or_else(|| ParseError::MissingArguments {
+                context: "press".to_string(),
+                usage: "press <key> [--selector <css|@ref>] [--hold <ms>]",
             })?;
             let mut c = json!({ "id": id, "action": "press", "key": key });
-            // `--hold <ms>`: hold the key down for <ms> then release, timed inside
-            // the daemon (one round-trip, no shell-sleep jitter) — for games and
-            // hold-to-charge where keydown+sleep+keyup over 3 round-trips is too
-            // imprecise.
-            if let Some(i) = rest.iter().position(|a| *a == "--hold") {
-                let ms = rest.get(i + 1).and_then(|s| s.parse::<u64>().ok()).ok_or(
-                    ParseError::MissingArguments {
-                        context: "press --hold".to_string(),
-                        usage: "press <key> --hold <ms>",
-                    },
-                )?;
+            if let Some(ms) = hold {
                 c["hold"] = json!(ms);
+            }
+            if let Some(sel) = selector {
+                c["selector"] = json!(sel);
             }
             Ok(c)
         }
@@ -5216,6 +5249,33 @@ mod tests {
         // Missing/invalid duration is an error, not a silent no-hold.
         assert!(parse_command(&args("press d --hold"), &default_flags()).is_err());
         assert!(parse_command(&args("press d --hold abc"), &default_flags()).is_err());
+    }
+
+    #[test]
+    fn test_press_selector_focuses_a_target() {
+        let cmd = parse_command(
+            &args("press Enter --selector textarea[name=q]"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["key"], "Enter");
+        assert_eq!(cmd["selector"], "textarea[name=q]");
+
+        // --on is the shorthand alias.
+        let aliased = parse_command(&args("press Enter --on @e12"), &default_flags()).unwrap();
+        assert_eq!(aliased["selector"], "@e12");
+
+        // A flag's value must never be mistaken for the key, whatever the order.
+        let leading = parse_command(
+            &args("press --selector textarea[name=q] Enter"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(leading["key"], "Enter");
+        assert_eq!(leading["selector"], "textarea[name=q]");
+
+        // Missing selector value is an error, not a silent no-focus press.
+        assert!(parse_command(&args("press Enter --selector"), &default_flags()).is_err());
     }
 
     #[test]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -919,12 +919,18 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     // `--selector <css|@ref>`: focus the target before the key, so
                     // the press can't land on whatever the page left focused (#167).
                     "--selector" | "--on" => {
-                        selector = Some(rest.get(i + 1).copied().ok_or(
-                            ParseError::MissingArguments {
-                                context: "press --selector".to_string(),
-                                usage: "press <key> --selector <css|@ref>",
-                            },
-                        )?);
+                        // A following flag means the value was omitted. Storing
+                        // it would fail later as "element --hold not found",
+                        // which reads like a page problem, not a typo.
+                        selector = Some(
+                            rest.get(i + 1)
+                                .copied()
+                                .filter(|v| !v.starts_with("--"))
+                                .ok_or(ParseError::MissingArguments {
+                                    context: "press --selector".to_string(),
+                                    usage: "press <key> --selector <css|@ref>",
+                                })?,
+                        );
                         i += 2;
                     }
                     arg if arg.starts_with("--") => i += 1,
@@ -5274,8 +5280,12 @@ mod tests {
         assert_eq!(leading["key"], "Enter");
         assert_eq!(leading["selector"], "textarea[name=q]");
 
-        // Missing selector value is an error, not a silent no-focus press.
+        // Missing selector value is an error, not a silent no-focus press —
+        // including when the next token is another flag.
         assert!(parse_command(&args("press Enter --selector"), &default_flags()).is_err());
+        assert!(
+            parse_command(&args("press Enter --selector --hold 100"), &default_flags()).is_err()
+        );
     }
 
     #[test]

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4518,11 +4518,26 @@ async fn handle_press(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
     // duration is precise (no shell-sleep / round-trip jitter). For games
     // (hold-to-move/charge) and any press-and-hold interaction.
     if let Some(ms) = cmd.get("hold").and_then(|v| v.as_u64()) {
-        interaction::dispatch_single_key(&mgr.client, &dispatch_session, &actual_key, "keyDown")
-            .await?;
+        // Carry the chord's modifiers through both halves: a held `Control+a`
+        // that dropped its Control would report the chord back while holding a
+        // plain `a`.
+        interaction::dispatch_single_key_with_modifiers(
+            &mgr.client,
+            &dispatch_session,
+            &actual_key,
+            "keyDown",
+            modifiers,
+        )
+        .await?;
         tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
-        interaction::dispatch_single_key(&mgr.client, &dispatch_session, &actual_key, "keyUp")
-            .await?;
+        interaction::dispatch_single_key_with_modifiers(
+            &mgr.client,
+            &dispatch_session,
+            &actual_key,
+            "keyUp",
+            modifiers,
+        )
+        .await?;
         return Ok(press_result(
             key,
             target,

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4491,18 +4491,84 @@ async fn handle_press(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
     // Parse modifier+key chords like "Control+a", "Shift+Enter", "Control+Shift+a"
     let (actual_key, modifiers) = parse_key_chord(key);
 
+    // `--selector`: focus the target before the key, so the press lands on the
+    // element the caller means even though each CLI invocation is a separate
+    // process that inherits whatever focus the page happens to hold (#167).
+    // The focus resolves the element's own frame; dispatch into that session so
+    // a field inside an iframe gets the key instead of the main frame.
+    let dispatch_session = match cmd.get("selector").and_then(|v| v.as_str()) {
+        Some(sel) => {
+            interaction::focus_reporting_session(
+                &mgr.client,
+                &session_id,
+                &state.ref_map,
+                sel,
+                &state.iframe_sessions,
+            )
+            .await?
+        }
+        None => session_id.clone(),
+    };
+
+    // Where the key is about to land. Read it BEFORE dispatching: Enter often
+    // navigates, and after a navigation there is no activeElement left to name.
+    let target = interaction::active_element_descriptor(&mgr.client, &dispatch_session).await;
+
     // `--hold <ms>`: keyDown, wait, keyUp — all inside the daemon so the hold
     // duration is precise (no shell-sleep / round-trip jitter). For games
     // (hold-to-move/charge) and any press-and-hold interaction.
     if let Some(ms) = cmd.get("hold").and_then(|v| v.as_u64()) {
-        interaction::dispatch_single_key(&mgr.client, &session_id, &actual_key, "keyDown").await?;
+        interaction::dispatch_single_key(&mgr.client, &dispatch_session, &actual_key, "keyDown")
+            .await?;
         tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
-        interaction::dispatch_single_key(&mgr.client, &session_id, &actual_key, "keyUp").await?;
-        return Ok(json!({ "pressed": key, "heldMs": ms }));
+        interaction::dispatch_single_key(&mgr.client, &dispatch_session, &actual_key, "keyUp")
+            .await?;
+        return Ok(press_result(
+            key,
+            target,
+            &actual_key,
+            json!({ "heldMs": ms }),
+        ));
     }
 
-    interaction::press_key_with_modifiers(&mgr.client, &session_id, &actual_key, modifiers).await?;
-    Ok(json!({ "pressed": key }))
+    interaction::press_key_with_modifiers(&mgr.client, &dispatch_session, &actual_key, modifiers)
+        .await?;
+    Ok(press_result(key, target, &actual_key, json!({})))
+}
+
+/// Build the `press` response, naming the element the key went to and warning
+/// when it provably went nowhere.
+///
+/// `press` used to report a bare `✓ Done` no matter what — including for an
+/// Enter dispatched with nothing focused, which neither submits nor activates
+/// anything. That made a swallowed keystroke indistinguishable from a working
+/// one (#167).
+fn press_result(key: &str, target: Option<String>, actual_key: &str, extra: Value) -> Value {
+    let mut out = json!({ "pressed": key });
+    let obj = out.as_object_mut().expect("press_result is an object");
+    if let Some(extra) = extra.as_object() {
+        for (k, v) in extra {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    if let Some(ref t) = target {
+        obj.insert("target".to_string(), json!(t));
+        if interaction::key_needs_focus(actual_key) && interaction::descriptor_is_unfocused(t) {
+            let where_it_went = if t == "none" {
+                "nothing is focused".to_string()
+            } else {
+                format!("activeElement is <{t}>")
+            };
+            obj.insert(
+                "warning".to_string(),
+                json!(format!(
+                    "{key} landed on no editable target ({where_it_went}), so it submitted and activated nothing. \
+                     Focus the field first: `press {key} --selector \"<css|@ref>\"`."
+                )),
+            );
+        }
+    }
+    out
 }
 
 /// Parse a key chord string like "Control+a" or "Control+Shift+Enter" into
@@ -12588,6 +12654,56 @@ fn error_response(id: &str, error: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn press_names_the_element_the_key_landed_on() {
+        let result = press_result(
+            "Enter",
+            Some("textarea[name=\"q\"]".into()),
+            "Enter",
+            json!({}),
+        );
+        assert_eq!(result["pressed"], "Enter");
+        assert_eq!(result["target"], "textarea[name=\"q\"]");
+        // Focused target: nothing to warn about.
+        assert!(result.get("warning").is_none());
+    }
+
+    #[test]
+    fn press_enter_with_nothing_focused_warns_instead_of_reporting_a_clean_success() {
+        let result = press_result("Enter", Some("body".into()), "Enter", json!({}));
+        let warning = result["warning"].as_str().expect("warning");
+        assert!(warning.contains("no editable target"));
+        assert!(warning.contains("--selector"));
+
+        // Same for an unfocused document with no activeElement at all.
+        let none = press_result("Enter", Some("none".into()), "Enter", json!({}));
+        assert!(none["warning"]
+            .as_str()
+            .expect("warning")
+            .contains("nothing is focused"));
+    }
+
+    #[test]
+    fn press_does_not_warn_for_keys_that_act_on_the_document() {
+        // Arrows scroll, Tab moves focus, Backspace navigates back — landing on
+        // <body> is legitimate for all of them, so no warning.
+        for key in ["ArrowDown", "Tab", "Backspace", "/"] {
+            let result = press_result(key, Some("body".into()), key, json!({}));
+            assert!(
+                result.get("warning").is_none(),
+                "{key} on <body> should not warn"
+            );
+        }
+    }
+
+    #[test]
+    fn press_hold_keeps_its_duration_alongside_the_target() {
+        let result = press_result("d", Some("body".into()), "d", json!({ "heldMs": 800 }));
+        assert_eq!(result["pressed"], "d");
+        assert_eq!(result["heldMs"], 800);
+        assert_eq!(result["target"], "body");
+    }
 
     #[tokio::test]
     async fn tab_duplicate_failure_preserves_active_tab_context() {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -2830,6 +2830,32 @@ async fn e2e_fill_then_press_enter_submits_the_form() {
         "Enter after fill must submit the form"
     );
 
+    // The other half: restoring focus must not override a page that moves focus
+    // on blur itself (#advance hands off to #next). Restore only when the blur
+    // left focus on <body>.
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "fill", "selector": "#advance", "value": "1234" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "8",
+            "action": "evaluate",
+            "script": "document.activeElement && document.activeElement.id"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        "next",
+        "fill must leave a page-driven focus handoff alone"
+    );
+
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);
 }

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -39,6 +39,7 @@ fn native_test_fixture_html(name: &str) -> &'static str {
         "iframe_button_probe" => include_str!("test_fixtures/iframe_button_probe.html"),
         "monaco_fill_probe" => include_str!("test_fixtures/monaco_fill_probe.html"),
         "ref_reuse_probe" => include_str!("test_fixtures/ref_reuse_probe.html"),
+        "enter_submit_probe" => include_str!("test_fixtures/enter_submit_probe.html"),
         _ => panic!("Unknown native test fixture: {}", name),
     }
 }
@@ -2747,6 +2748,162 @@ async fn e2e_hover_scroll_press() {
     .await;
     assert_success(&resp);
     assert_eq!(get_data(&resp)["pressed"], "Enter");
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Issue #167: `fill` ended with `el.blur()`, so `document.activeElement` was
+/// `<body>` by the time the next `press Enter` ran. The key went to the document,
+/// the form never submitted, and press still printed a clean success. Assert the
+/// whole chain: fill leaves the field focused, Enter reaches it, the form submits.
+#[tokio::test]
+#[ignore]
+async fn e2e_fill_then_press_enter_submits_the_form() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": native_test_fixture_url("enter_submit_probe")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "fill", "selector": "#q", "value": "test query" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // The field — not <body> — still holds focus after the fill.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "document.activeElement && document.activeElement.id"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        "q",
+        "fill must leave focus on the field it filled"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "press", "key": "Enter" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["pressed"], "Enter");
+    assert_eq!(data["target"], "input#q[name=\"q\"]");
+    assert!(
+        data.get("warning").is_none(),
+        "a key that landed on the field should not warn: {data}"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "evaluate", "script": "window.__submitted" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        true,
+        "Enter after fill must submit the form"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Issue #167: each CLI invocation is a separate process, so focus can be
+/// anywhere by the time `press` runs. `--selector` pins the target, and an Enter
+/// with nothing focused reports a warning instead of a bare success.
+#[tokio::test]
+#[ignore]
+async fn e2e_press_selector_pins_the_target_and_unfocused_enter_warns() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "navigate",
+            "url": native_test_fixture_url("enter_submit_probe")
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Nothing focused: Enter provably does nothing, so say so.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "press", "key": "Enter" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["target"], "body");
+    let warning = data["warning"]
+        .as_str()
+        .expect("unfocused Enter must warn instead of reporting a clean success");
+    assert!(warning.contains("--selector"), "warning: {warning}");
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "window.__submitted" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        false,
+        "the warning must describe a real no-op"
+    );
+
+    // `--selector` focuses first, so the same Enter now reaches the form.
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "press", "key": "Enter", "selector": "#q" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["target"], "input#q[name=\"q\"]");
+    assert!(data.get("warning").is_none(), "{data}");
+
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "evaluate", "script": "window.__submitted" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], true);
 
     let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     assert_success(&resp);

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -689,6 +689,20 @@ pub async fn fill(
             fire('change');
             try {{ el.blur(); }} catch (e) {{}}
             fire('focusout');                          // blur-triggered lookups/validation
+            // ...then put focus BACK on the field. The blur above left
+            // document.activeElement on <body>, so the very next `press Enter`
+            // was dispatched at the document and the form never submitted —
+            // while press still reported success (#167). Only restore when the
+            // blur didn't hand focus to something else: a page that
+            // deliberately advances focus on blur keeps its own target.
+            try {{
+                const doc = el.ownerDocument;
+                const root = (el.getRootNode && el.getRootNode()) || doc;
+                const ae = root && root.activeElement;
+                if (!ae || ae === doc.body || ae === doc.documentElement) {{
+                    el.focus({{ preventScroll: true }});
+                }}
+            }} catch (e) {{}}
             return 'input';
         }}"#,
         val = serde_json::to_string(value).unwrap_or_default(),
@@ -2020,6 +2034,29 @@ pub async fn focus(
     selector_or_ref: &str,
     iframe_sessions: &HashMap<String, String>,
 ) -> Result<(), String> {
+    focus_reporting_session(
+        client,
+        session_id,
+        ref_map,
+        selector_or_ref,
+        iframe_sessions,
+    )
+    .await
+    .map(|_| ())
+}
+
+/// Focus an element and return the CDP session it resolved in.
+///
+/// Callers that follow the focus with an input event — `press --selector` — need
+/// the frame's session so the key is dispatched where the element actually
+/// lives, not at the main frame (#167).
+pub async fn focus_reporting_session(
+    client: &CdpClient,
+    session_id: &str,
+    ref_map: &RefMap,
+    selector_or_ref: &str,
+    iframe_sessions: &HashMap<String, String>,
+) -> Result<String, String> {
     let (object_id, effective_session_id) = resolve_element_object_id(
         client,
         session_id,
@@ -2043,7 +2080,60 @@ pub async fn focus(
         )
         .await?;
 
-    Ok(())
+    Ok(effective_session_id)
+}
+
+/// A short CSS-ish descriptor of `document.activeElement` — `textarea[name="q"]`,
+/// `button#send`, or `body` when nothing is focused.
+///
+/// Keyboard events go to whatever holds focus, so a key command that reports
+/// success tells the agent nothing about *where* the key landed. Reporting the
+/// target turns a silent no-op into an observable one (#167).
+pub async fn active_element_descriptor(client: &CdpClient, session_id: &str) -> Option<String> {
+    let js = r#"(() => {
+        // Walk into shadow roots: document.activeElement stops at the host.
+        let el = document.activeElement;
+        while (el && el.shadowRoot && el.shadowRoot.activeElement) el = el.shadowRoot.activeElement;
+        if (!el) return 'none';
+        let out = el.tagName ? el.tagName.toLowerCase() : String(el);
+        if (el.id) out += '#' + el.id;
+        const name = el.getAttribute && el.getAttribute('name');
+        if (name) out += '[name="' + name + '"]';
+        return out;
+    })()"#;
+
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &EvaluateParams {
+                expression: js.to_string(),
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(session_id),
+        )
+        .await
+        .ok()?;
+
+    if result.exception_details.is_some() {
+        return None;
+    }
+    result.result.value?.as_str().map(String::from)
+}
+
+/// Does a key landing on `<body>` mean it provably did nothing?
+///
+/// Enter is the one key with no document-level default action: with nothing
+/// focused it neither submits, activates, nor scrolls. Arrows scroll, Tab moves
+/// focus, Backspace navigates back — those are all legitimate on `<body>`, so
+/// warning about them would be noise (#167).
+pub fn key_needs_focus(key_name: &str) -> bool {
+    key_name.eq_ignore_ascii_case("enter") || key_name.eq_ignore_ascii_case("return")
+}
+
+/// Is `descriptor` (from [`active_element_descriptor`]) a "nothing is focused" value?
+pub fn descriptor_is_unfocused(descriptor: &str) -> bool {
+    matches!(descriptor, "body" | "html" | "none")
 }
 
 pub async fn clear(

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -695,10 +695,16 @@ pub async fn fill(
             // while press still reported success (#167). Only restore when the
             // blur didn't hand focus to something else: a page that
             // deliberately advances focus on blur keeps its own target.
+            // Resolve the DEEPEST active element from the document, not from
+            // el's own root: a blur handler that moves focus into a *different*
+            // shadow root leaves el's root empty, and restoring off that would
+            // steal the focus the page just placed.
             try {{
                 const doc = el.ownerDocument;
-                const root = (el.getRootNode && el.getRootNode()) || doc;
-                const ae = root && root.activeElement;
+                let ae = doc && doc.activeElement;
+                while (ae && ae.shadowRoot && ae.shadowRoot.activeElement) {{
+                    ae = ae.shadowRoot.activeElement;
+                }}
                 if (!ae || ae === doc.body || ae === doc.documentElement) {{
                     el.focus({{ preventScroll: true }});
                 }}
@@ -1641,9 +1647,28 @@ pub async fn dispatch_single_key(
     key: &str,
     event_type: &str,
 ) -> Result<(), String> {
+    dispatch_single_key_with_modifiers(client, session_id, key, event_type, None).await
+}
+
+/// [`dispatch_single_key`] carrying a CDP modifier bitmask (1 = Alt, 2 = Control,
+/// 4 = Meta, 8 = Shift).
+///
+/// `press <chord> --hold` used to drop the chord's modifiers, so
+/// `press Control+a --hold 500` held a plain `a` while still reporting the chord
+/// back as pressed.
+pub async fn dispatch_single_key_with_modifiers(
+    client: &CdpClient,
+    session_id: &str,
+    key: &str,
+    event_type: &str,
+    modifiers: Option<i32>,
+) -> Result<(), String> {
     let (key_name, code, key_code) = named_key_info(key);
-    // Printable text is only meaningful on key-down; key-up never inserts.
-    let text = if event_type == "keyDown" {
+    // Printable text is only meaningful on key-down; key-up never inserts. A
+    // Control/Meta chord is a command (Ctrl+A = select-all), not text input, so
+    // it carries no text either — same rule as `press_key_with_modifiers`.
+    let has_command_modifier = modifiers.is_some_and(|m| m & (2 | 4) != 0);
+    let text = if event_type == "keyDown" && !has_command_modifier {
         key_text(&key_name)
     } else {
         None
@@ -1659,7 +1684,7 @@ pub async fn dispatch_single_key(
                 unmodified_text: text,
                 windows_virtual_key_code: Some(key_code),
                 native_virtual_key_code: Some(key_code),
-                modifiers: None,
+                modifiers,
             },
             Some(session_id),
         )

--- a/cli/src/native/test_fixtures/enter_submit_probe.html
+++ b/cli/src/native/test_fixtures/enter_submit_probe.html
@@ -16,14 +16,21 @@
       <input id="go" name="go" type="submit" value="Search" />
     </form>
 
-    <p id="log"></p>
+    <!--
+      The other half of the fix: fill restores focus only when the blur left it
+      on <body>. A page that deliberately advances focus on blur — a PIN/OTP
+      segment, a wizard step — must keep its own target, so #advance hands focus
+      to #next and fill must not take it back.
+    -->
+    <form id="wizard" onsubmit="return false">
+      <input id="advance" name="advance" type="text" />
+      <input id="next" name="next" type="text" />
+    </form>
 
     <script>
       window.__submitted = false;
-      // A page that deliberately advances focus on blur must keep its own
-      // target — fill's focus restore has to leave this one alone.
-      document.getElementById('q').addEventListener('input', () => {
-        document.getElementById('log').textContent = 'typed';
+      document.getElementById('advance').addEventListener('blur', () => {
+        document.getElementById('next').focus();
       });
     </script>
   </body>

--- a/cli/src/native/test_fixtures/enter_submit_probe.html
+++ b/cli/src/native/test_fixtures/enter_submit_probe.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>enter submit probe</title>
+  </head>
+  <body>
+    <!--
+      Issue #167: a search-style form. `fill` used to blur the field, so the
+      following `press Enter` was dispatched at <body> and never reached the
+      form — the CLI still printed a clean success. The submit handler below
+      records what actually happened so the test can tell the two apart.
+    -->
+    <form id="search" onsubmit="window.__submitted = true; return false">
+      <input id="q" name="q" type="text" />
+      <input id="go" name="go" type="submit" value="Search" />
+    </form>
+
+    <p id="log"></p>
+
+    <script>
+      window.__submitted = false;
+      // A page that deliberately advances focus on blur must keep its own
+      // target — fill's focus restore has to leave this one alone.
+      document.getElementById('q').addEventListener('input', () => {
+        document.getElementById('log').textContent = 'typed';
+      });
+    </script>
+  </body>
+</html>

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -795,6 +795,31 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             }
             return;
         }
+        // Key press: name the element the key went to, so a keystroke that
+        // landed nowhere doesn't read as a plain ✓ Done (issue #167).
+        if action == Some("press") {
+            if let Some(key) = data.get("pressed").and_then(|v| v.as_str()) {
+                let warning = data.get("warning").and_then(|v| v.as_str());
+                let indicator = if warning.is_some() {
+                    color::warning_indicator()
+                } else {
+                    color::success_indicator()
+                };
+                match data.get("target").and_then(|v| v.as_str()) {
+                    Some(target) => println!(
+                        "{} Pressed {} {}",
+                        indicator,
+                        key,
+                        color::dim(&format!("→ {target}"))
+                    ),
+                    None => println!("{} Pressed {}", indicator, key),
+                }
+                if let Some(w) = warning {
+                    eprintln!("{} {}", color::warning_indicator(), w);
+                }
+                return;
+            }
+        }
         // Tab switch
         if matches!(action, Some("tab_switch" | "tab_adopt")) {
             if let Some(tab_id) = data.get("tabId").and_then(|v| v.as_str()) {
@@ -1911,9 +1936,13 @@ Examples:
             r##"
 chrome-use press - Press a key or key combination
 
-Usage: chrome-use press <key>
+Usage: chrome-use press <key> [--selector <css|@ref>] [--hold <ms>]
 
 Presses a key or key combination. Supports special keys and modifiers.
+
+The key goes to whatever the page currently has focused, so the output names
+that element ("Pressed Enter → textarea[name=q]"). Use --selector to focus a
+target first when you can't be sure focus is where you left it.
 
 Aliases: key
 
@@ -1926,12 +1955,17 @@ Special Keys:
 Modifiers (combine with +):
   Control, Alt, Shift, Meta
 
+Options:
+  --selector <css|@ref>  Focus this element before pressing (alias: --on)
+  --hold <ms>            Hold the key down for <ms> before releasing
+
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
 
 Examples:
   chrome-use press Enter
+  chrome-use press Enter --selector "textarea[name=q]"
   chrome-use press Tab
   chrome-use press Control+a
   chrome-use press Control+Shift+s

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3787,9 +3787,13 @@ Core Commands:
   type <sel> <text>          Type into element
   fill <sel> <text>          Clear and fill (handles CodeMirror/Monaco/ProseMirror/
                              contenteditable; `--file <path>`/`--stdin` for large text)
-  press <key> [--hold <ms>]  Press key (Enter, Tab, Control+a). --hold keeps it
-                             down <ms> then releases — precise (in-daemon), for
-                             games/charge: `press d --hold 800`
+  press <key> [--selector <sel>] [--hold <ms>]
+                             Press key (Enter, Tab, Control+a) at the current
+                             focus; the output names where it landed. --selector
+                             focuses a target first (alias --on) when focus may
+                             have moved: `press Enter --selector "input[name=q]"`.
+                             --hold keeps it down <ms> then releases — precise
+                             (in-daemon), for games/charge: `press d --hold 800`
   keydown <key>              Hold a key down (no auto-release) — for games/shortcuts
   keyup <key>                Release a held key. Pair with keydown to hold-to-move:
                              `keydown d` … `keyup d`

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -139,7 +139,8 @@
 <span class="du-prompt">$</span> chrome-use focus @e1           <span class="du-cmt"># 聚焦元素</span>
 <span class="du-prompt">$</span> chrome-use fill @e2 <span class="du-str">"text"</span>     <span class="du-cmt"># 清空后输入</span>
 <span class="du-prompt">$</span> chrome-use type @e2 <span class="du-str">"text"</span>     <span class="du-cmt"># 直接输入（不清空）</span>
-<span class="du-prompt">$</span> chrome-use press Enter         <span class="du-cmt"># 按键（别名：key）</span>
+<span class="du-prompt">$</span> chrome-use press Enter         <span class="du-cmt"># 在当前焦点按键（别名：key），输出报告落点</span>
+<span class="du-prompt">$</span> chrome-use press Enter --selector @e2  <span class="du-cmt"># 先聚焦目标再按（别名：--on）</span>
 <span class="du-prompt">$</span> chrome-use press Control+a     <span class="du-cmt"># 组合键</span>
 <span class="du-prompt">$</span> chrome-use keydown Shift       <span class="du-cmt"># 按住键</span>
 <span class="du-prompt">$</span> chrome-use keyup Shift         <span class="du-cmt"># 释放键</span>

--- a/docs/interacting.html
+++ b/docs/interacting.html
@@ -139,7 +139,10 @@
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
           <span class="du-code-name">press / keydown / keyup</span>
         </div>
-<pre><code><span class="du-prompt">$</span> chrome-use press Enter                 <span class="du-cmt"># 在当前焦点按一个键</span>
+<pre><code><span class="du-prompt">$</span> chrome-use press Enter                 <span class="du-cmt"># 在当前焦点按一个键，输出会报告落点</span>
+                                       <span class="du-cmt"># ✓ Pressed Enter → textarea[name="q"]</span>
+<span class="du-prompt">$</span> chrome-use press Enter --selector @e2  <span class="du-cmt"># 先聚焦目标再按（别名 --on）——每次调用</span>
+                                       <span class="du-cmt"># 都是独立进程，别假设焦点还在原处</span>
 <span class="du-prompt">$</span> chrome-use press Control+a             <span class="du-cmt"># 组合键</span>
 <span class="du-prompt">$</span> chrome-use keydown d                   <span class="du-cmt"># 按住某键不放（不自动抬起）</span>
 <span class="du-prompt">$</span> chrome-use keyup d                     <span class="du-cmt"># 抬起——成对用来「按住移动」</span>

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -380,7 +380,12 @@ chrome-use type @e6 "ChatGPT" --enter  # type (real keystrokes, implies --key-ev
                                           # confirmed (e.g. juejin 「添加标签」). If you'd rather
                                           # pick from the list, type --key-events first, then
                                           # snapshot -i and click the candidate.
-chrome-use press Enter                 # press a key at current focus (down+up)
+chrome-use press Enter                 # press a key at current focus (down+up).
+                                          # The output names where it landed
+                                          # ("Pressed Enter → textarea[name=q]").
+chrome-use press Enter --selector @e2  # focus the target first (alias --on) —
+                                          # each CLI call is its own process, so
+                                          # don't assume focus stayed put
 chrome-use press Control+a             # key combination
 chrome-use keydown d                   # HOLD a key down (no auto-release)
 chrome-use keyup d                     # release it — pair them to hold-to-move

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -61,7 +61,8 @@ chrome-use dblclick @e1        # Double-click
 chrome-use focus @e1           # Focus element
 chrome-use fill @e2 "text"     # Clear and type
 chrome-use type @e2 "text"     # Type without clearing (add --clear to clear first, --delay <ms> for per-key delay)
-chrome-use press Enter         # Press key (alias: key)
+chrome-use press Enter         # Press key at current focus (alias: key); output names the target
+chrome-use press Enter --selector @e2  # Focus the target first (alias: --on)
 chrome-use press Control+a     # Key combination
 chrome-use keydown Shift       # Hold key down
 chrome-use keyup Shift         # Release key


### PR DESCRIPTION
Closes #167.

## 根因

`fill` 结尾会 `el.blur()` + `focusout`（为了触发站点的 blur 校验/联动），焦点因此掉回 `<body>`。紧接着的 `press Enter` 被派发到 document —— 表单永远不会提交，而 CLI 仍然打印 `✓ Done`。一次被吞掉的按键和一次成功的按键在输出上完全无法区分。

## 改动

| | |
|---|---|
| `fill` 归还焦点 | blur/focusout 照旧触发，之后把焦点还给原字段。仅当 blur 没有把焦点交给别的元素时才还 —— 站点主动推进焦点的场景保持站点自己的目标。 |
| `press --selector <css\|@ref>` | 按键前先聚焦目标（别名 `--on`）。每次 CLI 调用都是独立进程，无法假设焦点还在上一步留下的位置。聚焦会解析元素所在的 frame，iframe 里的字段也能收到按键。 |
| `press` 报告落点 | 结果带 `target`（**按键前**读取，Enter 常触发导航），输出 `✓ Pressed Enter → textarea[name="q"]`。 |
| 无焦点的 Enter 告警 | Enter 是唯一在无焦点时确实什么都不做的键；方向键滚动、Tab 移焦点、Backspace 后退落在 document 上都是正常行为，所以只对 Enter 告警，不制造噪音。 |

选择器解析改成位置扫描，`press --selector <sel> Enter` 不会再把选择器值误当成键名。

## 之前 / 之后

```
$ chrome-use press Enter                      # 什么都没聚焦
- ✓ Done
+ ⚠ Pressed Enter → body
+ ⚠ Enter landed on no editable target (activeElement is <body>), so it submitted
+   and activated nothing. Focus the field first: `press Enter --selector "<css|@ref>"`.
```

## 验证

- 新增 e2e 回归 `e2e_fill_then_press_enter_submits_the_form`：把 fill 的焦点归还去掉就失败（`left: ""` / `right: "q"`），加回来即通过。
- 新增 e2e `e2e_press_selector_pins_the_target_and_unfocused_enter_warns`：覆盖告警路径与 `--selector` 路径，并断言告警描述的确实是一次真实的 no-op。
- 4 个 `press_result` 单测 + 1 个解析单测；`cargo test` 1091 全绿；`e2e_form_interaction` / `e2e_fill_monaco_is_atomic_and_verified` / `e2e_hover_scroll_press` / `e2e_auth_login_waits_for_delayed_spa_form_render` 无回归。
- 真实 Chrome 按 issue 原始步骤复跑 google.com：`fill` → `press Enter` 现在跳到 `/search?q=…`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selector-based targeting for `press` with `--selector`/`--on`.
  * Added support for holding keys with `--hold`, including modifier combinations.
  * Press results now report the key, target element, hold duration, and relevant warnings.
  * Improved focus handling so filled inputs retain focus when appropriate.

* **Bug Fixes**
  * Improved validation for missing selector or hold values.
  * Enter-key interactions now reliably submit forms when the intended input is focused.

* **Documentation**
  * Updated command guidance with targeting, focus, and target-reporting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->