### PR TITLE
fix: 截图目标漂移不再静默成功，Windows 扩展状态读对路径 (#184) (#183)

### DIFF
--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -240,8 +240,20 @@ pub fn run_connect(args: &[String], json: bool) {
         println!("  Web Store extension id: {STORE_EXTENSION_ID}");
         println!("  unpacked/dev extension id: {EXTENSION_ID}");
         println!("  expected extension version: {expected_extension_version}");
-        match live_extension_version {
-            Some(ver) => println!("✓ live extension version: {ver}"),
+        // An outdated live extension used to print a plain ✓ next to a
+        // different "expected" number, leaving the reader to diff two version
+        // strings and with nothing to run (issue #183). Say which it is, and
+        // how to fix it.
+        match &live_extension_version {
+            Some(ver) if ver == expected_extension_version => {
+                println!("✓ live extension version: {ver}")
+            }
+            Some(ver) => println!(
+                "  ! live extension version: {ver} — OUTDATED (expected \
+                 {expected_extension_version}).\n\
+                 \x20   Update it at chrome://extensions (turn on Developer mode → Update), or \
+                 reload the unpacked build."
+            ),
             None => {
                 println!("  live extension version: unknown (relay has not reported hello yet)")
             }
@@ -1412,6 +1424,7 @@ struct ChromeExtensionStatus {
 
 fn chrome_profile_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
+    #[cfg(not(target_os = "windows"))]
     if let Some(config) = dirs::config_dir() {
         #[cfg(target_os = "macos")]
         {
@@ -1435,9 +1448,24 @@ fn chrome_profile_roots() -> Vec<PathBuf> {
                 roots.push(config.join(sub));
             }
         }
-        #[cfg(target_os = "windows")]
-        {
-            roots.push(config.join("Google").join("Chrome").join("User Data"));
+    }
+    // Windows keeps browser profiles under LOCALAPPDATA, not the Roaming
+    // AppData that `config_dir()` returns — reading the wrong root made every
+    // Windows install report "0 profiles found / not found in any Chrome
+    // profile" even while the relay was up and driving one (issue #183).
+    #[cfg(target_os = "windows")]
+    if let Some(local) = dirs::data_local_dir() {
+        for sub in [
+            "Google/Chrome",
+            "Google/Chrome Beta",
+            "Google/Chrome SxS",
+            "Chromium",
+        ] {
+            let mut root = local.clone();
+            for part in sub.split('/') {
+                root.push(part);
+            }
+            roots.push(root.join("User Data"));
         }
     }
     roots

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3726,6 +3726,14 @@ fn absolutize_saved_path(p: &str) -> String {
         .unwrap_or_else(|_| p.to_string())
 }
 
+/// Whether a resolved capture target is one that cannot hold page content —
+/// an empty URL or a blank/new-tab page (issue #184). Used to tell "the tab
+/// really is blank" (fine, capture it) from "we're driving a real page but the
+/// capture session landed on a blank one" (a drift, and an error).
+fn is_blank_capture_target(url: &str) -> bool {
+    url.is_empty() || url == "about:blank" || url == "about:newtab"
+}
+
 async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let annotate = cmd
         .get("annotate")
@@ -3833,6 +3841,29 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
         }),
     };
 
+    // Verify the CDP session we are about to capture is really attached to the
+    // tab this session is driving (issue #184). On the extension relay a page
+    // whose real Chrome profile injects extension frames could leave the capture
+    // session pointing at an extension-owned `about:blank` renderer while
+    // `tabs`/`snapshot` still reported the right page — the shot came back a
+    // blank image under a `✓`. A screenshot is the one verb whose output an
+    // agent cannot sanity-check, so a target it cannot confirm must fail loudly
+    // rather than write a plausible-looking file.
+    let live_url = mgr.get_url().await.unwrap_or_default();
+    let tracked_url = mgr.cached_active_url();
+    if is_blank_capture_target(&live_url) && !is_blank_capture_target(&tracked_url) {
+        return Err(format!(
+            "screenshot target drifted: this session is driving {tracked_url}, but its CDP \
+             session is attached to {} — the capture would be a blank image. Re-pin the tab \
+             (`chrome-use tab <ref>` or `chrome-use adopt <url>`) and retry.",
+            if live_url.is_empty() {
+                "an unknown target"
+            } else {
+                live_url.as_str()
+            }
+        ));
+    }
+
     if annotate {
         state.ref_map.clear();
         let _ = snapshot::take_snapshot(
@@ -3898,10 +3929,10 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     }
     // Stamp which page was captured so a screenshot of the wrong tab is obvious
     // (issue #8.1: relay sessions can drift to whatever tab the user activated).
-    if let Ok(url) = mgr.get_url().await {
-        if !url.is_empty() {
-            response["origin"] = json!(url);
-        }
+    // Reuses the URL read from the capture session before the shot (issue #184),
+    // so the stamp names the target that was actually captured.
+    if !live_url.is_empty() {
+        response["origin"] = json!(live_url);
     }
 
     Ok(response)
@@ -12807,6 +12838,21 @@ fn error_response(id: &str, error: &str) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use super::is_blank_capture_target;
+
+    // issue #184: a screenshot must not report ✓ when its capture session is on a
+    // blank target while the session is driving a real page.
+    #[test]
+    fn blank_capture_targets_are_recognised() {
+        assert!(is_blank_capture_target(""));
+        assert!(is_blank_capture_target("about:blank"));
+        assert!(is_blank_capture_target("about:newtab"));
+        assert!(!is_blank_capture_target(
+            "http://127.0.0.1:8791/design.html"
+        ));
+        assert!(!is_blank_capture_target("https://example.com/"));
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
## 根因

**#184 — screenshot 静默拍出 about:blank**

`screenshot` 和 `eval`/`get text` 走的是同一个 `active_session_id()`，所以不存在「target 解析方式不同」。真正糟糕的是结果形态：在真实 Chrome profile（装了 doubao / immersive-translate 等注入型扩展）上，捕获用的 CDP session 可能贴在扩展自己的 `about:blank` 渲染器上，而 relay 侧的 `chrome.tabs` 元数据仍然正确 —— 于是 `tabs` 显示真页面、`eval` 返回真页面，唯独截图是一张空白图，并且带着一个 `✓`。

截图是 agent 唯一没法自查输出的动作（它拿不到像素去核对），所以这里不能容忍「看起来成功」。

**#183 — Windows 上 `extension status` 报 0 profiles**

`chrome_profile_roots()` 在 Windows 分支用了 `dirs::config_dir()`（= Roaming AppData），但 Chrome 的 `User Data` 在 **LOCALAPPDATA**。于是 relay 明明连着 `leipeng950504@gmail.com` 这个 profile，状态却说「not found in any Chrome profile / 0 profiles」。另外扩展版本落后时打的是 `✓ live extension version: 0.5.12`，紧挨着 `expected extension version: 0.5.16` —— 让读者自己去 diff 两串版本号，且没有任何可执行的下一步。

## 改动

| 文件 | 改动 |
|---|---|
| `cli/src/native/actions.rs` | `handle_screenshot` 拍摄前比对 `cached_active_url()`（会话驱动的标签页）与捕获 session 上真实的 `location.href`；真页面 vs 空白目标 → 报错退出，不写文件。新增 `is_blank_capture_target()` + 单测。`origin` 戳复用拍摄前读到的同一个 URL。 |
| `cli/src/connect.rs` | Windows profile 根目录改读 `dirs::data_local_dir()`（Chrome / Beta / SxS / Chromium）。扩展版本落后时打 `! ... OUTDATED` 并给出更新方式，只有版本一致才打 `✓`。 |

## before / after

```
# before（#184）
✓ Screenshot saved to .../design-full.png
screenshot @ about:blank                     ← 7KB 纯白，但是个 ✓

# after
screenshot target drifted: this session is driving http://127.0.0.1:8791/design.html,
but its CDP session is attached to about:blank — the capture would be a blank image.
Re-pin the tab (`chrome-use tab <ref>` or `chrome-use adopt <url>`) and retry.
（退出码非 0，不写文件）
```

```
# before（#183，Windows）
✓ live extension version: 0.5.12
  expected extension version: 0.5.16
  Chrome profiles (0 found, 0 with the extension)

# after
  ! live extension version: 0.5.12 — OUTDATED (expected 0.5.16).
     Update it at chrome://extensions (turn on Developer mode → Update), or reload the unpacked build.
  Chrome profiles (…从 LOCALAPPDATA 真实枚举…)
```

## 验证

- `cargo fmt` / `cargo clippy --all-targets` — 改动文件零告警
- `cargo test --bin chrome-use` — 1118 passed, 0 failed（含新增的 `blank_capture_targets_are_recognised`）
- 真实 Chrome：
  - `open https://example.com` → `screenshot --full` = 79.6K 真内容，`screenshot @ https://example.com/` ✅ 无回归
  - `open about:blank` → `screenshot` 照常成功（真的空白页不会被误判成漂移）✅ 无误报

## 没做的部分

- #184 里「为什么捕获 session 会贴到扩展的 about:blank 渲染器」这一层还没有稳定复现（本机没有那套扩展组合），所以这次做的是**把静默成功变成响亮失败**，即 issue 里提的建议 2/3。等能复现了再去堵住漂移本身。
- #183 里报告的那次 `session unresponsive` 是一次性的，与版本不匹配没有确证的因果关系；本 PR 只解决可确证的两个状态显示问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extension status reporting by distinguishing current and outdated versions, with clearer update guidance.
  - Improved Chrome profile discovery on Windows across Chrome, Beta, SxS, and Chromium installations.
  - Prevented screenshots from being captured when the active browser target is an unintended blank or new-tab page.
  - Improved screenshot response accuracy by preserving the page URL captured before the screenshot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->