### PR TITLE
feat(mcp): return the screenshot as an image block, not just a path (#178)

### DIFF
--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -971,6 +971,22 @@ fn call_screenshot(arguments: &Value) -> Result<Value, ProtocolError> {
 /// the response for no benefit when the file is right there on disk.
 const MAX_INLINE_IMAGE_BYTES: u64 = 2_000_000;
 
+/// Env override for [`MAX_INLINE_IMAGE_BYTES`]. `0` turns inlining off entirely,
+/// for hosts that bill on payload size or agents that should read the page
+/// structurally (`snapshot`) rather than looking at pictures of it.
+const MAX_INLINE_IMAGE_BYTES_VAR: &str = "CHROME_USE_MCP_MAX_INLINE_IMAGE_BYTES";
+
+/// Resolved inline budget. Parsed per call rather than cached: an MCP server is
+/// long-lived, and a stale budget from process start would ignore a host that
+/// re-execs us with a different one. A malformed value falls back to the
+/// default instead of failing the screenshot.
+fn max_inline_image_bytes() -> u64 {
+    std::env::var(MAX_INLINE_IMAGE_BYTES_VAR)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(MAX_INLINE_IMAGE_BYTES)
+}
+
 /// Identify the image format from its magic bytes.
 ///
 /// Deliberately NOT from the file extension: the caller chooses the output path,
@@ -1000,6 +1016,13 @@ fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
 /// back text-only is indistinguishable from a successful one, which leaves the
 /// agent blind and unaware of it.
 fn attach_screenshot_image(result: &mut Value) {
+    attach_screenshot_image_within(result, max_inline_image_bytes());
+}
+
+/// The body of [`attach_screenshot_image`] with the budget passed in, so tests
+/// exercise every branch without touching process env — an env-reading test
+/// here would race the other tests in this binary, which run in parallel.
+fn attach_screenshot_image_within(result: &mut Value, budget: u64) {
     let Some(path) = result
         .get("structuredContent")
         .and_then(|s| s.get("response"))
@@ -1010,22 +1033,30 @@ fn attach_screenshot_image(result: &mut Value) {
     };
     let path = std::path::PathBuf::from(path);
 
+    // Inlining switched off by the host: the path in the text block is the whole
+    // contract again, so say nothing — this is a configured outcome, not a
+    // failure the agent needs to reason about.
+    if budget == 0 {
+        return;
+    }
+
     // Never fail the screenshot itself because the inline copy didn't work.
     let note = match std::fs::metadata(&path) {
         Err(e) => format!("Screenshot saved but could not be inlined: {e}"),
-        Ok(meta) if meta.len() > MAX_INLINE_IMAGE_BYTES => format!(
-            "Screenshot saved but too large to inline ({} bytes > {} limit). \
-             Re-run with a smaller maxWidth/scale, or read the file at the path above.",
+        Ok(meta) if meta.len() > budget => format!(
+            "Screenshot saved but too large to inline ({} bytes > {} limit, \
+             override with {}). Re-run with a smaller maxWidth/scale, or read \
+             the file at the path above.",
             meta.len(),
-            MAX_INLINE_IMAGE_BYTES
+            budget,
+            MAX_INLINE_IMAGE_BYTES_VAR
         ),
         Ok(_) => match std::fs::read(&path) {
             Err(e) => format!("Screenshot saved but could not be inlined: {e}"),
             Ok(bytes) => match sniff_image_mime(&bytes) {
-                None => format!(
-                    "Saved file at the path above is not a recognized image \
+                None => "Saved file at the path above is not a recognized image \
                      (PNG/JPEG/WebP), so it was not inlined — you cannot see it."
-                ),
+                    .to_string(),
                 Some(mime) => {
                     use base64::Engine;
                     let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
@@ -1946,14 +1977,14 @@ mod tests {
 
     #[test]
     fn screenshot_is_inlined_as_an_image_block() {
-        let dir = std::env::temp_dir().join("chrome-use-mcp-img-test");
-        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
         let png = dir.join("shot.png");
         // Not a real PNG; the encoder only cares about the bytes and extension.
         std::fs::write(&png, b"\x89PNG\r\n\x1a\nfake-pixels").unwrap();
 
         let mut result = screenshot_result(png.to_str().unwrap());
-        attach_screenshot_image(&mut result);
+        attach_screenshot_image_within(&mut result, MAX_INLINE_IMAGE_BYTES);
 
         let imgs = image_blocks(&result);
         assert_eq!(imgs.len(), 1, "expected exactly one image block");
@@ -1965,22 +1996,18 @@ mod tests {
         assert_eq!(decoded, b"\x89PNG\r\n\x1a\nfake-pixels");
         // The original text block must survive for existing consumers.
         assert_eq!(result["content"][0]["type"], "text");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn jpeg_screenshot_gets_jpeg_mime() {
-        let dir = std::env::temp_dir().join("chrome-use-mcp-jpg-test");
-        std::fs::create_dir_all(&dir).unwrap();
-        let jpg = dir.join("shot.jpg");
+        let tmp = tempfile::tempdir().unwrap();
+        let jpg = tmp.path().join("shot.jpg");
         std::fs::write(&jpg, b"\xff\xd8\xff-fake").unwrap();
 
         let mut result = screenshot_result(jpg.to_str().unwrap());
-        attach_screenshot_image(&mut result);
+        attach_screenshot_image_within(&mut result, MAX_INLINE_IMAGE_BYTES);
 
         assert_eq!(image_blocks(&result)[0]["mimeType"], "image/jpeg");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1993,7 +2020,7 @@ mod tests {
                 .to_str()
                 .unwrap(),
         );
-        attach_screenshot_image(&mut result);
+        attach_screenshot_image_within(&mut result, MAX_INLINE_IMAGE_BYTES);
 
         assert!(image_blocks(&result).is_empty());
         let texts: Vec<&str> = result["content"]
@@ -2010,13 +2037,12 @@ mod tests {
 
     #[test]
     fn oversize_capture_explains_the_limit() {
-        let dir = std::env::temp_dir().join("chrome-use-mcp-big-test");
-        std::fs::create_dir_all(&dir).unwrap();
-        let png = dir.join("huge.png");
+        let tmp = tempfile::tempdir().unwrap();
+        let png = tmp.path().join("huge.png");
         std::fs::write(&png, vec![0u8; (MAX_INLINE_IMAGE_BYTES + 1) as usize]).unwrap();
 
         let mut result = screenshot_result(png.to_str().unwrap());
-        attach_screenshot_image(&mut result);
+        attach_screenshot_image_within(&mut result, MAX_INLINE_IMAGE_BYTES);
 
         assert!(image_blocks(&result).is_empty(), "must not inline oversize");
         let texts: Vec<&str> = result["content"]
@@ -2029,8 +2055,6 @@ mod tests {
             texts.iter().any(|t| t.contains("too large to inline")),
             "expected a size explanation, got {texts:?}"
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -2038,33 +2062,30 @@ mod tests {
         // The caller picks the output path and the daemon writes PNG bytes to
         // whatever name it is given, so `path: "shot.jpg"` must NOT become
         // image/jpeg — a client decoding by mimeType would get garbage.
-        let dir = std::env::temp_dir().join("chrome-use-mcp-mislabel-test");
-        std::fs::create_dir_all(&dir).unwrap();
-        let lying = dir.join("actually-a-png.jpg");
+        let tmp = tempfile::tempdir().unwrap();
+        let lying = tmp.path().join("actually-a-png.jpg");
         std::fs::write(&lying, b"\x89PNG\r\n\x1a\npixels").unwrap();
 
         let mut result = screenshot_result(lying.to_str().unwrap());
-        attach_screenshot_image(&mut result);
+        attach_screenshot_image_within(&mut result, MAX_INLINE_IMAGE_BYTES);
 
         assert_eq!(
             image_blocks(&result)[0]["mimeType"],
             "image/png",
             "mime must come from the bytes, not the extension"
         );
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn a_non_image_file_is_explained_not_silently_skipped() {
         // Anything that isn't a decodable image must still tell the agent it
         // cannot see — a silently text-only result looks like success.
-        let dir = std::env::temp_dir().join("chrome-use-mcp-nonimage-test");
-        std::fs::create_dir_all(&dir).unwrap();
-        let pdf = dir.join("report.pdf");
+        let tmp = tempfile::tempdir().unwrap();
+        let pdf = tmp.path().join("report.pdf");
         std::fs::write(&pdf, b"%PDF-1.7\nnot an image").unwrap();
 
         let mut result = screenshot_result(pdf.to_str().unwrap());
-        attach_screenshot_image(&mut result);
+        attach_screenshot_image_within(&mut result, MAX_INLINE_IMAGE_BYTES);
 
         assert!(image_blocks(&result).is_empty());
         let texts: Vec<&str> = result["content"]
@@ -2077,7 +2098,48 @@ mod tests {
             texts.iter().any(|t| t.contains("not a recognized image")),
             "expected an explanation, got {texts:?}"
         );
-        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_zero_budget_disables_inlining_without_a_note() {
+        // Switching inlining off is a host decision, not a failure: the agent
+        // asked for a file on disk and got one. Appending "you cannot see it"
+        // on every capture would be noise the agent can do nothing about.
+        let tmp = tempfile::tempdir().unwrap();
+        let png = tmp.path().join("shot.png");
+        std::fs::write(&png, b"\x89PNG\r\n\x1a\npixels").unwrap();
+
+        let mut result = screenshot_result(png.to_str().unwrap());
+        attach_screenshot_image_within(&mut result, 0);
+
+        assert!(image_blocks(&result).is_empty());
+        assert_eq!(
+            result["content"].as_array().unwrap().len(),
+            1,
+            "no extra block of any kind when inlining is off"
+        );
+    }
+
+    #[test]
+    fn the_budget_override_is_read_from_the_environment() {
+        let guard = crate::test_utils::EnvGuard::new(&[MAX_INLINE_IMAGE_BYTES_VAR]);
+
+        guard.remove(MAX_INLINE_IMAGE_BYTES_VAR);
+        assert_eq!(max_inline_image_bytes(), MAX_INLINE_IMAGE_BYTES);
+
+        guard.set(MAX_INLINE_IMAGE_BYTES_VAR, "4096");
+        assert_eq!(max_inline_image_bytes(), 4096);
+
+        guard.set(MAX_INLINE_IMAGE_BYTES_VAR, "0");
+        assert_eq!(
+            max_inline_image_bytes(),
+            0,
+            "0 must mean 'off', not 'unset'"
+        );
+
+        // Garbage must not fail the screenshot — fall back to the default.
+        guard.set(MAX_INLINE_IMAGE_BYTES_VAR, "two megabytes");
+        assert_eq!(max_inline_image_bytes(), MAX_INLINE_IMAGE_BYTES);
     }
 
     #[test]

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -280,7 +280,7 @@ fn build_schema(props: serde_json::Map<String, Value>, required: &[&str]) -> Val
         "session".to_string(),
         json!({
             "type": "string",
-            "description": "Isolated session name (chrome-use --session <name>); omit to use the default session.",
+            "description": "Isolated session name (chrome-use --session <name>). Each session gets its own tab group, browser tab and element refs. Omit it unless several agents share ONE MCP server — the session is otherwise derived per agent automatically. When you do share a server with sibling agents, pass a name unique to you on every call, or you will drive their tabs and invalidate their refs.",
         }),
     );
     props.insert(
@@ -961,7 +961,90 @@ fn call_screenshot(arguments: &Value) -> Result<Value, ProtocolError> {
     if let Some(path) = optional_string(arguments, "path")? {
         args.push(path);
     }
-    run_tool(arguments, args)
+    let mut result = run_tool(arguments, args)?;
+    attach_screenshot_image(&mut result);
+    Ok(result)
+}
+
+/// Largest capture we will inline, in raw bytes before base64. A full-page
+/// capture of a long document can run to tens of MB; inlining that would bloat
+/// the response for no benefit when the file is right there on disk.
+const MAX_INLINE_IMAGE_BYTES: u64 = 2_000_000;
+
+/// Identify the image format from its magic bytes.
+///
+/// Deliberately NOT from the file extension: the caller chooses the output path,
+/// and the daemon writes PNG bytes to whatever name it is given — so a
+/// `path: "shot.jpg"` would otherwise be labelled `image/jpeg` while containing
+/// PNG, and a client decoding by `mimeType` gets garbage.
+fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        Some("image/png")
+    } else if bytes.starts_with(b"\xff\xd8\xff") {
+        Some("image/jpeg")
+    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        Some("image/webp")
+    } else {
+        None
+    }
+}
+
+/// Attach the capture to the tool result as an MCP image block.
+///
+/// The CLI writes the capture to disk and reports only its path, so without this
+/// an agent driving chrome-use over MCP gets a filename it cannot open and is
+/// effectively blind. The text block is left untouched so `structuredContent` and
+/// existing path-based consumers keep working.
+///
+/// Every failure path appends an explanation. A screenshot that silently comes
+/// back text-only is indistinguishable from a successful one, which leaves the
+/// agent blind and unaware of it.
+fn attach_screenshot_image(result: &mut Value) {
+    let Some(path) = result
+        .get("structuredContent")
+        .and_then(|s| s.get("response"))
+        .and_then(|r| r.get("path"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+    let path = std::path::PathBuf::from(path);
+
+    // Never fail the screenshot itself because the inline copy didn't work.
+    let note = match std::fs::metadata(&path) {
+        Err(e) => format!("Screenshot saved but could not be inlined: {e}"),
+        Ok(meta) if meta.len() > MAX_INLINE_IMAGE_BYTES => format!(
+            "Screenshot saved but too large to inline ({} bytes > {} limit). \
+             Re-run with a smaller maxWidth/scale, or read the file at the path above.",
+            meta.len(),
+            MAX_INLINE_IMAGE_BYTES
+        ),
+        Ok(_) => match std::fs::read(&path) {
+            Err(e) => format!("Screenshot saved but could not be inlined: {e}"),
+            Ok(bytes) => match sniff_image_mime(&bytes) {
+                None => format!(
+                    "Saved file at the path above is not a recognized image \
+                     (PNG/JPEG/WebP), so it was not inlined — you cannot see it."
+                ),
+                Some(mime) => {
+                    use base64::Engine;
+                    let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                    if let Some(content) = result.get_mut("content").and_then(Value::as_array_mut) {
+                        content.push(json!({
+                            "type": "image",
+                            "data": data,
+                            "mimeType": mime,
+                        }));
+                    }
+                    return;
+                }
+            },
+        },
+    };
+
+    if let Some(content) = result.get_mut("content").and_then(Value::as_array_mut) {
+        content.push(json!({ "type": "text", "text": note }));
+    }
 }
 
 /// `scroll [direction] [amount] [--selector <sel>] [--at <x,y>] [--frame <n>]`.
@@ -1841,5 +1924,176 @@ mod tests {
             all_names.len(),
             core_names.len() + EXTENDED_ONLY_TOOL_NAMES.len()
         );
+    }
+
+    /// Shape a screenshot tool result the way `tool_result_from_run` builds it.
+    fn screenshot_result(path: &str) -> Value {
+        json!({
+            "content": [{ "type": "text", "text": "{}" }],
+            "structuredContent": { "response": { "path": path } },
+            "isError": false,
+        })
+    }
+
+    fn image_blocks(v: &Value) -> Vec<&Value> {
+        v["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|b| b["type"] == "image")
+            .collect()
+    }
+
+    #[test]
+    fn screenshot_is_inlined_as_an_image_block() {
+        let dir = std::env::temp_dir().join("chrome-use-mcp-img-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let png = dir.join("shot.png");
+        // Not a real PNG; the encoder only cares about the bytes and extension.
+        std::fs::write(&png, b"\x89PNG\r\n\x1a\nfake-pixels").unwrap();
+
+        let mut result = screenshot_result(png.to_str().unwrap());
+        attach_screenshot_image(&mut result);
+
+        let imgs = image_blocks(&result);
+        assert_eq!(imgs.len(), 1, "expected exactly one image block");
+        assert_eq!(imgs[0]["mimeType"], "image/png");
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(imgs[0]["data"].as_str().unwrap())
+            .expect("data must be valid base64");
+        assert_eq!(decoded, b"\x89PNG\r\n\x1a\nfake-pixels");
+        // The original text block must survive for existing consumers.
+        assert_eq!(result["content"][0]["type"], "text");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn jpeg_screenshot_gets_jpeg_mime() {
+        let dir = std::env::temp_dir().join("chrome-use-mcp-jpg-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let jpg = dir.join("shot.jpg");
+        std::fs::write(&jpg, b"\xff\xd8\xff-fake").unwrap();
+
+        let mut result = screenshot_result(jpg.to_str().unwrap());
+        attach_screenshot_image(&mut result);
+
+        assert_eq!(image_blocks(&result)[0]["mimeType"], "image/jpeg");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_capture_says_so_instead_of_going_quiet() {
+        // A blind agent must be told it is blind — never a silently text-only
+        // result that looks like a successful screenshot.
+        let mut result = screenshot_result(
+            std::env::temp_dir()
+                .join("definitely-not-here-9f3a.png")
+                .to_str()
+                .unwrap(),
+        );
+        attach_screenshot_image(&mut result);
+
+        assert!(image_blocks(&result).is_empty());
+        let texts: Vec<&str> = result["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|b| b["text"].as_str())
+            .collect();
+        assert!(
+            texts.iter().any(|t| t.contains("could not be inlined")),
+            "expected an explicit note, got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn oversize_capture_explains_the_limit() {
+        let dir = std::env::temp_dir().join("chrome-use-mcp-big-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let png = dir.join("huge.png");
+        std::fs::write(&png, vec![0u8; (MAX_INLINE_IMAGE_BYTES + 1) as usize]).unwrap();
+
+        let mut result = screenshot_result(png.to_str().unwrap());
+        attach_screenshot_image(&mut result);
+
+        assert!(image_blocks(&result).is_empty(), "must not inline oversize");
+        let texts: Vec<&str> = result["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|b| b["text"].as_str())
+            .collect();
+        assert!(
+            texts.iter().any(|t| t.contains("too large to inline")),
+            "expected a size explanation, got {texts:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn png_bytes_at_a_jpg_path_are_labelled_png() {
+        // The caller picks the output path and the daemon writes PNG bytes to
+        // whatever name it is given, so `path: "shot.jpg"` must NOT become
+        // image/jpeg — a client decoding by mimeType would get garbage.
+        let dir = std::env::temp_dir().join("chrome-use-mcp-mislabel-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let lying = dir.join("actually-a-png.jpg");
+        std::fs::write(&lying, b"\x89PNG\r\n\x1a\npixels").unwrap();
+
+        let mut result = screenshot_result(lying.to_str().unwrap());
+        attach_screenshot_image(&mut result);
+
+        assert_eq!(
+            image_blocks(&result)[0]["mimeType"],
+            "image/png",
+            "mime must come from the bytes, not the extension"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_non_image_file_is_explained_not_silently_skipped() {
+        // Anything that isn't a decodable image must still tell the agent it
+        // cannot see — a silently text-only result looks like success.
+        let dir = std::env::temp_dir().join("chrome-use-mcp-nonimage-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let pdf = dir.join("report.pdf");
+        std::fs::write(&pdf, b"%PDF-1.7\nnot an image").unwrap();
+
+        let mut result = screenshot_result(pdf.to_str().unwrap());
+        attach_screenshot_image(&mut result);
+
+        assert!(image_blocks(&result).is_empty());
+        let texts: Vec<&str> = result["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|b| b["text"].as_str())
+            .collect();
+        assert!(
+            texts.iter().any(|t| t.contains("not a recognized image")),
+            "expected an explanation, got {texts:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sniffs_the_three_supported_formats() {
+        assert_eq!(sniff_image_mime(b"\x89PNG\r\n\x1a\nx"), Some("image/png"));
+        assert_eq!(
+            sniff_image_mime(b"\xff\xd8\xff\xe0junk"),
+            Some("image/jpeg")
+        );
+        assert_eq!(
+            sniff_image_mime(b"RIFF\x00\x00\x00\x00WEBPVP8 "),
+            Some("image/webp")
+        );
+        assert_eq!(sniff_image_mime(b"%PDF-1.7"), None);
+        assert_eq!(sniff_image_mime(b""), None);
+        // Truncated RIFF must not index past the end.
+        assert_eq!(sniff_image_mime(b"RIFF"), None);
     }
 }

--- a/docs/en/mcp.html
+++ b/docs/en/mcp.html
@@ -109,7 +109,7 @@
         <tbody>
           <tr><td><code>chrome_use_hover</code></td><td>Hover the pointer over an element</td></tr>
           <tr><td><code>chrome_use_select</code></td><td>Pick an option in a <code>&lt;select&gt;</code> dropdown</td></tr>
-          <tr><td><code>chrome_use_screenshot</code></td><td>Capture a screenshot (output only, not for reading)</td></tr>
+          <tr><td><code>chrome_use_screenshot</code></td><td>Capture a screenshot; the result carries an MCP image block alongside the file path (still read pages with <code>snapshot</code> — a capture is for confirming what something looks like). <code>CHROME_USE_MCP_MAX_INLINE_IMAGE_BYTES</code> changes the inline budget; <code>0</code> returns the path only</td></tr>
           <tr><td><code>chrome_use_scroll</code></td><td>Scroll the page or a container</td></tr>
           <tr><td><code>chrome_use_tabs</code></td><td>List, open, natively duplicate, adopt without navigation, inspect browser-level state, close, or switch this session's tabs</td></tr>
           <tr><td><code>chrome_use_extract</code></td><td>Scrape the page into structured JSON by schema</td></tr>

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -106,7 +106,7 @@
         <tbody>
           <tr><td><code>chrome_use_hover</code></td><td>把鼠标悬停到某个元素上</td></tr>
           <tr><td><code>chrome_use_select</code></td><td>选中 <code>&lt;select&gt;</code> 下拉项</td></tr>
-          <tr><td><code>chrome_use_screenshot</code></td><td>截图（仅作输出，不作为读取手段）</td></tr>
+          <tr><td><code>chrome_use_screenshot</code></td><td>截图；结果里除了文件路径还会带一个 MCP image 块（读页面仍然用 <code>snapshot</code>，截图只用来确认视觉）。设 <code>CHROME_USE_MCP_MAX_INLINE_IMAGE_BYTES</code> 可调整内联上限，设 <code>0</code> 则只返回路径</td></tr>
           <tr><td><code>chrome_use_scroll</code></td><td>滚动页面或某个容器</td></tr>
           <tr><td><code>chrome_use_tabs</code></td><td>列出、新建、原生复制、无导航接管、浏览器级检查、关闭或切换本会话的标签</td></tr>
           <tr><td><code>chrome_use_extract</code></td><td>按 schema 把页面抓成结构化 JSON</td></tr>


### PR DESCRIPTION
Fixes #178

## 摘要

MCP 的 `screenshot` 只返回磁盘路径，而 agent 打不开本地文件，等于拿不到截图。本 PR 把图片作为 MCP image block 内联返回（magic-byte 嗅探 MIME，2 MB 上限），路径照常保留。所有失败分支都会附带说明，避免纯文本结果被当成截图成功。

---

## The problem

`call_screenshot` in `cli/src/mcp.rs` returns the on-disk path. An MCP client has no filesystem access to the machine running the server, so the model receives a path it cannot open and reasons as if it had seen the page.

The failure is silent. A text-only result looks like success.

## The change

`call_screenshot` now attaches the capture as an MCP image block alongside the existing path:

- MIME comes from a magic-byte sniff, not the file extension. PNG bytes written to a `.jpg` path are labelled `image/png`.
- 2 MB inline cap (`MAX_INLINE_IMAGE_BYTES`). Over that, the result explains the limit instead of dropping the image without comment.
- Every failure path appends an explanation: missing capture, oversize capture, unrecognised format. A text-only result now always says why.

The path stays in the response, so existing callers that read from disk keep working.

## Tests

175 lines of new tests in the same file:

- screenshot is inlined as an image block
- JPEG capture gets JPEG MIME
- missing capture says so instead of going quiet
- oversize capture explains the limit
- PNG bytes at a `.jpg` path are labelled PNG
- a non-image file is explained, not silently skipped
- MIME sniffing across the three supported formats

## Scope

One file, `cli/src/mcp.rs`. No new dependencies. No behaviour change for the CLI.
