### PR TITLE
fix: drive the cursor for DOM-dispatched clicks, hide it during capture (#179)

### DIFF
--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -21,6 +21,66 @@ fn prefer_dom_dispatch(ref_map: &RefMap, selector_or_ref: &str) -> bool {
     ref_map.ref_is_in_iframe(selector_or_ref) || crate::connect::relay_url().is_some()
 }
 
+/// How long the cursor is shown travelling to the target before the click fires.
+/// Without a lead the overlay and the click land in the same frame and the click
+/// reads as instantaneous — you see the aftermath, never the movement.
+const CURSOR_LEAD_MS: u64 = 250;
+
+/// Whether the extension's cursor overlay is switched on: 0 = unknown, 1 = on,
+/// 2 = off. The overlay is an extension-side setting the daemon can't read, so we
+/// learn it from the first `ABExt.driveCursor` reply and then stop paying for the
+/// round trip when it's off (the common case). Toggling the setting takes effect
+/// on the next daemon start.
+static CURSOR_STATE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+/// True once we've confirmed the overlay is switched off, so callers can skip
+/// cursor round trips entirely on the default path.
+pub fn cursor_known_off() -> bool {
+    CURSOR_STATE.load(std::sync::atomic::Ordering::Relaxed) == 2
+}
+
+/// Mirror a DOM-dispatched click onto the on-page cursor overlay.
+///
+/// The extension mirrors `Input.dispatchMouseEvent` automatically, but a relay
+/// click goes through the DOM and produces no such event — so with the overlay
+/// enabled the pointer sat motionless while things got clicked. Best-effort
+/// throughout: a failure here must never fail the click.
+async fn drive_cursor(client: &CdpClient, session_id: &str, x: f64, y: f64, click: bool) {
+    use std::sync::atomic::Ordering;
+    if CURSOR_STATE.load(Ordering::Relaxed) == 2 {
+        return;
+    }
+    let reply = client
+        .send_command_typed::<_, serde_json::Value>(
+            "ABExt.driveCursor",
+            &serde_json::json!({ "sessionId": session_id, "x": x, "y": y, "click": click }),
+            None,
+        )
+        .await;
+    match reply {
+        // Only an explicit `disabled` proves the overlay is off. `no-tab` and
+        // `bad-coords` are transient — caching them would silently kill the
+        // cursor (and the hide-during-screenshot) for the daemon's whole life.
+        Ok(v) => {
+            let drawn = v.get("drawn").and_then(serde_json::Value::as_bool);
+            let reason = v.get("reason").and_then(serde_json::Value::as_str);
+            let next = match (drawn, reason) {
+                (Some(true), _) => 1,
+                (Some(false), Some("disabled")) => 2,
+                _ => return, // transient: leave the state as-is and retry later
+            };
+            CURSOR_STATE.store(next, Ordering::Relaxed);
+        }
+        // An extension predating `ABExt.driveCursor` errors every time. Stop
+        // paying resolve + two round trips + the lead delay on every click — but
+        // only if the cursor has never worked; a hiccup shouldn't disable a
+        // cursor we've already seen drawing.
+        Err(_) => {
+            let _ = CURSOR_STATE.compare_exchange(0, 2, Ordering::Relaxed, Ordering::Relaxed);
+        }
+    }
+}
+
 pub async fn click(
     client: &CdpClient,
     session_id: &str,
@@ -88,6 +148,24 @@ pub async fn click(
         && click_count == 1
         && crate::connect::relay_url().is_some()
     {
+        // Show the cursor travelling to the target before the DOM click fires.
+        // Skipped entirely once we know the overlay is off, so the default path
+        // costs nothing. Resolution failures just mean no cursor, never no click.
+        if CURSOR_STATE.load(std::sync::atomic::Ordering::Relaxed) != 2 {
+            if let Ok((cx, cy, _w, _h, cursor_session)) = resolve_element_center(
+                client,
+                session_id,
+                ref_map,
+                selector_or_ref,
+                iframe_sessions,
+            )
+            .await
+            {
+                drive_cursor(client, &cursor_session, cx, cy, false).await;
+                tokio::time::sleep(std::time::Duration::from_millis(CURSOR_LEAD_MS)).await;
+                drive_cursor(client, &cursor_session, cx, cy, true).await;
+            }
+        }
         return dom_click(
             client,
             session_id,

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -39,6 +39,32 @@ pub fn cursor_known_off() -> bool {
     CURSOR_STATE.load(std::sync::atomic::Ordering::Relaxed) == 2
 }
 
+/// Consecutive inconclusive `ABExt.driveCursor` replies (`no-tab`, `bad-coords`,
+/// a shape we don't recognize) before the cursor is treated as off. Those are
+/// transient in principle, so one of them must not disable the cursor — but an
+/// extension that returns them *every* time would otherwise make every click pay
+/// a rect lookup, two round trips and [`CURSOR_LEAD_MS`] forever.
+const CURSOR_INCONCLUSIVE_LIMIT: u8 = 3;
+
+static CURSOR_INCONCLUSIVE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+/// What one `ABExt.driveCursor` reply says about the overlay: `Some(state)` to
+/// move [`CURSOR_STATE`] there, `None` when the reply proves nothing.
+///
+/// Split out from the round trip so the decision table is unit-testable — the
+/// caller needs a live CDP client, this doesn't.
+fn cursor_state_from_reply(drawn: Option<bool>, reason: Option<&str>) -> Option<u8> {
+    match (drawn, reason) {
+        (Some(true), _) => Some(1),
+        // Only an explicit `disabled` proves the overlay is off. `no-tab` and
+        // `bad-coords` are transient — caching them on the first sighting would
+        // silently kill the cursor (and the hide-during-screenshot that depends
+        // on it) for the daemon's whole life.
+        (Some(false), Some("disabled")) => Some(2),
+        _ => None,
+    }
+}
+
 /// Mirror a DOM-dispatched click onto the on-page cursor overlay.
 ///
 /// The extension mirrors `Input.dispatchMouseEvent` automatically, but a relay
@@ -58,23 +84,32 @@ async fn drive_cursor(client: &CdpClient, session_id: &str, x: f64, y: f64, clic
         )
         .await;
     match reply {
-        // Only an explicit `disabled` proves the overlay is off. `no-tab` and
-        // `bad-coords` are transient — caching them would silently kill the
-        // cursor (and the hide-during-screenshot) for the daemon's whole life.
         Ok(v) => {
             let drawn = v.get("drawn").and_then(serde_json::Value::as_bool);
             let reason = v.get("reason").and_then(serde_json::Value::as_str);
-            let next = match (drawn, reason) {
-                (Some(true), _) => 1,
-                (Some(false), Some("disabled")) => 2,
-                _ => return, // transient: leave the state as-is and retry later
-            };
-            CURSOR_STATE.store(next, Ordering::Relaxed);
+            match cursor_state_from_reply(drawn, reason) {
+                Some(next) => {
+                    CURSOR_INCONCLUSIVE.store(0, Ordering::Relaxed);
+                    CURSOR_STATE.store(next, Ordering::Relaxed);
+                }
+                // Inconclusive: keep the state, but stop retrying forever.
+                None => {
+                    let seen = CURSOR_INCONCLUSIVE.fetch_add(1, Ordering::Relaxed) + 1;
+                    if seen >= CURSOR_INCONCLUSIVE_LIMIT {
+                        let _ = CURSOR_STATE.compare_exchange(
+                            0,
+                            2,
+                            Ordering::Relaxed,
+                            Ordering::Relaxed,
+                        );
+                    }
+                }
+            }
         }
         // An extension predating `ABExt.driveCursor` errors every time. Stop
-        // paying resolve + two round trips + the lead delay on every click — but
-        // only if the cursor has never worked; a hiccup shouldn't disable a
-        // cursor we've already seen drawing.
+        // paying the rect lookup + two round trips + the lead delay on every
+        // click — but only if the cursor has never worked; a hiccup shouldn't
+        // disable a cursor we've already seen drawing.
         Err(_) => {
             let _ = CURSOR_STATE.compare_exchange(0, 2, Ordering::Relaxed, Ordering::Relaxed);
         }
@@ -148,24 +183,6 @@ pub async fn click(
         && click_count == 1
         && crate::connect::relay_url().is_some()
     {
-        // Show the cursor travelling to the target before the DOM click fires.
-        // Skipped entirely once we know the overlay is off, so the default path
-        // costs nothing. Resolution failures just mean no cursor, never no click.
-        if CURSOR_STATE.load(std::sync::atomic::Ordering::Relaxed) != 2 {
-            if let Ok((cx, cy, _w, _h, cursor_session)) = resolve_element_center(
-                client,
-                session_id,
-                ref_map,
-                selector_or_ref,
-                iframe_sessions,
-            )
-            .await
-            {
-                drive_cursor(client, &cursor_session, cx, cy, false).await;
-                tokio::time::sleep(std::time::Duration::from_millis(CURSOR_LEAD_MS)).await;
-                drive_cursor(client, &cursor_session, cx, cy, true).await;
-            }
-        }
         return dom_click(
             client,
             session_id,
@@ -349,6 +366,7 @@ async fn dom_click(
         iframe_sessions,
     )
     .await?;
+    show_cursor_travelling_to(client, session_id, &effective_session_id, &object_id).await;
     client
         .send_command_typed::<_, Value>(
             "Runtime.callFunctionOn",
@@ -364,6 +382,65 @@ async fn dom_click(
         .await?;
     wait_for_paint_settled(client, &effective_session_id).await;
     Ok(())
+}
+
+/// Move the on-page cursor onto the element a DOM click is about to hit, then
+/// mark the click — the visible half of what `Input.dispatchMouseEvent` gives
+/// for free on the coordinate path.
+///
+/// The centre comes from the object we already resolved for the click, not from
+/// a second `resolve_element_center`: that would re-run identity verification
+/// and occlusion checks for a purely cosmetic overlay, and could resolve a
+/// *different* node than the one being clicked if the page moved in between.
+///
+/// Skipped for an element inside an iframe: `getBoundingClientRect` there is
+/// frame-local, and the overlay lives in the top document, so the cursor would
+/// be drawn somewhere the element isn't. Best-effort throughout — no cursor is
+/// always better than no click.
+async fn show_cursor_travelling_to(
+    client: &CdpClient,
+    page_session_id: &str,
+    effective_session_id: &str,
+    object_id: &str,
+) {
+    // The overlay is an extension feature: on a browser we launched ourselves
+    // there is nobody to answer `ABExt.driveCursor`.
+    if CURSOR_STATE.load(std::sync::atomic::Ordering::Relaxed) == 2
+        || effective_session_id != page_session_id
+        || crate::connect::relay_url().is_none()
+    {
+        return;
+    }
+    let rect = client
+        .send_command_typed::<_, Value>(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: "function() { const r = this.getBoundingClientRect(); \
+                     return { x: r.left + r.width / 2, y: r.top + r.height / 2 }; }"
+                    .to_string(),
+                object_id: Some(object_id.to_string()),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(effective_session_id),
+        )
+        .await;
+    let Some(value) = rect
+        .ok()
+        .and_then(|v| v.get("result")?.get("value").cloned())
+    else {
+        return;
+    };
+    let (Some(x), Some(y)) = (
+        value.get("x").and_then(Value::as_f64),
+        value.get("y").and_then(Value::as_f64),
+    ) else {
+        return;
+    };
+    drive_cursor(client, page_session_id, x, y, false).await;
+    tokio::time::sleep(std::time::Duration::from_millis(CURSOR_LEAD_MS)).await;
+    drive_cursor(client, page_session_id, x, y, true).await;
 }
 
 /// Trusted activation of an element inside an iframe (issue #39). Focuses the
@@ -2891,5 +2968,39 @@ mod tests {
         assert_eq!(key_text("ArrowUp"), None);
         assert_eq!(key_text("Backspace"), None);
         assert_eq!(key_text("Delete"), None);
+    }
+
+    #[test]
+    fn a_drawn_cursor_marks_the_overlay_on() {
+        assert_eq!(cursor_state_from_reply(Some(true), None), Some(1));
+        // `drawn: true` wins regardless of any reason riding along.
+        assert_eq!(cursor_state_from_reply(Some(true), Some("no-tab")), Some(1));
+    }
+
+    #[test]
+    fn only_an_explicit_disabled_switches_the_cursor_off() {
+        assert_eq!(
+            cursor_state_from_reply(Some(false), Some("disabled")),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn transient_refusals_prove_nothing_about_the_overlay() {
+        // `no-tab` happens when the session's tab isn't registered yet on the
+        // first click; `bad-coords` when the element resolved to something
+        // degenerate. Treating either as "off" would kill the cursor — and the
+        // hide-during-screenshot that rides on the same state — for the rest of
+        // the daemon's life, so both must stay inconclusive.
+        assert_eq!(cursor_state_from_reply(Some(false), Some("no-tab")), None);
+        assert_eq!(
+            cursor_state_from_reply(Some(false), Some("bad-coords")),
+            None
+        );
+        // An unrecognized shape (a newer/older extension) is inconclusive too,
+        // never a silent "off".
+        assert_eq!(cursor_state_from_reply(None, None), None);
+        assert_eq!(cursor_state_from_reply(Some(false), None), None);
+        assert_eq!(cursor_state_from_reply(None, Some("something-new")), None);
     }
 }

--- a/cli/src/native/screenshot.rs
+++ b/cli/src/native/screenshot.rs
@@ -134,8 +134,15 @@ pub async fn take_screenshot(
         false
     };
 
+    // Hide the agent cursor so it isn't baked into an image the model then
+    // reasons about (it would read as page content). Skipped when the overlay is
+    // known to be off; best-effort either way.
+    set_cursor_visible(client, session_id, false).await;
+
     let base64 =
         capture_screenshot_base64(client, session_id, ref_map, options, iframe_sessions).await;
+
+    set_cursor_visible(client, session_id, true).await;
 
     if overlay_injected {
         let _ = remove_annotation_overlay(client, session_id).await;
@@ -170,6 +177,21 @@ pub async fn take_screenshot(
         base64,
         annotations,
     })
+}
+
+/// Show/hide the extension's cursor overlay around a capture. No-op on a launched
+/// browser or an extension that predates `ABExt.setCursorVisible`.
+async fn set_cursor_visible(client: &CdpClient, session_id: &str, visible: bool) {
+    if crate::native::interaction::cursor_known_off() || crate::connect::relay_url().is_none() {
+        return;
+    }
+    let _ = client
+        .send_command_typed::<_, serde_json::Value>(
+            "ABExt.setCursorVisible",
+            &serde_json::json!({ "sessionId": session_id, "visible": visible }),
+            None,
+        )
+        .await;
 }
 
 async fn capture_screenshot_base64(

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -706,6 +706,56 @@ async function handleForwardCdpCommand(msg) {
     return { ungrouped: tabId ?? null }
   }
 
+  // Drive the on-page cursor explicitly. `maybeDriveCursor` below mirrors
+  // `Input.dispatchMouseEvent`, but on the relay a left click is dispatched
+  // through the DOM instead (see `prefer_dom_dispatch` in the daemon), which
+  // never produces a mouse event for it to mirror — so those clicks were
+  // invisible even with the overlay switched on. The daemon resolves the element
+  // centre and calls this directly for that path. No-op when the cursor is off.
+  if (method === 'ABExt.driveCursor') {
+    const tabId = tabIdFromSession(sessionId) ?? tabForSession(sessionId)
+    const x = Number(params?.x)
+    const y = Number(params?.y)
+    // `reason` matters: the daemon caches "disabled" to stop paying for the round
+    // trip, but must NOT cache a transient no-tab (a session tab not registered
+    // yet on the first click) — that would switch the cursor off for the rest of
+    // the daemon's life, including the hide-during-screenshot it depends on.
+    if (!cursorEnabled) return { drawn: false, reason: 'disabled' }
+    if (tabId == null) return { drawn: false, reason: 'no-tab' }
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      return { drawn: false, reason: 'bad-coords' }
+    }
+    await sendCdpToTab(tabId, 'Runtime.evaluate', {
+      // Clear `display` first: a screenshot whose restore round-trip failed would
+      // otherwise leave the overlay hidden forever (the draw path only touches
+      // opacity/transform), so drawing self-heals it.
+      expression:
+        '(function(){try{var c=window.__abCursor;if(c&&c.host)c.host.style.display="";}catch(e){}})();' +
+        cursorOverlayExpression(x, y, !!params?.click),
+      returnByValue: false,
+      awaitPromise: false,
+    }).catch(() => {})
+    return { drawn: true }
+  }
+
+  // Hide/show the overlay around a capture so the cursor doesn't end up baked
+  // into screenshots the agent then reasons about.
+  if (method === 'ABExt.setCursorVisible') {
+    const tabId = tabIdFromSession(sessionId) ?? tabForSession(sessionId)
+    if (!cursorEnabled || tabId == null) return { applied: false }
+    const show = !!params?.visible
+    await sendCdpToTab(tabId, 'Runtime.evaluate', {
+      expression:
+        '(function(){try{var c=window.__abCursor;if(!c||!c.host)return;' +
+        'c.host.style.display=' +
+        (show ? '""' : '"none"') +
+        ';}catch(e){}})()',
+      returnByValue: false,
+      awaitPromise: false,
+    }).catch(() => {})
+    return { applied: true }
+  }
+
   // On-demand adopt of a PRE-EXISTING tab (the user's own, or another session's).
   // Since we no longer eagerly attach the user's tabs (banner!), `adopt <spec>`
   // can't find them via the already-attached target list — so discover by


### PR DESCRIPTION
Fixes #179

## 摘要

两个相关的光标问题：(1) DOM 派发的点击不会产生 `Input.dispatchMouseEvent`，所以页面上的光标不动，看起来像没点；(2) 截图时光标被一起拍进去，模型会把它当成页面内容。本 PR 在 DOM 点击前显式驱动光标，并在截图前后隐藏/恢复它。

---

## Problem 1: DOM clicks move nothing

`prefer_dom_dispatch` routes some clicks through DOM dispatch instead of `Input.dispatchMouseEvent`. CDP input events drive the on-page cursor overlay; DOM dispatch produces no mirror event, so the cursor stays where it was. Watching a recording, the click looks like it never happened.

## Problem 2: the cursor lands in screenshots

`take_screenshot` captured with the overlay visible. The model then reads a rendered cursor as page content.

## The change

**`extensions/ab-connect/background.js`** — two new handlers:
- `ABExt.driveCursor` moves the overlay explicitly, for the DOM-dispatch path
- `ABExt.setCursorVisible` toggles it

**`cli/src/native/interaction.rs`** — drives the cursor before a DOM click, with a short lead-in so the movement is visible rather than teleporting. A failure to resolve the cursor means "no cursor", never "no click": the click still fires.

**`cli/src/native/screenshot.rs`** — hides the overlay around `capture_screenshot_base64` and restores it after. Skipped when the overlay is known to be off or there is no relay, so a launched (non-extension) browser pays nothing.

## Compatibility

`set_cursor_visible` is best-effort and returns early when `cursor_known_off()` or no relay URL is set. An extension older than this change simply ignores the command, and capture proceeds as before. No version gate needed.

## Note on overlap

This touches `cli/src/native/interaction.rs`, which #168 recently reworked around `fill`/`press`/`focus`. The hunks are disjoint (mine sit at the top of the file, around `prefer_dom_dispatch` and `click`) and it rebases onto v1.5.89 without conflict, but a second pair of eyes on the interaction there is welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved on-page cursor support for DOM-dispatched clicks.
  * Cursor placement now targets the resolved element before clicks when supported.
  * Added automatic cursor visibility handling during screenshot capture.

* **Bug Fixes**
  * Improved handling of unsupported, disabled, iframe, and unavailable cursor contexts.
  * Cursor overlays now recover visibility more reliably after interactions and screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->