### PR TITLE
fix(test): 尊重显式指定的 --session，不再静默跑进 cu-test (#181)

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4578,6 +4578,7 @@ mod tests {
     fn default_flags() -> Flags {
         Flags {
             session: "test".to_string(),
+            session_explicit: true,
             json: false,
             headed: false,
             debug: false,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -722,11 +722,18 @@ pub fn parse_flags(args: &[String]) -> Flags {
         json: env_var_is_truthy("AGENT_BROWSER_JSON") || config.json.unwrap_or(false),
         headed: env_var_is_truthy("AGENT_BROWSER_HEADED") || config.headed.unwrap_or(false),
         debug: env_var_is_truthy("AGENT_BROWSER_DEBUG") || config.debug.unwrap_or(false),
+        // An empty value is "unset", not "a session named empty string" — else
+        // `AGENT_BROWSER_SESSION=` would look explicit and `test` would forward
+        // an empty session name instead of isolating in `cu-test` (#181).
         session: env::var("AGENT_BROWSER_SESSION")
             .ok()
             .or(config.session.clone())
+            .filter(|s| !s.trim().is_empty())
             .unwrap_or_else(default_session_name),
-        session_explicit: env::var("AGENT_BROWSER_SESSION").is_ok() || config.session.is_some(),
+        session_explicit: env::var("AGENT_BROWSER_SESSION")
+            .ok()
+            .or(config.session.clone())
+            .is_some_and(|s| !s.trim().is_empty()),
         headers: config.headers,
         executable_path: env::var("AGENT_BROWSER_EXECUTABLE_PATH")
             .ok()
@@ -882,8 +889,10 @@ pub fn parse_flags(args: &[String]) -> Flags {
             }
             "--session" => {
                 if let Some(s) = args.get(i + 1) {
-                    flags.session = s.clone();
-                    flags.session_explicit = true;
+                    if !s.trim().is_empty() {
+                        flags.session = s.clone();
+                        flags.session_explicit = true;
+                    }
                     i += 1;
                 }
             }

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -390,6 +390,13 @@ pub struct Flags {
     pub headed: bool,
     pub debug: bool,
     pub session: String,
+    /// Whether `session` came from the user (`--session`, `AGENT_BROWSER_SESSION`,
+    /// config) rather than from `default_session_name()`. `test` needs the
+    /// distinction: it defaults to its own `cu-test` browser, but must honour an
+    /// explicitly named session — comparing against the literal `"default"`
+    /// silently ignored `--session default` and mis-read agent-derived names as
+    /// explicit (issue #181).
+    pub session_explicit: bool,
     pub headers: Option<String>,
     pub executable_path: Option<String>,
     pub cdp: Option<String>,
@@ -717,8 +724,9 @@ pub fn parse_flags(args: &[String]) -> Flags {
         debug: env_var_is_truthy("AGENT_BROWSER_DEBUG") || config.debug.unwrap_or(false),
         session: env::var("AGENT_BROWSER_SESSION")
             .ok()
-            .or(config.session)
+            .or(config.session.clone())
             .unwrap_or_else(default_session_name),
+        session_explicit: env::var("AGENT_BROWSER_SESSION").is_ok() || config.session.is_some(),
         headers: config.headers,
         executable_path: env::var("AGENT_BROWSER_EXECUTABLE_PATH")
             .ok()
@@ -875,6 +883,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
             "--session" => {
                 if let Some(s) = args.get(i + 1) {
                     flags.session = s.clone();
+                    flags.session_explicit = true;
                     i += 1;
                 }
             }

--- a/cli/src/test_runner.rs
+++ b/cli/src/test_runner.rs
@@ -27,6 +27,15 @@ use serde_json::Value;
 use std::process::Command;
 use std::time::Instant;
 
+/// Returns `(session, launch_a_browser, we_own_and_close_it)`.
+fn resolve_session(explicit: bool, session: &str, force_launch: bool) -> (String, bool, bool) {
+    if explicit {
+        (session.to_string(), force_launch, false)
+    } else {
+        ("cu-test".to_string(), true, true)
+    }
+}
+
 pub fn run_test(suite_path: &str, flags: &Flags) -> i32 {
     let text = match std::fs::read_to_string(suite_path) {
         Ok(t) => t,
@@ -65,13 +74,12 @@ pub fn run_test(suite_path: &str, flags: &Flags) -> i32 {
     };
 
     // A dedicated launched browser by default (deterministic, re-runnable). If
-    // the user named a --session, target that existing one instead.
-    let (session, do_launch) = if flags.session == "default" {
-        ("cu-test".to_string(), true)
-    } else {
-        (flags.session.clone(), flags.force_launch)
-    };
-    let owns_session = session == "cu-test";
+    // the user named a --session, target that existing one instead. Keying this
+    // on `session == "default"` was wrong twice over (issue #181): `--session
+    // default` was indistinguishable from no flag at all, and an agent-derived
+    // session name looked like an explicit one.
+    let (session, do_launch, owns_session) =
+        resolve_session(flags.session_explicit, &flags.session, flags.force_launch);
 
     let mut base: Vec<String> = vec!["--session".into(), session.clone()];
     if do_launch {
@@ -80,6 +88,20 @@ pub fn run_test(suite_path: &str, flags: &Flags) -> i32 {
     if let Some(p) = &flags.profile {
         base.push("--profile".into());
         base.push(p.clone());
+    }
+    // Without these the suite would silently run against the default relay
+    // profile while the user's own commands hit the pinned/verified one — the
+    // exact "logged in by hand, logged out under `test`" mismatch in #181.
+    if let Some(b) = &flags.browser {
+        base.push("--browser".into());
+        base.push(b.clone());
+    }
+    if let Some(a) = &flags.as_account {
+        base.push("--as".into());
+        base.push(a.clone());
+        if flags.as_strict {
+            base.push("--as-strict".into());
+        }
     }
 
     let artifacts_dir = flags
@@ -477,6 +499,26 @@ fn slug(name: &str) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn explicit_session_is_honoured_even_when_named_default() {
+        // issue #181: `--session default` used to be indistinguishable from no
+        // flag at all, so the suite silently ran in a fresh `cu-test` browser
+        // with none of the connected session's logins.
+        assert_eq!(
+            resolve_session(true, "default", false),
+            ("default".to_string(), false, false)
+        );
+        assert_eq!(
+            resolve_session(true, "work", false),
+            ("work".to_string(), false, false)
+        );
+        // An agent-derived name with no `--session` is still not explicit.
+        assert_eq!(
+            resolve_session(false, "cu-myrepo-0a1b2c", false),
+            ("cu-test".to_string(), true, true)
+        );
+    }
 
     #[test]
     fn step_mapping() {

--- a/cli/src/test_runner.rs
+++ b/cli/src/test_runner.rs
@@ -27,13 +27,44 @@ use serde_json::Value;
 use std::process::Command;
 use std::time::Instant;
 
-/// Returns `(session, launch_a_browser, we_own_and_close_it)`.
+/// Returns `(session, launch_a_browser, we_own_and_close_it)`. Ownership tracks
+/// "did we launch this browser", not the session name: `--launch` is also turned
+/// on implicitly under `CI`, and a browser we started must be closed by us even
+/// when the session was named by the user.
 fn resolve_session(explicit: bool, session: &str, force_launch: bool) -> (String, bool, bool) {
-    if explicit {
-        (session.to_string(), force_launch, false)
+    let (session, do_launch) = if explicit {
+        (session.to_string(), force_launch)
     } else {
-        ("cu-test".to_string(), true, true)
+        ("cu-test".to_string(), true)
+    };
+    (session, do_launch, do_launch)
+}
+
+/// The flags every step's sub-invocation inherits. Without `--browser` / `--as`
+/// the suite would silently run against the default relay profile while the
+/// user's own commands hit the pinned/verified one — the exact "logged in by
+/// hand, logged out under `test`" mismatch in issue #181.
+fn base_args(session: &str, do_launch: bool, flags: &Flags) -> Vec<String> {
+    let mut base: Vec<String> = vec!["--session".into(), session.to_string()];
+    if do_launch {
+        base.push("--launch".into());
     }
+    if let Some(p) = &flags.profile {
+        base.push("--profile".into());
+        base.push(p.clone());
+    }
+    if let Some(b) = &flags.browser {
+        base.push("--browser".into());
+        base.push(b.clone());
+    }
+    if let Some(a) = &flags.as_account {
+        base.push("--as".into());
+        base.push(a.clone());
+        if flags.as_strict {
+            base.push("--as-strict".into());
+        }
+    }
+    base
 }
 
 pub fn run_test(suite_path: &str, flags: &Flags) -> i32 {
@@ -81,28 +112,7 @@ pub fn run_test(suite_path: &str, flags: &Flags) -> i32 {
     let (session, do_launch, owns_session) =
         resolve_session(flags.session_explicit, &flags.session, flags.force_launch);
 
-    let mut base: Vec<String> = vec!["--session".into(), session.clone()];
-    if do_launch {
-        base.push("--launch".into());
-    }
-    if let Some(p) = &flags.profile {
-        base.push("--profile".into());
-        base.push(p.clone());
-    }
-    // Without these the suite would silently run against the default relay
-    // profile while the user's own commands hit the pinned/verified one — the
-    // exact "logged in by hand, logged out under `test`" mismatch in #181.
-    if let Some(b) = &flags.browser {
-        base.push("--browser".into());
-        base.push(b.clone());
-    }
-    if let Some(a) = &flags.as_account {
-        base.push("--as".into());
-        base.push(a.clone());
-        if flags.as_strict {
-            base.push("--as-strict".into());
-        }
-    }
+    let base = base_args(&session, do_launch, flags);
 
     let artifacts_dir = flags
         .download_path
@@ -518,6 +528,62 @@ mod tests {
             resolve_session(false, "cu-myrepo-0a1b2c", false),
             ("cu-test".to_string(), true, true)
         );
+        // `--launch` (also implicit under CI) on a named session: we started the
+        // browser, so we close it — otherwise it leaks with no cleanup owner.
+        assert_eq!(
+            resolve_session(true, "default", true),
+            ("default".to_string(), true, true)
+        );
+    }
+
+    #[test]
+    fn every_step_inherits_the_browser_pinning_flags() {
+        let mut flags = crate::flags::parse_flags(&["x".to_string()]);
+        flags.profile = Some("work".into());
+        flags.browser = Some("me@example.com".into());
+        flags.as_account = Some("chatgpt/huayue".into());
+        flags.as_strict = true;
+        assert_eq!(
+            base_args("default", false, &flags),
+            vec![
+                "--session",
+                "default",
+                "--profile",
+                "work",
+                "--browser",
+                "me@example.com",
+                "--as",
+                "chatgpt/huayue",
+                "--as-strict"
+            ]
+        );
+        assert!(base_args("cu-test", true, &flags).contains(&"--launch".to_string()));
+    }
+
+    #[test]
+    fn an_empty_session_is_not_an_explicit_one() {
+        // `AGENT_BROWSER_SESSION=` / `--session ""` must fall back to the
+        // isolated default rather than forwarding an empty session name (#181).
+        let flags = crate::flags::parse_flags(
+            &"--session  test suite.yaml"
+                .split(' ')
+                .map(String::from)
+                .collect::<Vec<_>>(),
+        );
+        assert!(!flags.session_explicit);
+        assert_ne!(flags.session, "");
+    }
+
+    #[test]
+    fn parse_flags_marks_an_explicit_default_session() {
+        let flags = crate::flags::parse_flags(
+            &"--session default test suite.yaml"
+                .split(' ')
+                .map(String::from)
+                .collect::<Vec<_>>(),
+        );
+        assert_eq!(flags.session, "default");
+        assert!(flags.session_explicit);
     }
 
     #[test]

--- a/docs/en/testing.html
+++ b/docs/en/testing.html
@@ -89,7 +89,7 @@
       <ul>
         <li>Exit code is <strong>0</strong> when every case passes, <strong>1</strong> if any fails &mdash; drop it straight into CI.</li>
         <li>By default it <strong>launches a brand-new isolated browser</strong> in a <code>cu-test</code> session (deterministic, reproducible) and closes it when done.</li>
-        <li>Pass <code>--session &lt;name&gt;</code> to run against an <strong>already-connected session</strong> (for example a real Chrome attached via <code>chrome-use extension connect</code>).</li>
+        <li>Pass <code>--session &lt;name&gt;</code> (<code>--session default</code> counts) to run against an <strong>already-connected session</strong> instead, reusing its logins and leaving it open afterwards. <code>--browser</code> / <code>--as</code> / <code>--profile</code> are forwarded to every step, so a suite can target one specific connected Chrome profile (for example a real Chrome attached via <code>chrome-use extension connect</code>).</li>
         <li>Failing cases automatically save a screenshot to <code>cu-test-artifacts/&lt;case&gt;.png</code>.</li>
       </ul>
 

--- a/docs/testing.html
+++ b/docs/testing.html
@@ -87,7 +87,7 @@
       <ul>
         <li>全部用例通过退出码为 <strong>0</strong>，任一失败为 <strong>1</strong> —— 直接丢进 CI。</li>
         <li>默认在一个 <code>cu-test</code> 会话里<strong>启动全新的隔离浏览器</strong>（确定、可复现），跑完即关。</li>
-        <li>传 <code>--session &lt;name&gt;</code> 可对着一个<strong>已连接的会话</strong>跑（比如通过 <code>chrome-use extension connect</code> 接上的真实 Chrome）。</li>
+        <li>传 <code>--session &lt;name&gt;</code>（<code>--session default</code> 也算）可对着一个<strong>已连接的会话</strong>跑，复用它的登录态，跑完不关闭。<code>--browser</code> / <code>--as</code> / <code>--profile</code> 会转发给每一步，可以精确指定某个已连接的 Chrome 配置（比如通过 <code>chrome-use extension connect</code> 接上的真实 Chrome）。</li>
         <li>失败的用例会自动把截图存到 <code>cu-test-artifacts/&lt;case&gt;.png</code>。</li>
       </ul>
 

--- a/skill-data/test/SKILL.md
+++ b/skill-data/test/SKILL.md
@@ -15,8 +15,12 @@ chrome-use test <suite.yaml> [--launch | --session <name>] [--json]
 
 - Exit code **0** if all cases pass, **1** if any fail → drop it straight into CI.
 - Default: launches a fresh isolated browser (deterministic, repeatable) in a
-  `cu-test` session and closes it after. Pass `--session <name>` to run against an
-  already-connected session (e.g. the live Chrome via `chrome-use extension connect`).
+  `cu-test` session and closes it after. Pass `--session <name>` (including
+  `--session default`) to run against an already-connected session instead — the
+  suite then reuses that session's logins and is left open when the run ends.
+  `--browser` / `--as` / `--profile` are forwarded to every step, so a suite can
+  target one specific connected Chrome profile (e.g. the live Chrome via
+  `chrome-use extension connect`).
 - Failed cases auto-save a screenshot to `cu-test-artifacts/<case>.png`.
 
 ## Suite format (YAML)


### PR DESCRIPTION
Fixes #181.

## 根因

`test_runner.rs` 用 `flags.session == "default"` 来判断「用户有没有指定会话」。这个判据两头都错：

1. `--session default` 和完全不传 `--session` 无法区分 —— 用户显式指定的会话被静默丢弃，套件跑进新启的隔离 `cu-test` 浏览器，连接好的真实 Chrome 的登录态一个都用不上（这就是 #181 的现象：手工命令登录是好的，`test` 里却 logged out）。
2. 反过来，1.5.90 起默认会话名会按 agent 身份派生（如 `cu-myrepo-0a1b2c`），这种自动名字又被误判成「显式指定」，于是本该隔离的默认行为反而去复用了 agent 会话。

第二个洞：即使会话对了，`test` 只把 `--session/--launch/--profile` 转发给每个 step，`--browser` / `--as` 被吞掉 —— 套件跑在默认 relay 配置上，用户手工命令跑在 pin 住的那个配置上，同样表现为「登录态不见了」。

## 改动

| 文件 | 改动 |
|---|---|
| `cli/src/flags.rs` | 新增 `Flags::session_explicit`，在 `--session` / `AGENT_BROWSER_SESSION` / 配置文件命中时置真 |
| `cli/src/test_runner.rs` | 抽出 `resolve_session()`，按 `session_explicit` 决定复用 vs 自建 `cu-test`；只关闭自己启的浏览器；转发 `--browser` / `--as` / `--as-strict` |
| `skill-data/test/SKILL.md`、`docs/testing.html`、`docs/en/testing.html` | 明确 `--session default` 也算显式指定、复用登录态且跑完不关闭、`--browser/--as/--profile` 会转发 |

## Before / after

复现套件（读 `localStorage.cu181`，读不到就抛错），先在会话里写好 marker：

```
# before —— --session default 被无视
$ chrome-use test auth-check.yaml --session default
suite: session reuse check  (session cu-test)
  ✗ ... step `eval` failed: Error: missing marker

# after
$ chrome-use test auth-check.yaml --session default
suite: session reuse check  (session default)
  ✓ marker written by the session is visible to the suite  0.4s
1 cases · 1 passed · 0 failed   (exit 0)
```

默认行为没退化 —— 不传 `--session` 仍然是全新隔离浏览器：

```
$ chrome-use test auth-check.yaml
suite: session reuse check  (session cu-test)
  ✗ ... Error: missing marker      # 干净浏览器里当然没有 marker，符合预期
```

## 验证

- `cargo fmt`
- `cargo test --bin chrome-use` → 1114 passed / 0 failed（含新增 `explicit_session_is_honoured_even_when_named_default`）
- `cargo clippy --all-targets` → 改动文件无新增告警
- 真实 Chrome 按 issue 原始步骤跑通（上面 before/after 即实测输出），会话跑完已 `close`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test runs can reuse explicitly selected sessions, including the default session, while keeping connected sessions open.
  * Browser, account, and profile selections are now applied consistently across all test suite steps.
  * Tests without an explicit session continue using an automatically managed test browser.

* **Documentation**
  * Updated testing guidance to explain session reuse and configuration forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->