### PR TITLE
fix: download-url 支持 blob: + 升级提示不再混进错误流 (#169, #170)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7390,17 +7390,156 @@ async fn resolve_download_href(
         .map(ToString::to_string)
 }
 
+/// Refuse to pull more than this through a CDP `Runtime.evaluate` result. The
+/// bytes come back base64-encoded inside a JSON message (~1.33x), and over the
+/// relay that message crosses a WebSocket hop — a hundred-megabyte string is a
+/// way to hang the session, not a way to download a file.
+const BLOB_DOWNLOAD_MAX_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Read a `blob:` URL's bytes from inside the page and write them to `dest`.
+///
+/// `chrome.downloads` can't touch a blob URL — it is scoped to the document that
+/// created it, not to the extension — so `download-url` used to reject the scheme
+/// outright and leave page-rendered assets unreachable (#169). The only route
+/// that returns the *original* bytes is to fetch the blob where it's valid; the
+/// canvas/`toDataURL` workaround re-encodes and silently drops metadata such as a
+/// C2PA provenance manifest.
+///
+/// A blob registered by an iframe isn't fetchable from the top frame, so on
+/// failure we retry in each frame and report which one produced the bytes.
+async fn download_blob_url(
+    mgr: &BrowserManager,
+    iframe_sessions: &HashMap<String, String>,
+    url: &str,
+    dest: &std::path::Path,
+) -> Result<Value, String> {
+    let js = format!(
+        r#"(async () => {{
+            try {{
+                const res = await fetch({url});
+                if (!res.ok) return {{ ok: false, error: 'fetch returned HTTP ' + res.status }};
+                const blob = await res.blob();
+                if (blob.size > {max}) {{
+                    return {{ ok: false, tooLarge: true, size: blob.size }};
+                }}
+                const dataUrl = await new Promise((resolve, reject) => {{
+                    const fr = new FileReader();
+                    fr.onload = () => resolve(String(fr.result));
+                    fr.onerror = () => reject(fr.error || new Error('FileReader failed'));
+                    fr.readAsDataURL(blob);
+                }});
+                const comma = dataUrl.indexOf(',');
+                return {{
+                    ok: true,
+                    b64: comma < 0 ? '' : dataUrl.slice(comma + 1),
+                    size: blob.size,
+                    type: blob.type || ''
+                }};
+            }} catch (e) {{
+                return {{ ok: false, error: String((e && e.message) || e) }};
+            }}
+        }})()"#,
+        url = serde_json::to_string(url).unwrap_or_default(),
+        max = BLOB_DOWNLOAD_MAX_BYTES,
+    );
+
+    // Top frame first — the common case, and the only attempt most blobs need.
+    let mut attempt = mgr.evaluate(&js, None).await.unwrap_or(Value::Null);
+    let mut resolved_in = "top".to_string();
+
+    if !attempt.get("ok").and_then(Value::as_bool).unwrap_or(false)
+        && !attempt
+            .get("tooLarge")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    {
+        let session_id = mgr.active_session_id()?.to_string();
+        let frames =
+            super::element::collect_all_frames_text(&mgr.client, &session_id, iframe_sessions)
+                .await
+                .unwrap_or_default();
+        for frame in frames.iter().filter(|f| f.kind != "top") {
+            let in_frame = mgr
+                .evaluate_in_frame(&js, &frame.frame_id, iframe_sessions)
+                .await
+                .unwrap_or(Value::Null);
+            let ok = in_frame.get("ok").and_then(Value::as_bool).unwrap_or(false);
+            let too_large = in_frame
+                .get("tooLarge")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if ok || too_large {
+                attempt = in_frame;
+                resolved_in = frame.url.clone();
+                break;
+            }
+        }
+    }
+
+    if attempt
+        .get("tooLarge")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let size = attempt.get("size").and_then(Value::as_u64).unwrap_or(0);
+        return Err(format!(
+            "blob: download is {size} bytes, over the {BLOB_DOWNLOAD_MAX_BYTES}-byte limit for \
+             reading bytes through the page. Use the asset's http(s) URL if it has one."
+        ));
+    }
+    if !attempt.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        let detail = attempt
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("the blob URL was not fetchable in any frame");
+        return Err(format!(
+            "blob: download failed — {detail}. A blob URL is only valid in the document that \
+             created it and dies with that document, so re-read it from a fresh snapshot of the \
+             page that rendered it."
+        ));
+    }
+
+    let b64 = attempt
+        .get("b64")
+        .and_then(Value::as_str)
+        .ok_or("blob: download returned no data")?;
+    let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, b64)
+        .map_err(|e| format!("blob: download returned undecodable data: {e}"))?;
+    std::fs::write(dest, &bytes).map_err(|e| format!("Failed to write {}: {e}", dest.display()))?;
+
+    Ok(json!({
+        "path": dest.to_string_lossy(),
+        "url": url,
+        "bytes": bytes.len(),
+        "contentType": attempt.get("type").and_then(Value::as_str).unwrap_or(""),
+        "frame": resolved_in,
+    }))
+}
+
 async fn handle_download_url(cmd: &Value, state: &DaemonState) -> Result<Value, String> {
     let url = cmd
         .get("url")
         .and_then(Value::as_str)
         .ok_or("Missing 'url' parameter")?;
     let parsed = url::Url::parse(url).map_err(|e| format!("Invalid download URL: {}", e))?;
-    if !matches!(parsed.scheme(), "http" | "https") {
-        return Err("Invalid download URL: expected http:// or https://".to_string());
+    if !matches!(parsed.scheme(), "http" | "https" | "blob") {
+        return Err("Invalid download URL: expected http://, https:// or blob:".to_string());
     }
 
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+
+    // A blob never goes through the extension's download machinery — its bytes
+    // live in the page, and that's where we read them (#169).
+    if parsed.scheme() == "blob" {
+        let path_str = cmd.get("path").and_then(Value::as_str).ok_or(
+            "blob: downloads need an explicit destination — the bytes are read from the page, \
+             so there is no browser download to inherit a filename from: \
+             `download-url <blob:…> <path>`",
+        )?;
+        let (_, dest) = prepare_download_destination(path_str)?;
+        return download_blob_url(mgr, &state.iframe_sessions, url, &dest).await;
+    }
+
     if !relay_supports_downloads(mgr).await {
         return Err(
             "URL-initiated downloads require ab-connect 0.5.13 or newer with the downloads permission"

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -2935,6 +2935,223 @@ async fn e2e_press_selector_pins_the_target_and_unfocused_enter_warns() {
     assert_success(&resp);
 }
 
+/// Issue #169: `download-url` rejected `blob:` outright, so an asset the page had
+/// already rendered could not be retrieved as bytes at all. The bytes must come
+/// back **byte-exact** — the canvas/`toDataURL` workaround re-encodes and drops
+/// metadata (for Google-generated images, the C2PA provenance manifest).
+#[tokio::test]
+#[ignore]
+async fn e2e_download_url_reads_blob_bytes_from_the_page() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // A blob whose bytes are a known, non-image byte sequence — including a 0x00
+    // and a 0xFF, so any re-encode or text round-trip would corrupt it.
+    let page = concat!(
+        "data:text/html,<html><body><script>",
+        "window.__bytes = new Uint8Array([0,1,2,253,254,255,65,66,67]);",
+        "window.__url = URL.createObjectURL(",
+        "new Blob([window.__bytes], {type:'application/octet-stream'}));",
+        "</script></body></html>"
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": page }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "evaluate", "script": "window.__url" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let blob_url = get_data(&resp)["result"]
+        .as_str()
+        .expect("blob url")
+        .to_string();
+    assert!(blob_url.starts_with("blob:"), "got {blob_url}");
+
+    let dir = std::env::temp_dir().join("chrome-use-e2e-blob");
+    let _ = std::fs::create_dir_all(&dir);
+    let dest = dir.join("blob-download.bin");
+    let _ = std::fs::remove_file(&dest);
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "download_url",
+            "url": blob_url,
+            "path": dest.to_string_lossy()
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["bytes"], 9);
+    assert_eq!(data["contentType"], "application/octet-stream");
+
+    let written = std::fs::read(&dest).expect("downloaded file");
+    assert_eq!(
+        written,
+        vec![0u8, 1, 2, 253, 254, 255, 65, 66, 67],
+        "blob download must be byte-exact, not re-encoded"
+    );
+    let _ = std::fs::remove_file(&dest);
+
+    // A destination is required: the bytes are read from the page, so there is no
+    // browser download to inherit a filename from.
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "download_url", "url": blob_url }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false);
+    assert!(
+        resp["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("explicit destination"),
+        "{resp}"
+    );
+
+    // A revoked blob must fail loudly, not write an empty file.
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "evaluate", "script": "URL.revokeObjectURL(window.__url), 1" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "7",
+            "action": "download_url",
+            "url": blob_url,
+            "path": dest.to_string_lossy()
+        }),
+        &mut state,
+    )
+    .await;
+    assert_eq!(resp["success"], false, "{resp}");
+    assert!(
+        !dest.exists(),
+        "a failed blob download must not leave a file"
+    );
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
+/// Issue #169, the harder half: a blob registered by a cross-origin frame is not
+/// fetchable from the top frame at all (`TypeError: Failed to fetch` — the very
+/// symptom the report hit). The download has to find the frame that owns it.
+///
+/// Nested `data:` documents are opaque origins, so the iframe here really is
+/// cross-origin to its parent — no external page needed to reproduce it.
+#[tokio::test]
+#[ignore]
+async fn e2e_download_url_finds_a_blob_registered_by_another_frame() {
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // The iframe publishes its blob URL through the DOM: an isolated world can
+    // read the document but not the frame's `window` globals.
+    let inner = "data:text/html,<body><script>document.body.textContent=\
+                 URL.createObjectURL(new Blob([new Uint8Array([9,8,7])]))</script></body>";
+    let page = format!(
+        "data:text/html,<html><body><iframe src=\"{}\"></iframe></body></html>",
+        inner.replace('"', "&quot;")
+    );
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": page }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Read the blob URL out of the frame that made it.
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "evaluate",
+            "script": "document.body.textContent.trim()",
+            "frame": "1"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let blob_url = get_data(&resp)["result"]
+        .as_str()
+        .expect("blob url")
+        .to_string();
+    assert!(blob_url.starts_with("blob:"), "got {blob_url}");
+
+    // The top frame genuinely cannot reach it — this is the reported failure.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": format!("fetch({}).then(() => 'ok').catch(() => 'fail')",
+                              serde_json::to_string(&blob_url).unwrap())
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        "fail",
+        "precondition: the top frame must not be able to fetch this blob"
+    );
+
+    let dir = std::env::temp_dir().join("chrome-use-e2e-blob");
+    let _ = std::fs::create_dir_all(&dir);
+    let dest = dir.join("iframe-blob.bin");
+    let _ = std::fs::remove_file(&dest);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "download_url",
+            "url": blob_url,
+            "path": dest.to_string_lossy()
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["bytes"], 3);
+    assert!(
+        data["frame"].as_str().unwrap_or_default().contains("data:"),
+        "the response should name the frame the bytes came from: {data}"
+    );
+    assert_eq!(
+        std::fs::read(&dest).expect("downloaded file"),
+        vec![9u8, 8, 7]
+    );
+    let _ = std::fs::remove_file(&dest);
+
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 // ---------------------------------------------------------------------------
 // Raw mouse regressions
 // ---------------------------------------------------------------------------

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1893,6 +1893,13 @@ Starts an HTTP(S) download through ab-connect. When path is provided, the
 completed file is moved there. Without path, Chrome keeps it in the profile's
 normal download directory. Requires ab-connect 0.5.13 or newer.
 
