### PR TITLE
feat: derive the session name from agent identity before terminal identity (#180)

### DIFF
--- a/cli/src/doctor/environment.rs
+++ b/cli/src/doctor/environment.rs
@@ -35,6 +35,28 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         )),
     }
 
+    // Which session this shell resolves to, and why. The name decides the tab
+    // group, the daemon port and where `keep`/handoff state lives, and it can be
+    // derived from an env var this build has never heard of (any
+    // `<PRODUCT>_SESSION_ID`-style name) — so "why am I on a different session
+    // than I expected?" needs an answer that doesn't involve reading the source.
+    let (derived, source) = crate::flags::describe_default_session();
+    let detail = match source {
+        Some(var) => format!("Default session {derived} (derived from {var})"),
+        None => format!("Default session {derived} (no per-agent env id found)"),
+    };
+    // Reported as the DEFAULT, not as "the session you are on": `--session`, the
+    // config file and `AGENT_BROWSER_SESSION` all override it, and doctor has no
+    // command line to inspect.
+    let detail = match std::env::var("AGENT_BROWSER_SESSION")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        Some(explicit) => format!("{detail}; overridden by AGENT_BROWSER_SESSION={explicit}"),
+        None => detail,
+    };
+    checks.push(Check::new("env.session", category, Status::Pass, detail));
+
     let state_dir = get_state_dir();
     let socket_dir = get_socket_dir();
 

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -530,8 +530,8 @@ const AGENT_ID_SUFFIX_DENYLIST: &[&str] = &["XDG_SESSION_ID", "GNOME_DESKTOP_SES
 /// convention. Env iteration order is unspecified, so hits are sorted to keep the
 /// derived session name stable across invocations — an unstable name would spawn
 /// a fresh daemon on every command.
-fn scan_conventional_agent_id(vars: &[(String, String)]) -> Option<String> {
-    let mut hits: Vec<String> = vars
+fn scan_conventional_agent_id(vars: &[(String, String)]) -> Option<(String, String)> {
+    let mut hits: Vec<(String, String)> = vars
         .iter()
         .filter(|(k, v)| {
             !v.is_empty()
@@ -540,8 +540,10 @@ fn scan_conventional_agent_id(vars: &[(String, String)]) -> Option<String> {
                 && !AGENT_ID_VARS.contains(&k.as_str())
                 && !TERMINAL_ID_VARS.contains(&k.as_str())
         })
-        // Key included so two harnesses exporting the same value still differ.
-        .map(|(k, v)| format!("{k}={v}"))
+        // Key included in the id so two harnesses exporting the same value still
+        // differ; also reported as the source, so `doctor` can say which var the
+        // session was keyed on.
+        .map(|(k, v)| (k.clone(), format!("{k}={v}")))
         .collect();
     hits.sort();
     hits.into_iter().next()
@@ -570,16 +572,37 @@ fn default_session_name() -> String {
 /// env to test this would race every other test that reads env — and in a
 /// threaded test binary that is undefined behaviour, not just flakiness.
 fn pick_agent_id(vars: &[(String, String)]) -> Option<String> {
+    pick_agent_id_with_source(vars).map(|(_, id)| id)
+}
+
+/// As [`pick_agent_id`], but also reports WHICH env var the id came from.
+///
+/// The convention scan can key the session on a var nobody here has heard of,
+/// and a wrong hit is close to undebuggable from the outside: the session name
+/// silently changes, so the tab group, the daemon and any `keep`/handoff state
+/// all move with it. `chrome-use doctor` prints this so the answer to "why am I
+/// on a different session?" is one command away.
+fn pick_agent_id_with_source(vars: &[(String, String)]) -> Option<(String, String)> {
     let lookup = |name: &str| {
         vars.iter()
             .find(|(k, v)| k == name && !v.is_empty())
-            .map(|(_, v)| v.clone())
+            .map(|(_, v)| (name.to_string(), v.clone()))
     };
     let first_set = |names: &[&str]| names.iter().find_map(|n| lookup(n));
 
     first_set(AGENT_ID_VARS)
         .or_else(|| scan_conventional_agent_id(vars))
         .or_else(|| first_set(TERMINAL_ID_VARS))
+}
+
+/// The session name this process would derive with no `--session` /
+/// `AGENT_BROWSER_SESSION`, plus the env var it was keyed on (`None` when
+/// nothing stable was found and the name is the historical `default`).
+pub fn describe_default_session() -> (String, Option<String>) {
+    let vars: Vec<(String, String)> = env::vars().collect();
+    let picked = pick_agent_id_with_source(&vars);
+    let source = picked.as_ref().map(|(k, _)| k.clone());
+    (session_name_for(picked.map(|(_, id)| id)), source)
 }
 
 /// Render the session name for a chosen agent id. `None` keeps the historical
@@ -1972,6 +1995,36 @@ mod tests {
         // A different task (different id) -> a different session, no collision.
         let two = session_name_for(pick_agent_id(&env(&[("CODEX_THREAD_ID", "thread-two")])));
         assert_ne!(one, two, "two agents must not collide");
+    }
+
+    #[test]
+    fn the_derivation_reports_which_var_it_keyed_on() {
+        // doctor prints this; without it, a session silently keyed on some
+        // unknown harness var is close to undebuggable from the outside.
+        let explicit = pick_agent_id_with_source(&env(&[("CODEX_THREAD_ID", "t1")]));
+        assert_eq!(
+            explicit,
+            Some(("CODEX_THREAD_ID".to_string(), "t1".to_string()))
+        );
+
+        // A convention hit reports the var name, while the id itself keeps the
+        // `KEY=VALUE` form so two harnesses sharing a value still differ.
+        let scanned = pick_agent_id_with_source(&env(&[("SOMEFUTUREAGENT_SESSION_ID", "t1")]));
+        assert_eq!(
+            scanned,
+            Some((
+                "SOMEFUTUREAGENT_SESSION_ID".to_string(),
+                "SOMEFUTUREAGENT_SESSION_ID=t1".to_string()
+            ))
+        );
+
+        let terminal = pick_agent_id_with_source(&env(&[("WT_SESSION", "tab-guid")]));
+        assert_eq!(
+            terminal,
+            Some(("WT_SESSION".to_string(), "tab-guid".to_string()))
+        );
+
+        assert_eq!(pick_agent_id_with_source(&env(&[])), None);
     }
 
     #[test]

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -470,11 +470,28 @@ pub struct Flags {
 /// that can separate two agents working in the SAME directory (the exact case a
 /// cwd-based name cannot). `AGENT_BROWSER_SESSION_ID` lets a runner inject its
 /// own id explicitly (e.g. cmux can export it per agent).
+///
+/// Resolution runs in three tiers: these explicit agent ids, then any var
+/// following the `<PRODUCT>_SESSION_ID` convention (see [`AGENT_ID_SUFFIXES`]),
+/// then [`TERMINAL_ID_VARS`]. Agent ids must outrank terminal ids — two agents
+/// sharing one terminal tab have distinct agent ids but the SAME `WT_SESSION` /
+/// `TMUX_PANE`, so keying on the terminal would collapse them onto one daemon.
+///
+/// Every id here is inherited by child processes, so a `chrome-use` invoked from
+/// an agent's shell tool resolves to the same session as one invoked by that
+/// agent's MCP server.
 const AGENT_ID_VARS: &[&str] = &[
     "AGENT_BROWSER_SESSION_ID",
+    "OPENCODE_PID",
     "CODEX_THREAD_ID",
     "CMUX_SURFACE_ID",
     "CMUX_CLAUDE_PID",
+    "CLAUDE_PID",
+];
+
+/// Per-terminal ids. Coarser than an agent id (one tab can host several agents),
+/// so these are the last resort before falling back to `default`.
+const TERMINAL_ID_VARS: &[&str] = &[
     "GHOSTTY_SURFACE_ID",
     "TERM_SESSION_ID",
     "ITERM_SESSION_ID",
@@ -483,7 +500,52 @@ const AGENT_ID_VARS: &[&str] = &[
     "TMUX_PANE",
     "STY",
     "WINDOWID",
+    "WT_SESSION",
+    // macOS Terminal.app. Listed here (not left to the convention scan) because
+    // it is per-TERMINAL, not per-agent: two agents in one tab share it. Kept
+    // after TERM_SESSION_ID/ITERM_SESSION_ID so existing macOS users keep the
+    // name they already derive.
+    "SHELL_SESSION_ID",
 ];
+
+/// Naming conventions agent harnesses already follow for a per-session/per-task
+/// id. Matching the CONVENTION rather than a list of products is what makes this
+/// work for a harness nobody here has heard of: any tool exporting
+/// `<PRODUCT>_SESSION_ID` (Claude Code), `<PRODUCT>_THREAD_ID`, or
+/// `<PRODUCT>_CONVERSATION_ID` gets isolation with no change here.
+const AGENT_ID_SUFFIXES: &[&str] = &["_SESSION_ID", "_THREAD_ID", "_CONVERSATION_ID"];
+
+/// Vars that match [`AGENT_ID_SUFFIXES`] but are shared by every process in a
+/// login session or desktop. Keying on one would give every concurrent agent the
+/// SAME name — precisely the collision this mechanism exists to prevent — so they
+/// are excluded rather than silently trusted.
+///
+/// `GNOME_DESKTOP_SESSION_ID` is the dangerous one: modern gnome-session exports
+/// it as the literal constant `this-is-deprecated`, so on a GNOME desktop EVERY
+/// agent would derive an identical name. It also sorts early enough to outrank a
+/// genuine per-task id.
+const AGENT_ID_SUFFIX_DENYLIST: &[&str] = &["XDG_SESSION_ID", "GNOME_DESKTOP_SESSION_ID"];
+
+/// Find a per-agent id from any harness following the `AGENT_ID_SUFFIXES`
+/// convention. Env iteration order is unspecified, so hits are sorted to keep the
+/// derived session name stable across invocations — an unstable name would spawn
+/// a fresh daemon on every command.
+fn scan_conventional_agent_id(vars: &[(String, String)]) -> Option<String> {
+    let mut hits: Vec<String> = vars
+        .iter()
+        .filter(|(k, v)| {
+            !v.is_empty()
+                && AGENT_ID_SUFFIXES.iter().any(|s| k.ends_with(s))
+                && !AGENT_ID_SUFFIX_DENYLIST.contains(&k.as_str())
+                && !AGENT_ID_VARS.contains(&k.as_str())
+                && !TERMINAL_ID_VARS.contains(&k.as_str())
+        })
+        // Key included so two harnesses exporting the same value still differ.
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect();
+    hits.sort();
+    hits.into_iter().next()
+}
 
 /// Auto-derive the default session so concurrent agents don't all collide on one
 /// shared `default` tab group. A session name maps to its own tab group AND
@@ -497,10 +559,34 @@ const AGENT_ID_VARS: &[&str] = &[
 /// `default` — unchanged behaviour, since there's nothing stable to isolate on.
 /// `--session` / `AGENT_BROWSER_SESSION` are resolved before this and override it.
 fn default_session_name() -> String {
-    let Some(agent_id) = AGENT_ID_VARS
-        .iter()
-        .find_map(|v| env::var(v).ok().filter(|s| !s.is_empty()))
-    else {
+    session_name_for(pick_agent_id(&env::vars().collect::<Vec<_>>()))
+}
+
+/// Choose the id to key the session on, in tier order: an explicit/known agent
+/// id, then any var following the `<PRODUCT>_SESSION_ID` convention, then a
+/// terminal id.
+///
+/// Takes the environment as an argument rather than reading it. Mutating process
+/// env to test this would race every other test that reads env — and in a
+/// threaded test binary that is undefined behaviour, not just flakiness.
+fn pick_agent_id(vars: &[(String, String)]) -> Option<String> {
+    let lookup = |name: &str| {
+        vars.iter()
+            .find(|(k, v)| k == name && !v.is_empty())
+            .map(|(_, v)| v.clone())
+    };
+    let first_set = |names: &[&str]| names.iter().find_map(|n| lookup(n));
+
+    first_set(AGENT_ID_VARS)
+        .or_else(|| scan_conventional_agent_id(vars))
+        .or_else(|| first_set(TERMINAL_ID_VARS))
+}
+
+/// Render the session name for a chosen agent id. `None` keeps the historical
+/// `default` behaviour — with nothing stable to isolate on, there is nothing to
+/// isolate.
+fn session_name_for(agent_id: Option<String>) -> String {
+    let Some(agent_id) = agent_id else {
         return "default".to_string();
     };
     let tag = format!("{:06x}", session_hash(&agent_id) & 0x00ff_ffff);
@@ -1858,27 +1944,103 @@ mod tests {
         assert!(sanitize_session_component(&"a".repeat(100)).len() <= 24);
     }
 
+    fn env(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
     #[test]
     fn default_session_isolates_concurrent_agents() {
         use crate::validation::is_valid_session_name;
-        let guard = EnvGuard::new(AGENT_ID_VARS);
-        for &v in AGENT_ID_VARS {
-            guard.remove(v);
-        }
-        // Plain shell with no per-agent id → unchanged "default" behaviour.
-        assert_eq!(default_session_name(), "default");
+        // Plain shell with no per-agent id -> unchanged "default" behaviour.
+        assert_eq!(session_name_for(pick_agent_id(&env(&[]))), "default");
 
         // Codex exposes one stable id per task. Recognizing it is what keeps
         // concurrent Codex tasks in the same checkout off the shared `default`
         // daemon (issue #149).
-        guard.set("CODEX_THREAD_ID", "thread-one-uuid");
-        let one = default_session_name();
+        let one = session_name_for(pick_agent_id(&env(&[("CODEX_THREAD_ID", "thread-one")])));
         assert!(one.starts_with("cu-"), "got {one}");
         assert!(is_valid_session_name(&one));
-        assert_eq!(one, default_session_name(), "must be stable across calls");
+        assert_eq!(
+            one,
+            session_name_for(pick_agent_id(&env(&[("CODEX_THREAD_ID", "thread-one")]))),
+            "must be stable across calls"
+        );
 
-        // A different task (different id) → a different session, no collision.
-        guard.set("CODEX_THREAD_ID", "thread-two-uuid");
-        assert_ne!(one, default_session_name(), "two agents must not collide");
+        // A different task (different id) -> a different session, no collision.
+        let two = session_name_for(pick_agent_id(&env(&[("CODEX_THREAD_ID", "thread-two")])));
+        assert_ne!(one, two, "two agents must not collide");
+    }
+
+    #[test]
+    fn unknown_harness_is_isolated_by_convention() {
+        // A harness this build has never heard of, following the usual naming.
+        let one = pick_agent_id(&env(&[("SOMEFUTUREAGENT_SESSION_ID", "task-one")]));
+        let two = pick_agent_id(&env(&[("SOMEFUTUREAGENT_SESSION_ID", "task-two")]));
+        assert!(one.is_some(), "conventional id should be recognized");
+        assert_ne!(
+            one, two,
+            "an unrecognized harness must still isolate its concurrent tasks"
+        );
+        assert!(session_name_for(one).starts_with("cu-"));
+    }
+
+    #[test]
+    fn agent_id_outranks_terminal_id() {
+        // Two agents sharing ONE terminal tab have the same WT_SESSION but their
+        // own agent ids. The agent id has to win, or they collapse onto a single
+        // daemon and stomp each other's refs -- the exact clash this prevents.
+        let tab = ("WT_SESSION", "same-terminal-tab-guid");
+        let one = pick_agent_id(&env(&[tab, ("SOMEFUTUREAGENT_SESSION_ID", "agent-one")]));
+        let two = pick_agent_id(&env(&[tab, ("SOMEFUTUREAGENT_SESSION_ID", "agent-two")]));
+        assert_ne!(one, two, "agent id must outrank the shared terminal id");
+
+        // With no agent id at all, the terminal id still beats nothing.
+        let terminal_only = pick_agent_id(&env(&[tab]));
+        assert_eq!(terminal_only.as_deref(), Some("same-terminal-tab-guid"));
+        assert_ne!(session_name_for(terminal_only), "default");
+    }
+
+    #[test]
+    fn shared_login_session_ids_are_not_mistaken_for_agent_ids() {
+        // These match the convention but are identical for every process in one
+        // login -- trusting one would give all agents the SAME session, which is
+        // the bug, not the fix. GNOME literally exports the constant string
+        // "this-is-deprecated", so every agent on a GNOME desktop would collide.
+        assert_eq!(pick_agent_id(&env(&[("XDG_SESSION_ID", "3")])), None);
+        assert_eq!(
+            pick_agent_id(&env(&[("GNOME_DESKTOP_SESSION_ID", "this-is-deprecated")])),
+            None
+        );
+        assert_eq!(
+            session_name_for(pick_agent_id(&env(&[("XDG_SESSION_ID", "3")]))),
+            "default"
+        );
+    }
+
+    #[test]
+    fn per_terminal_ids_never_outrank_a_real_agent_id() {
+        // SHELL_SESSION_ID (macOS Terminal.app) ends in _SESSION_ID and would
+        // otherwise be picked up by the convention scan and beat a genuine
+        // per-agent id -- but it is per-TERMINAL, so two agents in one tab share
+        // it. It must resolve in the terminal tier, i.e. only as a last resort.
+        let shell = ("SHELL_SESSION_ID", "one-terminal-tab");
+        let a = pick_agent_id(&env(&[shell, ("SOMEFUTUREAGENT_SESSION_ID", "agent-a")]));
+        let b = pick_agent_id(&env(&[shell, ("SOMEFUTUREAGENT_SESSION_ID", "agent-b")]));
+        assert_ne!(a, b, "two agents in one terminal must not collide");
+
+        // Alone, it is still better than falling back to `default`.
+        assert_eq!(
+            pick_agent_id(&env(&[shell])).as_deref(),
+            Some("one-terminal-tab")
+        );
+
+        // And macOS users already keyed on TERM_SESSION_ID keep that name.
+        assert_eq!(
+            pick_agent_id(&env(&[shell, ("TERM_SESSION_ID", "iterm-guid")])).as_deref(),
+            Some("iterm-guid")
+        );
     }
 }

--- a/docs/en/sessions.html
+++ b/docs/en/sessions.html
@@ -161,9 +161,15 @@
 
       <p>
         When <code>--session</code> is omitted, chrome-use derives a stable per-agent session from supported
-        runner IDs. Codex tasks use <code>CODEX_THREAD_ID</code> automatically; other runners can provide
-        <code>AGENT_BROWSER_SESSION_ID</code>. A plain shell without a runner ID retains the
-        <code>default</code> session. To set an explicit shell default, use
+        runner IDs. Codex tasks use <code>CODEX_THREAD_ID</code> automatically, Claude Code uses
+        <code>CLAUDE_PID</code>, and other runners can provide <code>AGENT_BROWSER_SESSION_ID</code> — a runner
+        nobody here has heard of is picked up too, as long as it exports a
+        <code>&lt;PRODUCT&gt;_SESSION_ID</code> / <code>_THREAD_ID</code> / <code>_CONVERSATION_ID</code> variable.
+        Failing all of those it falls back to a terminal ID (<code>WT_SESSION</code>,
+        <code>TERM_SESSION_ID</code>, …), and only a shell with none of them retains the
+        <code>default</code> session. Run <code>chrome-use doctor</code> and read the
+        <code>Default session</code> line to see which session this shell resolves to and which variable it
+        was derived from. To set an explicit shell default, use
         <code>AGENT_BROWSER_SESSION=myapp</code>. Close a session with <code>close</code> when you no longer
         need it, and use <code>session list</code> to see which sessions are still active:
       </p>

--- a/docs/sessions.html
+++ b/docs/sessions.html
@@ -149,9 +149,13 @@
 
       <p>
         省略 <code>--session</code> 时，chrome-use 会优先从受支持的运行器 ID 派生稳定的独立会话。
-        Codex 任务会自动使用 <code>CODEX_THREAD_ID</code>，其他运行器可以提供
-        <code>AGENT_BROWSER_SESSION_ID</code>。没有运行器 ID 的普通 shell 仍使用
-        <code>default</code>。想显式设置当前 shell 的默认会话，用
+        Codex 任务会自动使用 <code>CODEX_THREAD_ID</code>，Claude Code 用 <code>CLAUDE_PID</code>，
+        其他运行器可以提供 <code>AGENT_BROWSER_SESSION_ID</code>；没在名单里的运行器，只要导出
+        <code>&lt;产品名&gt;_SESSION_ID</code> / <code>_THREAD_ID</code> / <code>_CONVERSATION_ID</code>
+        这类变量也会被自动识别。都没有时退回到终端 ID（<code>WT_SESSION</code>、
+        <code>TERM_SESSION_ID</code> 等），仍然什么都没有的普通 shell 才用 <code>default</code>。
+        想知道当前 shell 到底会落到哪个会话、是靠哪个变量派生的，跑 <code>chrome-use doctor</code>
+        看 <code>Default session</code> 那一行。想显式设置当前 shell 的默认会话，用
         <code>AGENT_BROWSER_SESSION=myapp</code>。会话不需要时用 <code>close</code> 关掉，用
         <code>session list</code> 看还有哪些活跃会话：
       </p>


### PR DESCRIPTION
Fixes #180

## 摘要

同一台机器上并发运行的多个 agent 会共用同一个 session daemon，互相抢标签页。本 PR 把 session 名的推导改成三层：先用 agent id，再用 `<PRODUCT>_SESSION_ID` 这类约定变量，最后才退回终端 id。**请先看下面的"已知限制"再决定是否需要讨论方案。**

---

## The problem

Session name derivation keys on terminal identity. Two agents running in the same terminal tab share `WT_SESSION` / `TMUX_PANE`, so they collapse onto one daemon and fight over tabs.

## The change

`cli/src/flags.rs` resolves the session name in three tiers:

**1. Explicit agent ids** — `AGENT_BROWSER_SESSION_ID`, `OPENCODE_PID`, `CODEX_THREAD_ID`, `CMUX_SURFACE_ID`, `CMUX_CLAUDE_PID`, `CLAUDE_PID`

**2. Convention-matching vars** — anything named `<PRODUCT>_SESSION_ID`, `<PRODUCT>_THREAD_ID`, or `<PRODUCT>_CONVERSATION_ID`, sorted for a stable derived name. Denylist for shared login/desktop ids (`XDG_SESSION_ID`, `GNOME_DESKTOP_SESSION_ID`) which identify a *login*, not an agent.

**3. Per-terminal ids** — `WT_SESSION`, `TMUX_PANE`, `TERM_SESSION_ID`, then `default`

Agent ids must outrank terminal ids. Keying on the terminal is what collapses two agents sharing one tab onto one daemon.

Tier 2 exists so a harness you have never heard of gets isolation without a patch here, as long as it follows the naming convention.

## Known limitation, please read

Isolation itself works: sequential multi-session use is correct, verified in practice.

**Parallel named sessions through one MCP server do not work**, and this feature is what invites someone to try. Firing 3 agents at one MCP server with distinct `session:` values produced empty errors from every call, spawned no daemons, and left the MCP server wedged for the rest of its life. The shared relay degraded too.

The cause looks structural rather than in this patch: the MCP layer forks one CLI per call, so N parallel cold named sessions means N concurrent daemon spawns competing for one extension relay. The per-session lifecycle locks hold; the fork-per-call design does not. The forked CLI's stderr is swallowed, which is why the error is empty.

A real fix probably means the MCP server holding one persistent connection per session and multiplexing calls over it, rather than forking. That is a larger change than this PR and I have not attempted it.

I am opening this as a PR rather than an issue because the code is written and rebased, but I would rather discuss the approach than have it merged unexamined. If you would prefer a narrower version (tier 1 only, no convention matching), say so and I will cut it down.

## Scope

One file, `cli/src/flags.rs`. No new dependencies.
