### PR TITLE
fix: 受管理状态的代价说清楚，扩展版本别再谎报 OUTDATED (#187) (#186)

### DIFF
--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -1724,6 +1724,10 @@ pub enum ExtVersionVerdict {
     BehindStore { store: String },
     /// Live IS the newest published build; the bundled one isn't out yet.
     NewestPublished { store: String },
+    /// Live is newer than anything published, yet still behind the bundled
+    /// build — an intermediate unpacked build. Saying "you're on the published
+    /// build" here would be false, so it gets its own verdict.
+    AheadOfStore { store: String },
     /// Behind the bundled build, and the Store version is unknown (offline).
     BehindBundledStoreUnknown,
     /// Live is newer than the bundled build (unpacked dev build).
@@ -1743,7 +1747,10 @@ pub fn classify_ext_version(live: &str, bundled: &str, store: Option<&str>) -> E
         Some(s) if crate::upgrade::version_is_newer(s, live) => ExtVersionVerdict::BehindStore {
             store: s.to_string(),
         },
-        Some(s) => ExtVersionVerdict::NewestPublished {
+        Some(s) if s == live => ExtVersionVerdict::NewestPublished {
+            store: s.to_string(),
+        },
+        Some(s) => ExtVersionVerdict::AheadOfStore {
             store: s.to_string(),
         },
         None => ExtVersionVerdict::BehindBundledStoreUnknown,
@@ -1772,6 +1779,11 @@ pub fn ext_version_line(live: &str, bundled: &str, store: Option<&str>) -> Strin
              \x20   and nothing is broken. To run the bundled build now, load \
              extensions/ab-connect unpacked."
         ),
+        ExtVersionVerdict::AheadOfStore { store } => format!(
+            "✓ live extension version: {live} — ahead of everything published on the Web Store \
+             ({store}),\n\
+             \x20   behind the {bundled} this CLI bundles: an intermediate unpacked build."
+        ),
         ExtVersionVerdict::BehindBundledStoreUnknown => format!(
             "  live extension version: {live} (this CLI bundles {bundled}; couldn't reach the \
              Web Store\n\
@@ -1787,6 +1799,10 @@ pub fn ext_version_line(live: &str, bundled: &str, store: Option<&str>) -> Strin
 /// version already differs from the bundled one, and any failure (offline, CI,
 /// proxy) degrades to `None` rather than blocking a diagnostic command.
 /// `curl` matches how the CLI does its other version checks (see `upgrade`).
+/// `prodversion` only gates `minimum_chrome_version` constraints; ab-connect
+/// declares none, and the service answers with 0.5.12 even for prodversion=90 —
+/// so a fixed value is safe here. Were that ever to change, the service replies
+/// `noupdate`, which degrades to "Store version unknown", never a false claim.
 pub fn store_extension_version() -> Option<String> {
     let url = format!(
         "{UPDATE_URL}?response=updatecheck&prodversion=140.0&acceptformat=crx3\
@@ -3258,9 +3274,12 @@ mod tests {
 
     #[test]
     fn store_update_response_yields_the_published_version() {
-        let xml = r#"<?xml version="1.0" encoding="UTF-8"?><gupdate protocol="2.0">\
-<app appid="knfcmbamhjmaonkfnjhldjedeobeafmk" status="ok"><updatecheck \
-codebase="https://x/KNFC_0_5_12_0.crx" status="ok" version="0.5.12"/></app></gupdate>"#;
+        let xml = concat!(
+            r#"<?xml version="1.0" encoding="UTF-8"?><gupdate protocol="2.0">"#,
+            r#"<app appid="knfcmbamhjmaonkfnjhldjedeobeafmk" status="ok">"#,
+            r#"<updatecheck codebase="https://x/KNFC_0_5_12_0.crx" status="ok" version="0.5.12"/>"#,
+            r#"</app></gupdate>"#,
+        );
         assert_eq!(
             parse_store_update_version(xml).as_deref(),
             Some("0.5.12"),

--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -172,7 +172,11 @@ pub fn run_connect(args: &[String], json: bool) {
             if cfg!(target_os = "macos") {
                 println!(
                     "  To fully remove the extension, delete the \"chrome-use connect\" profile\n\
-                     in System Settings → Profiles (or run: profiles remove -identifier {PROFILE_ID})."
+                     in System Settings → Profiles (or run: profiles remove -identifier {PROFILE_ID}).\n\
+                     That also takes Chrome out of \"managed by your organization\" mode, so the\n\
+                     \"Use secure DNS\" setting is yours again (#187) — and Chrome uninstalls the\n\
+                     extension the policy installed. To keep driving Chrome without the policy,\n\
+                     re-add the extension per profile from {STORE_URL}."
                 );
                 let (approved, old_ids) = approved_config_profiles();
                 let _ = approved;
@@ -199,6 +203,17 @@ pub fn run_connect(args: &[String], json: bool) {
     let profiles = chrome_profiles();
     let policy = managed_policy_state();
     let (_, old_ids) = approved_config_profiles();
+    // Only ask the Web Store when the numbers already disagree — the happy path
+    // stays network-free, and the answer is what decides whether the user has
+    // anything to update to at all (#186).
+    let version_mismatch = [
+        live_extension_version.as_deref(),
+        extension_status.as_ref().and_then(|s| s.version.as_deref()),
+    ]
+    .into_iter()
+    .flatten()
+    .any(|v| v != expected_extension_version);
+    let store_extension_version = version_mismatch.then(store_extension_version).flatten();
     if json {
         println!(
             "{}",
@@ -215,6 +230,8 @@ pub fn run_connect(args: &[String], json: bool) {
                     },
                     "extensionId": EXTENSION_ID,
                     "expectedExtensionVersion": expected_extension_version,
+                    "bundledExtensionVersion": expected_extension_version,
+                    "storeExtensionVersion": store_extension_version,
                     "liveExtensionVersion": live_extension_version,
                     "relayUp": relay_url.is_some(),
                     "relayUrl": relay_url,
@@ -239,20 +256,21 @@ pub fn run_connect(args: &[String], json: bool) {
         }
         println!("  Web Store extension id: {STORE_EXTENSION_ID}");
         println!("  unpacked/dev extension id: {EXTENSION_ID}");
-        println!("  expected extension version: {expected_extension_version}");
+        println!("  bundled extension version (ships with this CLI): {expected_extension_version}");
         // An outdated live extension used to print a plain ✓ next to a
         // different "expected" number, leaving the reader to diff two version
         // strings and with nothing to run (issue #183). Say which it is, and
-        // how to fix it.
+        // how to fix it — but only call it outdated when a NEWER build is
+        // actually published (#186): the bundled version regularly runs ahead
+        // of the Web Store, and "Update" cannot install what isn't released.
         match &live_extension_version {
-            Some(ver) if ver == expected_extension_version => {
-                println!("✓ live extension version: {ver}")
-            }
             Some(ver) => println!(
-                "  ! live extension version: {ver} — OUTDATED (expected \
-                 {expected_extension_version}).\n\
-                 \x20   Update it at chrome://extensions (turn on Developer mode → Update), or \
-                 reload the unpacked build."
+                "{}",
+                ext_version_line(
+                    ver,
+                    expected_extension_version,
+                    store_extension_version.as_deref()
+                )
             ),
             None => {
                 println!("  live extension version: unknown (relay has not reported hello yet)")
@@ -278,7 +296,11 @@ pub fn run_connect(args: &[String], json: bool) {
             ),
         }
         if let Some(status) = extension_status {
-            print_chrome_extension_status(&status, expected_extension_version);
+            print_chrome_extension_status(
+                &status,
+                expected_extension_version,
+                store_extension_version.as_deref(),
+            );
         } else {
             println!("  Chrome profile extension status: not found in any Chrome profile");
         }
@@ -314,14 +336,22 @@ pub fn run_connect(args: &[String], json: bool) {
             }
         }
         match &policy {
-            PolicyState::Active => println!(
-                "{}",
-                if zh {
-                    "  ✓ 静默安装策略：已生效（缺失的 profile 会在 Chrome 重启时装上）"
-                } else {
-                    "  ✓ silent-install policy: active (missing profiles install on Chrome restart)"
-                }
-            ),
+            PolicyState::Active => {
+                println!(
+                    "{}",
+                    if zh {
+                        "  ✓ 静默安装策略：已生效（缺失的 profile 会在 Chrome 重启时装上）"
+                    } else {
+                        "  ✓ silent-install policy: active (missing profiles install on Chrome restart)"
+                    }
+                );
+                // The policy is also why Chrome says "managed by your
+                // organization", why the extension has no manual update/remove
+                // button (#186), and why Secure DNS is locked (#187). Status is
+                // where people come looking for that answer — so answer it here,
+                // with the way out, instead of leaving a bare ✓.
+                println!("{}", managed_mode_notice(zh));
+            }
             PolicyState::Stale(entry) => {
                 if zh {
                     println!(
@@ -369,7 +399,9 @@ pub fn run_connect(args: &[String], json: bool) {
     }
 }
 
-/// `extension install [--no-open] [--all-profiles]` — the guided setup.
+/// `extension install [--no-open] [--all-profiles] [--no-profile]` — the guided
+/// setup. `--no-profile` never writes the macOS policy profile, so Chrome never
+/// enters managed mode (#187); the Web Store route covers the install instead.
 ///
 /// Everything that CAN be automatic is: the native-messaging host (user-level,
 /// shared by every profile) is written outright, and the state of every Chrome
@@ -461,6 +493,12 @@ fn run_install_windows(json: bool, host_paths: &[String]) {
 fn run_install_unix(args: &[String], json: bool, host_paths: Vec<String>) {
     let no_open = args.iter().any(|a| a == "--no-open");
     let all_profiles = args.iter().any(|a| a == "--all-profiles");
+    // Opting out of the managed-policy route entirely (#187): approving it puts
+    // Chrome in "managed by your organization" mode, which Chrome uses to
+    // disable settings it reserves on managed browsers — Secure DNS (DoH) among
+    // them, which broke DoH-dependent sites for the reporter. Users who want
+    // the Web-Store-only path must be able to say so up front.
+    let no_profile = args.iter().any(|a| a == "--no-profile");
 
     let profiles = chrome_profiles();
     let missing: Vec<&ChromeProfileInfo> =
@@ -485,7 +523,7 @@ fn run_install_unix(args: &[String], json: bool, host_paths: Vec<String>) {
 
     // Path A: write + open the policy profile, unless it's already doing its
     // job or the user explicitly chose the per-profile route.
-    let policy_needed = policy != PolicyState::Active && !all_profiles;
+    let policy_needed = wants_policy_profile(&policy, all_profiles, no_profile);
     let mobileconfig = if policy_needed {
         Some(install_force_install_profile(no_open))
     } else {
@@ -507,6 +545,7 @@ fn run_install_unix(args: &[String], json: bool, host_paths: Vec<String>) {
                         "staleProfileIds": old_ids,
                         "profileId": PROFILE_ID,
                     },
+                    "noProfile": no_profile,
                     "profile": mobileconfig.as_ref().and_then(|r| r.as_ref().ok().map(|p| p.display().to_string())),
                     "profileError": mobileconfig.as_ref().and_then(|r| r.as_ref().err().cloned()),
                     "profiles": profiles,
@@ -685,9 +724,11 @@ fn run_install_unix(args: &[String], json: bool, host_paths: Vec<String>) {
                         if no_open { "写好" } else { "打开" },
                         path.display()
                     );
+                    println!("{}", managed_mode_tradeoff(zh));
                     println!(
                         "  B) 每个 profile 点一下：chrome-use extension install --all-profiles\n\
-                         \x20    会在每个缺失的 profile 里打开商店安装页 —— 逐个点「加入 Chrome」。"
+                         \x20    会在每个缺失的 profile 里打开商店安装页 —— 逐个点「加入 Chrome」。\n\
+                         \x20    Chrome 不会进入受管理状态，扩展仍由商店自动更新。"
                     );
                 } else {
                     println!("  Pick ONE:");
@@ -702,10 +743,12 @@ fn run_install_unix(args: &[String], json: bool, host_paths: Vec<String>) {
                         if no_open { "wrote" } else { "opened" },
                         path.display()
                     );
+                    println!("{}", managed_mode_tradeoff(zh));
                     println!(
                         "  B) One click per profile: chrome-use extension install --all-profiles\n\
                          \x20    opens the Web Store page inside each missing profile — press\n\
-                         \x20    \"Add to Chrome\" in each."
+                         \x20    \"Add to Chrome\" in each. Chrome stays unmanaged and the Store\n\
+                         \x20    keeps the extension updated."
                     );
                 }
                 if cfg!(target_os = "macos") && !no_open && interactive_tty() {
@@ -727,7 +770,26 @@ fn run_install_unix(args: &[String], json: bool, host_paths: Vec<String>) {
                     );
                 }
             }
-            None => {}
+            // `--no-profile`: the user opted out of managed mode, so there is no
+            // policy to approve — say what to do instead of printing nothing (#187).
+            None => {
+                if zh {
+                    println!(
+                        "  已跳过策略描述文件（--no-profile）：Chrome 不会进入受管理状态，\n\
+                         \x20 「使用安全 DNS」也不受影响。改为每个 profile 手动装一次扩展：\n\
+                         \x20   chrome-use extension install --all-profiles\n\
+                         \x20   （或自行在各 profile 里打开 {STORE_URL} 点「加入 Chrome」）"
+                    );
+                } else {
+                    println!(
+                        "  Policy profile skipped (--no-profile): Chrome stays unmanaged and your\n\
+                         \x20 \"Use secure DNS\" setting is untouched. Install the extension per\n\
+                         \x20 profile instead:\n\
+                         \x20   chrome-use extension install --all-profiles\n\
+                         \x20   (or open {STORE_URL} in each profile and press \"Add to Chrome\")"
+                    );
+                }
+            }
         }
     }
 
@@ -1646,6 +1708,188 @@ fn managed_policy_state() -> PolicyState {
     }
 }
 
+/// What a live extension version actually means, given the build this CLI
+/// bundles AND the newest build published on the Chrome Web Store.
+///
+/// The middle case is the one that matters: a Web Store user is pinned to the
+/// newest **published** build, which is regularly older than the version in
+/// this repo (0.5.16 bundled while the Store still served 0.5.12 — #186).
+/// Calling that "OUTDATED" and telling them to hit Update sends them after a
+/// build that does not exist yet.
+#[derive(Debug, PartialEq)]
+pub enum ExtVersionVerdict {
+    /// Live == bundled.
+    Current,
+    /// Live is behind a build the user can actually install today.
+    BehindStore { store: String },
+    /// Live IS the newest published build; the bundled one isn't out yet.
+    NewestPublished { store: String },
+    /// Behind the bundled build, and the Store version is unknown (offline).
+    BehindBundledStoreUnknown,
+    /// Live is newer than the bundled build (unpacked dev build).
+    AheadOfBundled,
+}
+
+/// Classify the live extension version. `store` is the newest version the Web
+/// Store serves, when we managed to ask.
+pub fn classify_ext_version(live: &str, bundled: &str, store: Option<&str>) -> ExtVersionVerdict {
+    if live == bundled {
+        return ExtVersionVerdict::Current;
+    }
+    if crate::upgrade::version_is_newer(live, bundled) {
+        return ExtVersionVerdict::AheadOfBundled;
+    }
+    match store {
+        Some(s) if crate::upgrade::version_is_newer(s, live) => ExtVersionVerdict::BehindStore {
+            store: s.to_string(),
+        },
+        Some(s) => ExtVersionVerdict::NewestPublished {
+            store: s.to_string(),
+        },
+        None => ExtVersionVerdict::BehindBundledStoreUnknown,
+    }
+}
+
+/// The `live extension version:` line for `extension status`, phrased by what
+/// the user can actually do about it.
+pub fn ext_version_line(live: &str, bundled: &str, store: Option<&str>) -> String {
+    match classify_ext_version(live, bundled, store) {
+        ExtVersionVerdict::Current => format!("✓ live extension version: {live}"),
+        ExtVersionVerdict::AheadOfBundled => format!(
+            "✓ live extension version: {live} (newer than the {bundled} this CLI bundles — \
+             unpacked dev build)"
+        ),
+        ExtVersionVerdict::BehindStore { store } => format!(
+            "  ! live extension version: {live} — OUTDATED, the Web Store serves {store}.\n\
+             \x20   Update it at chrome://extensions (turn on Developer mode → Update), or \
+             reload the unpacked build."
+        ),
+        ExtVersionVerdict::NewestPublished { store } => format!(
+            "✓ live extension version: {live} — the newest build published on the Web Store \
+             ({store}).\n\
+             \x20   This CLI bundles {bundled}, which isn't published yet: there is nothing to \
+             update to,\n\
+             \x20   and nothing is broken. To run the bundled build now, load \
+             extensions/ab-connect unpacked."
+        ),
+        ExtVersionVerdict::BehindBundledStoreUnknown => format!(
+            "  live extension version: {live} (this CLI bundles {bundled}; couldn't reach the \
+             Web Store\n\
+             \x20   to see which build is published — offline?). If a newer one exists: \
+             chrome://extensions\n\
+             \x20   → Developer mode → Update."
+        ),
+    }
+}
+
+/// Ask the Chrome Web Store's update service which version it currently serves
+/// for our extension. Best-effort and short-fused: this only runs when the live
+/// version already differs from the bundled one, and any failure (offline, CI,
+/// proxy) degrades to `None` rather than blocking a diagnostic command.
+/// `curl` matches how the CLI does its other version checks (see `upgrade`).
+pub fn store_extension_version() -> Option<String> {
+    let url = format!(
+        "{UPDATE_URL}?response=updatecheck&prodversion=140.0&acceptformat=crx3\
+         &x=id%3D{STORE_EXTENSION_ID}%26uc"
+    );
+    let out = std::process::Command::new("curl")
+        .args(["-fsSL", "--max-time", "4", &url])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    parse_store_update_version(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Pull `version="x.y.z"` out of the update service's XML response. The
+/// `updatecheck` element carries it; `status="noupdate"`/error responses don't,
+/// and yield `None`.
+fn parse_store_update_version(xml: &str) -> Option<String> {
+    let tag = xml.split("<updatecheck").nth(1)?;
+    let v = tag.split("version=\"").nth(1)?;
+    let v = v.split('"').next()?.trim();
+    (!v.is_empty() && v.chars().next().is_some_and(|c| c.is_ascii_digit())).then(|| v.to_string())
+}
+
+/// Should this `extension install` run write + queue the macOS policy profile?
+/// Only when it isn't already doing its job, the user didn't pick the
+/// per-profile Web Store route, and didn't opt out of managed mode with
+/// `--no-profile` (#187).
+#[cfg_attr(target_os = "windows", allow(dead_code))]
+fn wants_policy_profile(policy: &PolicyState, all_profiles: bool, no_profile: bool) -> bool {
+    *policy != PolicyState::Active && !all_profiles && !no_profile
+}
+
+/// What approving the policy profile costs the user, spelled out where they can
+/// still say no. Chrome treats ANY policy as "managed by your organization",
+/// and on a managed browser it locks settings it doesn't let managed users
+/// change — Secure DNS (DoH) is the one that bit #187 — and marks the extension
+/// "installed by your administrator", which removes the manual update/remove
+/// buttons (#186). Neither is something we can policy our way out of: the
+/// managed badge IS the force-install mechanism. So disclose it and give the
+/// exit.
+#[cfg_attr(target_os = "windows", allow(dead_code))]
+fn managed_mode_tradeoff(zh: bool) -> String {
+    if zh {
+        format!(
+            "     代价（批准前请先读）：Chrome 会变成「由贵单位管理」状态 ——\n\
+             \x20      · 「使用安全 DNS (DoH)」会被 Chrome 停用并锁死（#187）；自定义 DoH\n\
+             \x20        依赖者（如访问 linux.do）请改选 B。\n\
+             \x20      · 扩展会显示「由管理员安装」：没有手动更新/删除按钮（#186），\n\
+             \x20        更新交给 Chrome 自动进行（约每 5 小时一次，商店源）。\n\
+             \x20      随时可退出：profiles remove -identifier {PROFILE_ID}\n\
+             \x20      （或跳过这一步：chrome-use extension install --no-profile）"
+        )
+    } else {
+        format!(
+            "     What it costs (read before approving): Chrome switches to \"managed by\n\
+             \x20      your organization\" —\n\
+             \x20      · Chrome disables and locks the \"Use secure DNS\" (DoH) setting (#187);\n\
+             \x20        if you rely on a custom DoH resolver, pick B instead.\n\
+             \x20      · The extension shows as \"installed by your administrator\": no manual\n\
+             \x20        update/remove button (#186); Chrome auto-updates it from the Web\n\
+             \x20        Store (~every 5h) instead.\n\
+             \x20      Reversible any time: profiles remove -identifier {PROFILE_ID}\n\
+             \x20      (or skip this step up front: chrome-use extension install --no-profile)"
+        )
+    }
+}
+
+/// The consequences of a live force-install policy, printed by `extension
+/// status` — the two things users file issues about (#186 "the extension is
+/// managed and I can't update it", #187 "Secure DNS is locked") plus how to
+/// update now and how to leave managed mode without losing the extension.
+#[cfg_attr(target_os = "windows", allow(dead_code))]
+fn managed_mode_notice(zh: bool) -> String {
+    if zh {
+        format!(
+            "  ! 因此 Chrome 处于「由贵单位管理」状态，代价有两个：\n\
+             \x20   · 扩展显示「由管理员安装」——没有手动更新/删除按钮（#186）。\n\
+             \x20     更新由 Chrome 自动从商店拉取（约每 5 小时）；想立刻更新：\n\
+             \x20     chrome://extensions → 打开右上角「开发者模式」→ 点「更新」。\n\
+             \x20   · 「使用安全 DNS (DoH)」被 Chrome 停用并锁死（#187）。\n\
+             \x20   想退出受管理状态（自定义 DoH 会恢复）：\n\
+             \x20     profiles remove -identifier {PROFILE_ID}\n\
+             \x20   注意：移除策略后 Chrome 会一并卸载它装的扩展。之后在每个 profile 里\n\
+             \x20   打开 {STORE_URL}\n\
+             \x20   点一次「加入 Chrome」即可 —— 同一个扩展，照样自动更新，且可自行管理。"
+        )
+    } else {
+        format!(
+            "  ! That policy is also why Chrome is \"managed by your organization\":\n\
+             \x20   · the extension shows as \"installed by your administrator\" — no manual\n\
+             \x20     update/remove button (#186). Chrome auto-updates it from the Web Store\n\
+             \x20     (~every 5h); to update now: chrome://extensions → Developer mode →\n\
+             \x20     Update.\n\
+             \x20   · Chrome disables and locks the \"Use secure DNS\" (DoH) setting (#187).\n\
+             \x20   To leave managed mode (your custom DoH comes back):\n\
+             \x20     profiles remove -identifier {PROFILE_ID}\n\
+             \x20   Removing the policy also uninstalls the extension it installed — re-add it\n\
+             \x20   per profile from {STORE_URL}\n\
+             \x20   (\"Add to Chrome\"): same extension, still auto-updating, yours to manage."
+        )
+    }
+}
+
 /// Whether an enterprise/managed-Chrome policy BLOCKS our extension — the
 /// "您的管理员已屏蔽此内容 / Your administrator has blocked this" case (distinct
 /// from force-install). True when our id is in `ExtensionInstallBlocklist`, or
@@ -1939,7 +2183,11 @@ fn parse_chrome_extension_status(
     }
 }
 
-fn print_chrome_extension_status(status: &ChromeExtensionStatus, expected_version: &str) {
+fn print_chrome_extension_status(
+    status: &ChromeExtensionStatus,
+    expected_version: &str,
+    store_version: Option<&str>,
+) {
     let source = if status.id == STORE_EXTENSION_ID {
         "Web Store"
     } else {
@@ -1952,9 +2200,14 @@ fn print_chrome_extension_status(status: &ChromeExtensionStatus, expected_versio
     );
     if let Some(ver) = &status.version {
         println!("  active manifest version: {ver}");
-        if crate::upgrade::version_is_newer(expected_version, ver) {
+        // Only nag when a newer build is actually installable — being behind
+        // the bundled version while sitting on the newest PUBLISHED one is the
+        // normal state for Web Store users, not a problem to fix (#186).
+        if let ExtVersionVerdict::BehindStore { store } =
+            classify_ext_version(ver, expected_version, store_version)
+        {
             println!(
-                "! active extension is older than bundled {expected_version}; open chrome://extensions, accept pending permissions/reload, or restart Chrome"
+                "! active extension {ver} is older than the published {store}; open chrome://extensions, accept pending permissions/reload, or restart Chrome"
             );
         }
     }
@@ -2937,6 +3190,112 @@ mod tests {
         assert!(!cfg.contains("updates.xml"), "no self-hosted update feed");
         assert!(cfg.contains(PROFILE_ID));
         assert!(cfg.contains("leeguoo.com"));
+    }
+
+    #[test]
+    fn no_profile_opts_out_of_the_managed_policy_route() {
+        // #187: approving the policy makes Chrome managed, which locks Secure
+        // DNS — `--no-profile` must mean we never write or queue it, whatever
+        // the current policy state is.
+        for policy in [
+            PolicyState::Absent,
+            PolicyState::Stale("x;y".into()),
+            PolicyState::Unknown,
+        ] {
+            assert!(
+                wants_policy_profile(&policy, false, false),
+                "{policy:?} with no opt-out should still offer the policy"
+            );
+            assert!(!wants_policy_profile(&policy, false, true), "--no-profile");
+            assert!(
+                !wants_policy_profile(&policy, true, false),
+                "--all-profiles picks the Web Store route"
+            );
+        }
+        // Already doing its job — nothing to write.
+        assert!(!wants_policy_profile(&PolicyState::Active, false, false));
+    }
+
+    #[test]
+    fn a_live_extension_is_only_outdated_when_a_newer_one_is_published() {
+        // #186: the bundled build runs ahead of the Web Store (0.5.16 bundled
+        // while the Store served 0.5.12). A Web Store user IS up to date there;
+        // calling it OUTDATED and pointing at Update chases a build that does
+        // not exist.
+        assert_eq!(
+            classify_ext_version("0.5.12", "0.5.16", Some("0.5.12")),
+            ExtVersionVerdict::NewestPublished {
+                store: "0.5.12".into()
+            }
+        );
+        assert_eq!(
+            classify_ext_version("0.5.10", "0.5.16", Some("0.5.12")),
+            ExtVersionVerdict::BehindStore {
+                store: "0.5.12".into()
+            }
+        );
+        assert_eq!(
+            classify_ext_version("0.5.16", "0.5.16", Some("0.5.12")),
+            ExtVersionVerdict::Current
+        );
+        assert_eq!(
+            classify_ext_version("0.5.17", "0.5.16", Some("0.5.12")),
+            ExtVersionVerdict::AheadOfBundled
+        );
+        // Offline: don't invent a verdict either way.
+        assert_eq!(
+            classify_ext_version("0.5.12", "0.5.16", None),
+            ExtVersionVerdict::BehindBundledStoreUnknown
+        );
+
+        // The line the user reads must not say OUTDATED for the published build,
+        // and must say it when a newer build really is out there.
+        let published = ext_version_line("0.5.12", "0.5.16", Some("0.5.12"));
+        assert!(!published.contains("OUTDATED"), "{published}");
+        assert!(published.starts_with('✓'), "{published}");
+        assert!(ext_version_line("0.5.10", "0.5.16", Some("0.5.12")).contains("OUTDATED"));
+    }
+
+    #[test]
+    fn store_update_response_yields_the_published_version() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?><gupdate protocol="2.0">\
+<app appid="knfcmbamhjmaonkfnjhldjedeobeafmk" status="ok"><updatecheck \
+codebase="https://x/KNFC_0_5_12_0.crx" status="ok" version="0.5.12"/></app></gupdate>"#;
+        assert_eq!(
+            parse_store_update_version(xml).as_deref(),
+            Some("0.5.12"),
+            "must read the updatecheck version, not the codebase filename"
+        );
+        // No update element (unlisted/removed item) → no claim.
+        assert_eq!(parse_store_update_version("<gupdate></gupdate>"), None);
+        assert_eq!(parse_store_update_version(""), None);
+    }
+
+    #[test]
+    fn managed_mode_texts_name_both_costs_and_the_way_out() {
+        // Both issues this text answers must stay answerable from the output
+        // alone: what managed mode costs (#186 no manual update/remove, #187
+        // Secure DNS locked) and the exact command that undoes it.
+        for zh in [false, true] {
+            let notice = managed_mode_notice(zh);
+            let tradeoff = managed_mode_tradeoff(zh);
+            for text in [&notice, &tradeoff] {
+                assert!(text.contains(PROFILE_ID), "removal command must be shown");
+                assert!(text.contains("DNS"), "the DoH lockdown must be named");
+            }
+            assert!(
+                notice.contains("chrome://extensions"),
+                "status must say how to force an update now"
+            );
+            assert!(
+                notice.contains(STORE_URL),
+                "status must say how to keep the extension after un-managing"
+            );
+            assert!(
+                tradeoff.contains("--no-profile"),
+                "the pre-approval text must offer the opt-out"
+            );
+        }
     }
 
     #[test]

--- a/cli/src/doctor/versions.rs
+++ b/cli/src/doctor/versions.rs
@@ -68,7 +68,19 @@ pub(super) fn check(checks: &mut Vec<Check>) {
                              this CLI bundles {expected_ext}, not published yet"
                     ),
                 )),
-                _ => checks.push(
+                connect::ExtVersionVerdict::AheadOfStore { store } => checks.push(Check::new(
+                    "versions.extension",
+                    category,
+                    Status::Pass,
+                    format!(
+                        "extension {ext} — ahead of the published {store}, behind the bundled \
+                         {expected_ext} (intermediate unpacked build)"
+                    ),
+                )),
+                // The guard above already excludes Current / AheadOfBundled.
+                connect::ExtVersionVerdict::Current
+                | connect::ExtVersionVerdict::AheadOfBundled
+                | connect::ExtVersionVerdict::BehindBundledStoreUnknown => checks.push(
                     Check::new(
                         "versions.extension",
                         category,

--- a/cli/src/doctor/versions.rs
+++ b/cli/src/doctor/versions.rs
@@ -39,20 +39,52 @@ pub(super) fn check(checks: &mut Vec<Check>) {
     // from the extension manifest) is what we expect to be running.
     let expected_ext = env!("AB_CONNECT_VERSION");
     match connect::relay_ext_version() {
+        // Behind the bundled build is only a WARNING when a newer build is
+        // actually published — the bundled version routinely runs ahead of the
+        // Web Store, and telling people to hit Update for a build that isn't
+        // released is a dead end (#186). Ask the Store before judging.
         Some(ext) if upgrade::version_is_newer(expected_ext, &ext) => {
-            checks.push(
-                Check::new(
+            let store = connect::store_extension_version();
+            match connect::classify_ext_version(&ext, expected_ext, store.as_deref()) {
+                connect::ExtVersionVerdict::BehindStore { store } => checks.push(
+                    Check::new(
+                        "versions.extension",
+                        category,
+                        Status::Warn,
+                        format!("extension {ext} is behind the published {store}"),
+                    )
+                    .with_fix(
+                        "update ab-connect in Chrome: chrome://extensions \u{2192} \
+                         Developer mode \u{2192} Update (or reload the unpacked build)"
+                            .to_string(),
+                    ),
+                ),
+                connect::ExtVersionVerdict::NewestPublished { store } => checks.push(Check::new(
                     "versions.extension",
                     category,
-                    Status::Warn,
-                    format!("extension {ext} is behind the bundled {expected_ext}"),
-                )
-                .with_fix(
-                    "update ab-connect in Chrome: chrome://extensions \u{2192} reload \
-                     (or wait for the Web Store auto-update)"
-                        .to_string(),
+                    Status::Pass,
+                    format!(
+                        "extension {ext} — newest published on the Web Store ({store}); \
+                             this CLI bundles {expected_ext}, not published yet"
+                    ),
+                )),
+                _ => checks.push(
+                    Check::new(
+                        "versions.extension",
+                        category,
+                        Status::Info,
+                        format!(
+                            "extension {ext} is behind the bundled {expected_ext} \
+                             (Web Store version unknown — offline?)"
+                        ),
+                    )
+                    .with_fix(
+                        "if a newer build is published: chrome://extensions \u{2192} \
+                         Developer mode \u{2192} Update"
+                            .to_string(),
+                    ),
                 ),
-            );
+            }
         }
         Some(ext) => {
             checks.push(Check::new(

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -4030,6 +4030,19 @@ MCP:
 Setup:
   install                    Install browser binaries
   install --with-deps        Also install system dependencies (Linux)
+  extension install          Guided setup for driving your real Chrome. On macOS it
+                             offers a policy profile that installs the extension into
+                             every profile silently — that also puts Chrome in
+                             "managed by your organization" mode, which locks the
+                             "Use secure DNS" setting and removes the extension's
+                             manual update/remove buttons. --no-profile skips it (Web
+                             Store route instead); --all-profiles opens the Store page
+                             in each profile; --no-open writes the policy without
+                             queueing it.
+  extension status           Host/relay/extension versions, driving profile, per-profile
+                             coverage, and what the install policy currently costs
+  extension uninstall        Remove the native-messaging host (+ tells you how to drop
+                             the policy profile and leave managed mode)
   upgrade                    Upgrade to the latest version
   doctor [--fix]             Diagnose install; auto-clean stale files
   dashboard start            Start the observability dashboard

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -639,7 +639,7 @@ JS</code></pre>
 <span class="du-prompt">$</span> chrome-use extension install <span class="du-flag">--all-profiles</span>   <span class="du-cmt"># 在每个缺失的 profile 里打开商店页</span></code></pre>
       </div>
       <div class="du-callout note">
-        <div class="du-callout-title">⚠️ macOS 的策略描述文件 = 受管理的 Chrome</div>
+        <div class="du-callout-title">⚠ macOS 的策略描述文件 = 受管理的 Chrome</div>
         安装向导里那条「静默装进所有 profile」会让 Chrome 变成「由贵单位管理」：
         <strong>「使用安全 DNS (DoH)」被停用并锁死</strong>（<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>），
         扩展也变成「由管理员安装」、没有手动更新/删除按钮（<a href="https://github.com/leeguooooo/chrome-use/issues/186">#186</a>）。

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -632,7 +632,19 @@ JS</code></pre>
 <span class="du-prompt">$</span> chrome-use tab t3                   <span class="du-cmt"># 把会话切到其中一个</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span>              <span class="du-cmt"># 像普通会话一样驱动它</span>
 <span class="du-prompt">$</span> chrome-use extension status         <span class="du-cmt"># 宿主是否已安装？</span>
-<span class="du-prompt">$</span> chrome-use extension uninstall      <span class="du-cmt"># 移除宿主清单</span></code></pre>
+<span class="du-prompt">$</span> chrome-use extension uninstall      <span class="du-cmt"># 移除宿主清单</span>
+
+<span class="du-cmt"># macOS：跳过那个会让 Chrome 进入受管理状态的策略描述文件</span>
+<span class="du-prompt">$</span> chrome-use extension install <span class="du-flag">--no-profile</span>
+<span class="du-prompt">$</span> chrome-use extension install <span class="du-flag">--all-profiles</span>   <span class="du-cmt"># 在每个缺失的 profile 里打开商店页</span></code></pre>
+      </div>
+      <div class="du-callout note">
+        <div class="du-callout-title">⚠️ macOS 的策略描述文件 = 受管理的 Chrome</div>
+        安装向导里那条「静默装进所有 profile」会让 Chrome 变成「由贵单位管理」：
+        <strong>「使用安全 DNS (DoH)」被停用并锁死</strong>（<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>），
+        扩展也变成「由管理员安装」、没有手动更新/删除按钮（<a href="https://github.com/leeguooooo/chrome-use/issues/186">#186</a>）。
+        用 <code>--no-profile</code> 跳过，或用 <code>profiles remove -identifier com.leeguoo.chrome-use.connect</code> 退出
+        （Chrome 会一并卸载它装的扩展，从商店重装即可）。当前状态随时可查：<code>chrome-use extension status</code>。
       </div>
       <p>
         <code>chrome-use status</code> 会区分「已安装清单」和「launcher 确实指向可执行文件」；

--- a/docs/en/commands.html
+++ b/docs/en/commands.html
@@ -647,7 +647,23 @@ JS</code></pre>
 <span class="du-prompt">$</span> chrome-use tab t3                   <span class="du-cmt"># switch the session to one of them</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span>              <span class="du-cmt"># drive it like any normal session</span>
 <span class="du-prompt">$</span> chrome-use extension status         <span class="du-cmt"># is the host installed?</span>
-<span class="du-prompt">$</span> chrome-use extension uninstall      <span class="du-cmt"># remove the host manifest</span></code></pre>
+<span class="du-prompt">$</span> chrome-use extension uninstall      <span class="du-cmt"># remove the host manifest</span>
+
+<span class="du-cmt"># macOS: skip the policy profile that puts Chrome in managed mode</span>
+<span class="du-prompt">$</span> chrome-use extension install <span class="du-flag">--no-profile</span>
+<span class="du-prompt">$</span> chrome-use extension install <span class="du-flag">--all-profiles</span>   <span class="du-cmt"># open the Store page in each missing profile</span></code></pre>
+      </div>
+      <div class="du-callout note">
+        <div class="du-callout-title">⚠️ The macOS policy profile means a managed Chrome</div>
+        The setup wizard's "silent, every profile at once" route makes Chrome "managed by your organization":
+        <strong>the "Use secure DNS" (DoH) setting is disabled and locked</strong>
+        (<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>), and the extension becomes
+        "installed by your administrator" with no manual update/remove button
+        (<a href="https://github.com/leeguooooo/chrome-use/issues/186">#186</a>).
+        Skip it with <code>--no-profile</code>, or undo it with
+        <code>profiles remove -identifier com.leeguoo.chrome-use.connect</code> (Chrome then uninstalls the
+        policy-installed extension — re-add it from the Store). <code>chrome-use extension status</code> always
+        reports where you stand.
       </div>
       <p>
         <code>chrome-use status</code> distinguishes an installed manifest from a runnable native-host launcher.

--- a/docs/en/commands.html
+++ b/docs/en/commands.html
@@ -654,7 +654,7 @@ JS</code></pre>
 <span class="du-prompt">$</span> chrome-use extension install <span class="du-flag">--all-profiles</span>   <span class="du-cmt"># open the Store page in each missing profile</span></code></pre>
       </div>
       <div class="du-callout note">
-        <div class="du-callout-title">⚠️ The macOS policy profile means a managed Chrome</div>
+        <div class="du-callout-title">⚠ The macOS policy profile means a managed Chrome</div>
         The setup wizard's "silent, every profile at once" route makes Chrome "managed by your organization":
         <strong>the "Use secure DNS" (DoH) setting is disabled and locked</strong>
         (<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>), and the extension becomes

--- a/docs/en/install.html
+++ b/docs/en/install.html
@@ -168,6 +168,33 @@ programs.chrome-use = {
         then you add the extension once from the Web Store (Windows has no macOS-style silent force-install). After that, <code>chrome-use open</code> drives your logged-in Chrome the same way.
       </div>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">⚠️ macOS: the policy profile puts Chrome in managed mode</div>
+        <p>
+          On macOS, <code>extension install</code> offers a "silent, every profile at once" route:
+          approve an <code>ExtensionInstallForcelist</code> configuration profile. It really is
+          install-once-and-forget, but it also makes Chrome
+          <strong>"managed by your organization"</strong>:
+        </p>
+        <ul>
+          <li><strong>Chrome disables and locks the "Use secure DNS" (DoH) setting</strong> — sites that depend on a custom DoH resolver (e.g. <code>linux.do</code>) stop resolving (<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>).</li>
+          <li>The extension shows as <strong>"installed by your administrator"</strong>: no manual update/remove button; Chrome auto-updates it from the Web Store instead (<a href="https://github.com/leeguooooo/chrome-use/issues/186">#186</a>).</li>
+        </ul>
+        <p>
+          Skip it if you'd rather not — the Web Store route gets you the same extension, just one
+          click per profile:
+        </p>
+<pre><code><span class="du-prompt">$</span> chrome-use extension install --no-profile      <span class="du-cmt"># never writes the policy profile</span>
+<span class="du-prompt">$</span> chrome-use extension install --all-profiles    <span class="du-cmt"># opens the Store page in each missing profile</span></code></pre>
+        <p>Already approved it and want out (your custom DoH comes back immediately):</p>
+<pre><code><span class="du-prompt">$</span> profiles remove -identifier com.leeguoo.chrome-use.connect</code></pre>
+        <p>
+          Note: removing the policy also uninstalls the extension it installed — re-add it per
+          profile from the Web Store. Same extension, still auto-updating, and yours to manage.
+          <code>chrome-use extension status</code> always reports which state you're in.
+        </p>
+      </div>
+
       <div class="du-callout tip">
         <div class="du-callout-title">✅ Don't want to touch your real Chrome?</div>
         Use <code>chrome-use --launch open &lt;url&gt;</code> to spin up a brand-new, isolated blank-profile browser (with the full anti-detection patch set),

--- a/docs/en/install.html
+++ b/docs/en/install.html
@@ -169,7 +169,7 @@ programs.chrome-use = {
       </div>
 
       <div class="du-callout note">
-        <div class="du-callout-title">⚠️ macOS: the policy profile puts Chrome in managed mode</div>
+        <div class="du-callout-title">⚠ macOS: the policy profile puts Chrome in managed mode</div>
         <p>
           On macOS, <code>extension install</code> offers a "silent, every profile at once" route:
           approve an <code>ExtensionInstallForcelist</code> configuration profile. It really is

--- a/docs/en/real-chrome.html
+++ b/docs/en/real-chrome.html
@@ -90,7 +90,7 @@
       </ul>
 
       <div class="du-callout note">
-        <div class="du-callout-title">⚠️ macOS: don't approve the policy profile by reflex</div>
+        <div class="du-callout-title">⚠ macOS: don't approve the policy profile by reflex</div>
         The setup wizard offers a "silent, every profile at once" route (the configuration profile
         <code>com.leeguoo.chrome-use.connect</code>). It puts Chrome in "managed by your organization" mode:
         <strong>the "Use secure DNS" (DoH) setting is disabled and locked</strong>

--- a/docs/en/real-chrome.html
+++ b/docs/en/real-chrome.html
@@ -90,6 +90,19 @@
       </ul>
 
       <div class="du-callout note">
+        <div class="du-callout-title">⚠️ macOS: don't approve the policy profile by reflex</div>
+        The setup wizard offers a "silent, every profile at once" route (the configuration profile
+        <code>com.leeguoo.chrome-use.connect</code>). It puts Chrome in "managed by your organization" mode:
+        <strong>the "Use secure DNS" (DoH) setting is disabled and locked</strong>
+        (<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>), and the extension is marked
+        "installed by your administrator" with no manual update/remove button
+        (<a href="https://github.com/leeguooooo/chrome-use/issues/186">#186</a>).
+        A Web Store install needs none of that — pass <code>--no-profile</code> to skip it, or undo an approved one
+        with <code>profiles remove -identifier com.leeguoo.chrome-use.connect</code> (Chrome then uninstalls the
+        policy-installed extension; re-add it from the Store).
+      </div>
+
+      <div class="du-callout note">
         <div class="du-callout-title">ℹ️ Dev-build fallback (Load unpacked)</div>
         <code>chrome://extensions</code> → turn on <strong>Developer mode</strong> → <em>Load unpacked</em> →
         pick <code>extensions/ab-connect</code>. Note: a load-unpacked extension may be disabled after Chrome restarts,

--- a/docs/en/troubleshooting.html
+++ b/docs/en/troubleshooting.html
@@ -272,6 +272,44 @@
         extension/relay background.
       </div>
 
+      <h2>Chrome says "managed by your organization" / Secure DNS is locked / the extension won't update</h2>
+      <p>
+        All three come from one thing: the macOS configuration profile
+        (<code>com.leeguoo.chrome-use.connect</code>) that installs the extension into every profile
+        silently. Chrome treats <em>any</em> policy as managed mode, and that costs you:
+      </p>
+      <ul>
+        <li><strong>The "Use secure DNS" (DoH) setting is disabled and locked</strong> — sites that depend
+          on a custom DoH resolver stop resolving
+          (<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>).</li>
+        <li>The extension is marked <strong>"installed by your administrator"</strong>: no manual
+          update/remove button
+          (<a href="https://github.com/leeguooooo/chrome-use/issues/186">#186</a>).</li>
+      </ul>
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">Leaving managed mode</span>
+        </div>
+<pre><code><span class="du-cmt"># where you stand right now (costs + the way out):</span>
+<span class="du-prompt">$</span> chrome-use extension status
+
+<span class="du-cmt"># drop the policy profile — your custom DoH comes back immediately</span>
+<span class="du-prompt">$</span> profiles remove -identifier com.leeguoo.chrome-use.connect
+
+<span class="du-cmt"># Chrome uninstalls the extension it installed; re-add it from the Store (one click per profile)</span>
+<span class="du-prompt">$</span> chrome-use extension install --no-profile --all-profiles</code></pre>
+      </div>
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ "The extension is behind" is often not a problem</div>
+        The <strong>bundled</strong> version in <code>extension status</code> is the one in this repo's
+        source. Web Store review takes time, so it regularly runs ahead of what the Store serves. The CLI
+        now asks the Store before judging: if you're on the <strong>newest published</strong> build it no
+        longer says OUTDATED and no longer sends you after an update that doesn't exist — it only points
+        at <code>chrome://extensions</code> → Developer mode → Update when a newer build really is out.
+        To run the source build, load <code>extensions/ab-connect</code> unpacked.
+      </div>
+
       <h2>You read the wrong page</h2>
       <p>
         <code>eval</code>, <code>screenshot</code>, and <code>network requests</code> all print the page they actually ran on

--- a/docs/en/troubleshooting.html
+++ b/docs/en/troubleshooting.html
@@ -301,7 +301,7 @@
 <span class="du-prompt">$</span> chrome-use extension install --no-profile --all-profiles</code></pre>
       </div>
       <div class="du-callout note">
-        <div class="du-callout-title">ℹ️ "The extension is behind" is often not a problem</div>
+        <div class="du-callout-title">"The extension is behind" is often not a problem</div>
         The <strong>bundled</strong> version in <code>extension status</code> is the one in this repo's
         source. Web Store review takes time, so it regularly runs ahead of what the Store serves. The CLI
         now asks the Store before judging: if you're on the <strong>newest published</strong> build it no

--- a/docs/install.html
+++ b/docs/install.html
@@ -167,6 +167,32 @@ programs.chrome-use = {
         再从应用商店手动装一次扩展即可（Windows 没有 macOS 那套静默强制安装）。之后 <code>chrome-use open</code> 一样驱动你已登录的 Chrome。
       </div>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">⚠️ macOS：那个「策略描述文件」会让 Chrome 进入受管理状态</div>
+        <p>
+          <code>extension install</code> 在 macOS 上会提供一条「静默装进所有 profile」的路径：批准一个
+          <code>ExtensionInstallForcelist</code> 策略描述文件。它确实一劳永逸，但代价是 Chrome 会变成
+          <strong>「由贵单位管理」</strong>：
+        </p>
+        <ul>
+          <li><strong>「使用安全 DNS (DoH)」被停用并锁死</strong>——依赖自定义 DoH 的站点（如 <code>linux.do</code>）会解析失败（<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>）。</li>
+          <li>扩展显示<strong>「由管理员安装」</strong>：没有手动更新/删除按钮，更新交给 Chrome 自动从商店拉取（<a href="https://github.com/leeguooooo/chrome-use/issues/186">#186</a>）。</li>
+        </ul>
+        <p>
+          不想要就跳过它——从商店装扩展的效果完全一样，只是每个 profile 要点一次「加入 Chrome」：
+        </p>
+<pre><code><span class="du-prompt">$</span> chrome-use extension install --no-profile      <span class="du-cmt"># 不写策略描述文件</span>
+<span class="du-prompt">$</span> chrome-use extension install --all-profiles    <span class="du-cmt"># 在每个缺失的 profile 里打开商店页</span></code></pre>
+        <p>
+          已经批准过、想退出受管理状态（自定义 DoH 会立刻恢复）：
+        </p>
+<pre><code><span class="du-prompt">$</span> profiles remove -identifier com.leeguoo.chrome-use.connect</code></pre>
+        <p>
+          注意：移除策略后 Chrome 会一并卸载它装的扩展——之后在每个 profile 里从商店重新「加入 Chrome」即可，
+          还是同一个扩展、照样自动更新，而且这次归你自己管。<code>chrome-use extension status</code> 会实时告诉你当前处于哪种状态。
+        </p>
+      </div>
+
       <div class="du-callout tip">
         <div class="du-callout-title">✅ 不想碰你的真实 Chrome？</div>
         用 <code>chrome-use --launch open &lt;url&gt;</code> 开一个全新的、隔离的空 profile 浏览器（上全套反检测补丁），

--- a/docs/install.html
+++ b/docs/install.html
@@ -168,7 +168,7 @@ programs.chrome-use = {
       </div>
 
       <div class="du-callout note">
-        <div class="du-callout-title">⚠️ macOS：那个「策略描述文件」会让 Chrome 进入受管理状态</div>
+        <div class="du-callout-title">⚠ macOS：那个「策略描述文件」会让 Chrome 进入受管理状态</div>
         <p>
           <code>extension install</code> 在 macOS 上会提供一条「静默装进所有 profile」的路径：批准一个
           <code>ExtensionInstallForcelist</code> 策略描述文件。它确实一劳永逸，但代价是 Chrome 会变成

--- a/docs/real-chrome.html
+++ b/docs/real-chrome.html
@@ -87,6 +87,17 @@
       </ul>
 
       <div class="du-callout note">
+        <div class="du-callout-title">⚠️ macOS：别顺手批准那个策略描述文件</div>
+        安装向导会提供一条「静默装进所有 profile」的路径（配置描述文件 <code>com.leeguoo.chrome-use.connect</code>）。
+        它会让 Chrome 进入「由贵单位管理」状态：<strong>「使用安全 DNS (DoH)」被停用并锁死</strong>
+        （<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>），扩展也会标成「由管理员安装」、
+        没有手动更新/删除按钮（<a href="https://github.com/leeguooooo/chrome-use/issues/186">#186</a>）。
+        商店安装完全不需要它——加 <code>--no-profile</code> 即可跳过；已经批准过的用
+        <code>profiles remove -identifier com.leeguoo.chrome-use.connect</code> 退出（Chrome 会一并卸载它装的扩展，
+        再从商店装回来即可）。
+      </div>
+
+      <div class="du-callout note">
         <div class="du-callout-title">ℹ️ 开发版兜底（Load unpacked）</div>
         <code>chrome://extensions</code> → 打开 <strong>Developer mode</strong> → <em>Load unpacked</em> →
         选 <code>extensions/ab-connect</code>。注意：Load-unpacked 装的扩展在 Chrome 重启后可能被禁用，

--- a/docs/real-chrome.html
+++ b/docs/real-chrome.html
@@ -87,7 +87,7 @@
       </ul>
 
       <div class="du-callout note">
-        <div class="du-callout-title">⚠️ macOS：别顺手批准那个策略描述文件</div>
+        <div class="du-callout-title">⚠ macOS：别顺手批准那个策略描述文件</div>
         安装向导会提供一条「静默装进所有 profile」的路径（配置描述文件 <code>com.leeguoo.chrome-use.connect</code>）。
         它会让 Chrome 进入「由贵单位管理」状态：<strong>「使用安全 DNS (DoH)」被停用并锁死</strong>
         （<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>），扩展也会标成「由管理员安装」、

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -283,7 +283,7 @@
 <span class="du-prompt">$</span> chrome-use extension install --no-profile --all-profiles</code></pre>
       </div>
       <div class="du-callout note">
-        <div class="du-callout-title">ℹ️ 「扩展版本落后」不一定是问题</div>
+        <div class="du-callout-title">「扩展版本落后」不一定是问题</div>
         <code>extension status</code> 里的 <strong>bundled</strong> 是本仓库源码里的版本，商店上架要审核，
         所以它经常比商店版新。CLI 现在会去问一次商店：你手上的就是<strong>已发布的最新版</strong>时不会再报
         OUTDATED，也不会让你去点一个根本不存在的更新；只有商店确实有更新的版本时才提示

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -257,6 +257,39 @@
         <a href="/real-chrome.html">驱动真实 Chrome</a>。
       </div>
 
+      <h2>Chrome 变成「由贵单位管理」／安全 DNS 被锁／扩展更新不了</h2>
+      <p>
+        这三件事同一个来源：macOS 上那个用来<strong>静默把扩展装进所有 profile</strong> 的策略描述文件
+        （<code>com.leeguoo.chrome-use.connect</code>）。Chrome 只要看见任何策略就进入受管理状态，随之而来：
+      </p>
+      <ul>
+        <li><strong>「使用安全 DNS (DoH)」被停用并锁死</strong>——依赖自定义 DoH 的站点会解析失败
+          （<a href="https://github.com/leeguooooo/chrome-use/issues/187">#187</a>）。</li>
+        <li>扩展标为<strong>「由管理员安装」</strong>，没有手动更新／删除按钮
+          （<a href="https://github.com/leeguooooo/chrome-use/issues/186">#186</a>）。</li>
+      </ul>
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">退出受管理状态</span>
+        </div>
+<pre><code><span class="du-cmt"># 当前状态（含代价与出路）：</span>
+<span class="du-prompt">$</span> chrome-use extension status
+
+<span class="du-cmt"># 移除策略描述文件——自定义 DoH 立刻恢复</span>
+<span class="du-prompt">$</span> profiles remove -identifier com.leeguoo.chrome-use.connect
+
+<span class="du-cmt"># Chrome 会一并卸载它装的扩展，从商店重新装一次即可（每个 profile 点一下）</span>
+<span class="du-prompt">$</span> chrome-use extension install --no-profile --all-profiles</code></pre>
+      </div>
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ 「扩展版本落后」不一定是问题</div>
+        <code>extension status</code> 里的 <strong>bundled</strong> 是本仓库源码里的版本，商店上架要审核，
+        所以它经常比商店版新。CLI 现在会去问一次商店：你手上的就是<strong>已发布的最新版</strong>时不会再报
+        OUTDATED，也不会让你去点一个根本不存在的更新；只有商店确实有更新的版本时才提示
+        <code>chrome://extensions</code> → 开发者模式 → 更新。想跑源码里的新版，只能用「加载已解压的扩展程序」。
+      </div>
+
       <h2>读到了错误的页面</h2>
       <p>
         <code>eval</code>、<code>screenshot</code>、<code>network requests</code> 都会把实际运行所在的页面打到 stderr：

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -411,12 +411,26 @@ One-time setup:
 chrome-use extension install        # writes the native-messaging host manifest
 ```
 
+On macOS the guided setup also offers a policy profile that installs the
+extension into every Chrome profile silently. It works, but it puts Chrome in
+**"managed by your organization"** mode: Chrome then disables and locks the
+"Use secure DNS" (DoH) setting (#187) and marks the extension "installed by
+your administrator" — no manual update/remove button (#186). Skip it with
+`chrome-use extension install --no-profile` (Web Store route instead); undo an
+approved one with `profiles remove -identifier com.leeguoo.chrome-use.connect`,
+which also uninstalls the extension the policy installed (re-add it from the
+Store). `chrome-use extension status` reports which state the machine is in.
+
 The native-messaging host accepts **both** extension origins, so either install
 works — but prefer the Store build:
 
 1. **Chrome Web Store (recommended)** — one-click *Add to Chrome*:
    <https://chromewebstore.google.com/detail/chrome-use/knfcmbamhjmaonkfnjhldjedeobeafmk>
    Restart-stable and auto-updating (store id `knfcmbamhjmaonkfnjhldjedeobeafmk`).
+   NOTE: the Store serves the newest **published** build, which is regularly
+   older than the version bundled with the CLI (review latency). `extension
+   status` asks the Store before calling anything OUTDATED — being on the
+   newest published build is fine, not a problem to fix.
 2. **Load unpacked (dev)** — load `<repo>/extensions/ab-connect` from source;
    its pinned `key` gives the stable id `ciiljdlhd…`. NOTE: Load-unpacked
    extensions can be disabled/dropped on Chrome restart (Developer-mode handling),

--- a/skill-data/real-chrome/SKILL.md
+++ b/skill-data/real-chrome/SKILL.md
@@ -21,6 +21,14 @@ One-time setup:
    `extensions/ab-connect`. Load-unpacked can be disabled on Chrome restart, so
    prefer the Store build for unattended setups.)
 
+> **macOS: the "silent, all profiles" policy makes Chrome managed.** Approving
+> the configuration profile `extension install` offers puts Chrome in "managed by
+> your organization" mode — which locks the "Use secure DNS" (DoH) setting (#187)
+> and strips the extension's manual update/remove buttons (#186). Use
+> `chrome-use extension install --no-profile` to never write it, or
+> `profiles remove -identifier com.leeguoo.chrome-use.connect` to undo it (Chrome
+> then uninstalls the policy-installed extension — re-add it from the Store).
+
 Once installed, plain `chrome-use open <url>` auto-connects through the
 extension relay — `auto_connect_cdp` **prefers the live relay over a raw
 `--remote-debugging-port`**, so Chrome 136+'s "Allow remote debugging?" consent


### PR DESCRIPTION
Closes #187, closes #186.

## 根因

两个 issue 指向同一个装置、两条不同的洞。

**1. 策略描述文件的代价从没披露过（#187）**

macOS 上 `extension install` 会写并排队一个 `ExtensionInstallForcelist` 配置描述文件，用来把扩展静默装进所有 profile。Chrome 只要看见任何策略就进入「由贵单位管理」状态，于是：

- Chrome **停用并锁死「使用安全 DNS (DoH)」**——报告者依赖自定义 DoH 才能无污染访问 `linux.do`，装完就打不开了；
- 扩展被标成「由管理员安装」，**没有手动更新/删除按钮**（这正是 #186）。

批准前 CLI 一个字都没提，批准后也没给退出方式。报告者建议的第 2 条（在 mobileconfig 里补 `DnsOverHttpsMode`）没有采纳：那只会把 DoH 也变成策略托管项，用户自己的模板/域名照样填不回去——受管理状态本身就是强制安装的代价，能做的是**说清楚 + 给出口**。

**2. 「找不到更新插件的办法」的真身（#186）：我们自己在谎报 OUTDATED**

本仓库源码里的扩展版本是 **0.5.16**，而商店实际服务的最新版是 **0.5.12**（用商店 updatecheck 接口实测）：

```
$ curl -s "https://clients2.google.com/service/update2/crx?response=updatecheck&prodversion=140.0&acceptformat=crx3&x=id%3Dknfcmbamhjmaonkfnjhldjedeobeafmk%26uc"
… <updatecheck … version="0.5.12"/>
```

昨晚 v1.5.92 为了修 #183 加的提示，把「live ≠ bundled」一律判成 `OUTDATED`，并让用户去 `chrome://extensions` 点更新——可 0.5.16 根本没发布，点一万次也拿不到。`doctor` 和 profile 那条 `! active extension is older than bundled` 同病。所以用户找不到更新方法，是因为**没有可更新的东西**，而 CLI 却说他落后了。

## 改动

| 位置 | 改了什么 |
|---|---|
| `extension install --no-profile` | 新增标志：完全不写/不排队策略描述文件，改走商店安装路径；`[3/3]` 打印对应指引而不是什么都不打 |
| 安装向导 A) 选项 | 批准前列出两项代价（DoH 锁死 / 无手动更新删除）+ `profiles remove -identifier …` 退出命令 + `--no-profile` 出口；B) 明说不会进入受管理状态 |
| `extension status` | 策略生效时说明「因此 Chrome 受管理」、如何立刻更新、如何退出，并提醒移除策略会一并卸载它装的扩展（要从商店重装） |
| `extension uninstall` | 提示补上同样的因果 |
| 版本判定（status + doctor + profile 行） | 只在版本对不上时问一次商店 updatecheck（`curl --max-time 4`，失败降级）：真落后于**已发布**版才叫 OUTDATED；手上就是已发布最新版则打 ✓ 并说明源码版未发布、要跑它只能加载已解压扩展；离线则不下结论 |
| JSON | 新增 `storeExtensionVersion`、`bundledExtensionVersion`（`expectedExtensionVersion` 保留不动）、install 的 `noProfile` |
| 文档 | `docs/{,en/}install.html` 受管理状态告示、`docs/{,en/}troubleshooting.html` 新章节、`skill-data/core/references/commands.md`、`skill-data/real-chrome/SKILL.md`、顶层 help 的 Setup 段补 `extension install/status/uninstall` |

## before / after

本机（策略已批准，live 0.5.12 / bundled 0.5.16 / store 0.5.12）：

**before**
```
  expected extension version: 0.5.16
  ! live extension version: 0.5.12 — OUTDATED (expected 0.5.16).
     Update it at chrome://extensions (turn on Developer mode → Update), or reload the unpacked build.
! active extension is older than bundled 0.5.16; open chrome://extensions, accept pending permissions/reload, or restart Chrome
  ✓ silent-install policy: active (missing profiles install on Chrome restart)
```

**after**
```
  bundled extension version (ships with this CLI): 0.5.16
✓ live extension version: 0.5.12 — the newest build published on the Web Store (0.5.12).
    This CLI bundles 0.5.16, which isn't published yet: there is nothing to update to,
    and nothing is broken. To run the bundled build now, load extensions/ab-connect unpacked.
  ✓ silent-install policy: active (missing profiles install on Chrome restart)
  ! That policy is also why Chrome is "managed by your organization":
    · the extension shows as "installed by your administrator" — no manual
      update/remove button (#186). Chrome auto-updates it from the Web Store
      (~every 5h); to update now: chrome://extensions → Developer mode → Update.
    · Chrome disables and locks the "Use secure DNS" (DoH) setting (#187).
    To leave managed mode (your custom DoH comes back):
      profiles remove -identifier com.leeguoo.chrome-use.connect
    Removing the policy also uninstalls the extension it installed — re-add it
    per profile from https://chromewebstore.google.com/detail/chrome-use/knfcmbamhjmaonkfnjhldjedeobeafmk
    ("Add to Chrome"): same extension, still auto-updating, yours to manage.
```

`doctor`：`warn extension 0.5.12 is behind the bundled 0.5.16` → `pass extension 0.5.12 — newest published on the Web Store (0.5.12); this CLI bundles 0.5.16, not published yet`。

## 验证

- `cargo fmt`、`cargo test --bin chrome-use` → **1122 passed**、`cargo clippy --all-targets` 只剩 `connection.rs` / `chrome.rs` / `test_runner.rs` 三条历史告警。
- 两个新回归测试都**先把修复去掉确认会红**再加回来：
  - `no_profile_opts_out_of_the_managed_policy_route`（去掉 `!no_profile` → FAILED）
  - `a_live_extension_is_only_outdated_when_a_newer_one_is_published`（退回「落后即 OUTDATED」→ FAILED，`left: BehindStore … right: NewestPublished`）
- 真机（macOS，策略已批准，12 个 Chrome profile）：
  - `extension install --no-profile`（把策略状态伪装成 absent）→ 打印跳过指引，`ab-connect.mobileconfig` 的 mtime **没变**；
  - `extension install --no-open` → A) 下面照常打印代价与退出命令，B) 说明不进入受管理状态；
  - `extension status` / `--json` / `doctor` → 如上；`CHROME_USE_LANG=zh` 双语文案都核对过。

## 还没做的

商店上架的 **0.5.16 还没提交/发布**（商店仍是 0.5.12）。这条 CLI 侧改不了，得手动走 CWS 提审——在那之前，用户看到的「0.5.12 是已发布最新版」是事实陈述，不是遮掩。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added extension version status showing bundled, published, and live versions.
  - Added `--no-profile` installation mode to avoid managed Chrome setup.
  - Added profile-wide installation and extension uninstall guidance.
  - Improved status messages for managed mode, Secure DNS restrictions, and removal steps.

- **Bug Fixes**
  - Improved version checks when the Web Store is unavailable or behind the bundled build.
  - Improved Windows Chrome profile discovery.

- **Documentation**
  - Expanded installation, troubleshooting, command, and real-Chrome guidance for macOS managed profiles and extension updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->