+blob: URLs take a different route. Chrome's download machinery can't reach a
+blob (it belongs to the document that created it), so the bytes are read from
+inside the page and written straight to disk — byte-exact, metadata intact, no
+ab-connect needed. A destination path is required, and the blob must still be
+alive in a loaded page. Blobs registered by an iframe are found automatically.
+Max 32 MB, since the bytes travel back through a CDP message.
+
 Alias: download-start
 
 Global Options:
@@ -1902,6 +1909,7 @@ Global Options:
 Examples:
   chrome-use download-url "https://example.com/report.pdf"
   chrome-use download-url "https://example.com/video.mp4" ./video.mp4
+  chrome-use download-url "blob:https://example.com/9f2c-…" ./generated.png
 "##
         }
         "downloads" => {
@@ -3807,7 +3815,9 @@ Core Commands:
   drag <src> <dst>           Drag and drop
   upload <sel> <files...>    Upload files
   download <sel> <path>      Download file from an element
-  download-url <url> [path]  Start a URL download through ab-connect
+  download-url <url> [path]  Start a URL download through ab-connect. A blob:
+                             URL is read from inside the page instead (byte-exact,
+                             no re-encode) — path required
   downloads [--limit N]      List downloads (--clear clears history)
   scroll <dir> [px]          Scroll (up/down/left/right)
   scrollintoview <sel>       Scroll element into view

--- a/cli/src/upgrade.rs
+++ b/cli/src/upgrade.rs
@@ -100,9 +100,40 @@ pub fn run_update_check() {
     }
 }
 
+/// Should the "update available" line actually be printed?
+///
+/// The notice shares stderr with real errors, so a programmatic caller that
+/// reports "chrome-use failed, here is its stderr" was quoting housekeeping as
+/// part of the failure (#170). Print it only where a human reads it:
+///
+/// - stderr must be a TTY — the conventional split, and the one that fixes
+///   every wrapper without the wrapper having to opt out;
+/// - `--json` runs are machine-facing by definition, TTY or not;
+/// - `CHROME_USE_NO_UPDATE_NOTICE` and the de-facto `NO_UPDATE_NOTIFIER`
+///   silence it explicitly.
+///
+/// This gates the *notice* only. The daily background version check — and an
+/// opted-in auto-upgrade — still run, so a later interactive command is right.
+fn update_notice_visible() -> bool {
+    update_notice_visible_from(
+        std::env::var_os("CHROME_USE_NO_UPDATE_NOTICE").is_some()
+            || std::env::var_os("NO_UPDATE_NOTIFIER").is_some(),
+        std::env::args().any(|a| a == "--json"),
+        std::io::IsTerminal::is_terminal(&std::io::stderr()),
+    )
+}
+
+/// The decision behind [`update_notice_visible`], split out so it's testable
+/// without a real TTY (under `cargo test` stderr is captured, so the live
+/// function would answer "no" to everything).
+fn update_notice_visible_from(silenced: bool, json_output: bool, stderr_is_tty: bool) -> bool {
+    !silenced && !json_output && stderr_is_tty
+}
+
 /// Non-blocking "update available" notice. Called once per command run:
 /// - prints a one-line hint to **stderr** (never stdout, so `--json` is clean)
-///   when a cached release is newer than the running binary;
+///   when a cached release is newer than the running binary — and only when a
+///   human is there to read it, see [`update_notice_visible`];
 /// - refreshes the cached latest version at most once a day via a **detached**
 ///   background process, so the current command never waits on the network.
 ///
@@ -162,11 +193,15 @@ pub fn maybe_notify_update() {
                     .stderr(Stdio::null())
                     .spawn();
             }
-            eprintln!(
-                "{} auto-updating chrome-use → v{latest} in the background (you have {CURRENT_VERSION}; takes effect on your next run)",
-                color::warning_indicator()
-            );
-        } else {
+            // The upgrade itself still runs when nobody's watching; only the
+            // announcement is gated (#170).
+            if update_notice_visible() {
+                eprintln!(
+                    "{} auto-updating chrome-use → v{latest} in the background (you have {CURRENT_VERSION}; takes effect on your next run)",
+                    color::warning_indicator()
+                );
+            }
+        } else if update_notice_visible() {
             let hint = if cfg!(windows) {
                 ""
             } else {
@@ -335,5 +370,26 @@ pub fn run_upgrade() {
             eprintln!("  curl -fsSL {} | sh", INSTALL_URL);
             exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_notice_only_reaches_a_human_at_a_terminal() {
+        // The case from #170: a wrapper captures stderr, and the notice ended up
+        // quoted back to the end user as half of a failure message.
+        assert!(!update_notice_visible_from(false, false, false));
+        assert!(update_notice_visible_from(false, false, true));
+    }
+
+    #[test]
+    fn update_notice_stays_out_of_json_runs_and_honours_the_opt_out() {
+        // --json is machine-facing whether or not a TTY is attached.
+        assert!(!update_notice_visible_from(false, true, true));
+        // CHROME_USE_NO_UPDATE_NOTICE / NO_UPDATE_NOTIFIER win over everything.
+        assert!(!update_notice_visible_from(true, false, true));
     }
 }


### PR DESCRIPTION
Closes #169. Closes #170.

## #169 — `download-url` 拒绝 `blob:`

`chrome.downloads` 够不到 blob：blob URL 属于创建它的 document，不属于扩展。所以 `download-url` 在入口就拒掉整个 scheme，页面上**已经渲染出来**的资源一个字节都取不回来 —— issue 里那张表三条路全堵死。

blob: 现在走完全不同的路径：**在页面内 fetch 到字节，直接落盘**。

- **字节级一致。** canvas/`toDataURL` 那个 workaround 会重新编码，把 C2PA 溯源清单（记录「已施加 SynthID 水印」的那份签名）静默丢掉。「下载一个文件」不该有这种副作用。
- **不需要 ab-connect** —— 完全不碰扩展的下载机制。
- **跨 frame 能找到。** iframe 注册的 blob 在顶层 frame 根本 fetch 不到（正是你看到的 `TypeError: Failed to fetch`）。顶层失败后逐个 frame 重试，并在结果里报告字节是从哪个 frame 取到的。

约束都是显式的、报错都是可操作的：

| 情况 | 行为 |
|---|---|
| 没给路径 | 报错：字节从页面读，没有浏览器下载可以继承文件名 |
| > 32 MB | 报错并给出实际大小 —— 字节要 base64 塞进一条 CDP 消息，过大是挂会话而不是下载文件 |
| blob 已 revoke / 任何 frame 都取不到 | 报错并说明 blob 只在创建它的 document 里有效、随该 document 一起消失 |
| 失败 | 绝不留空文件 |

## #170 — 升级提示混进错误流

提示和真错误共用 stderr，包装 chrome-use 的工具「报告失败并附上 stderr」时，一半篇幅是与故障无关的家务事。

采纳了你列的方案 1 + 2 + 4（互不冲突，一起上）：只在 stderr 是 TTY、非 `--json`、且没设 `CHROME_USE_NO_UPDATE_NOTICE` / `NO_UPDATE_NOTIFIER` 时才打印。

**只挡提示** —— 每日后台版本检查和开了开关的自动升级照常跑，所以下一次交互式命令仍然会正确提醒。方案 3（只在成功时打印）没采纳：TTY 判定已经覆盖了程序化调用者这个真实场景，再加一条只会让「什么时候会看到提示」更难预测。

## 验证

- `e2e_download_url_reads_blob_bytes_from_the_page` —— 字节序列刻意含 `0x00` 和 `0xFF`，任何重编码或文本往返都会破坏它；同时覆盖「缺路径」和「已 revoke」两条失败路径。
- `e2e_download_url_finds_a_blob_registered_by_another_frame` —— 嵌套 `data:` 文档是 opaque origin，所以 iframe 与父页面**真的**跨源，不需要外部页面就能复现。测试**先断言顶层 fetch 确实失败**（复现前提），再验证兜底路径取到字节。
- 2 个提示门控单测（决策拆成纯函数，否则 `cargo test` 下 stderr 被捕获，什么都断言不出来）。
- `cargo test` 1093 全绿；clippy 干净。
- 真实 Chrome：跨源 iframe 的 blob 落盘字节 `09 08 07`，与源一致，`frame` 字段正确指向 iframe。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for downloading `blob:` URLs with byte-exact content.
  - Blob downloads can resolve content from page frames and support files up to 32 MiB.
  - Added clear destination requirements, download metadata, and failure messages.

- **Bug Fixes**
  - Improved handling of failed or revoked blob downloads without creating incomplete files.
  - Update notices are now suppressed for JSON output, non-interactive terminals, or opted-out environments.

- **Documentation**
  - Updated `download-url` help with blob handling details, limits, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->