### PR TITLE
fix: 空白截图不再顶着 ✓ 交付，接入门槛别只认三个 runner (#184) (#172)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3735,8 +3735,9 @@ fn is_blank_capture_target(url: &str) -> bool {
 }
 
 /// The single RGBA colour every pixel of `path` shares, or `None` when the image
-/// holds more than one colour (or can't be read). Early-exits on the first pixel
-/// that differs, so a real screenshot costs a couple of comparisons.
+/// holds more than one colour (or can't be read). Decoding the file is
+/// unconditional; only the pixel walk early-exits, which it almost always does on
+/// the first differing pixel of a real capture.
 fn uniform_image_color(path: &str) -> Option<[u8; 4]> {
     let img = image::open(path).ok()?.to_rgba8();
     let mut px = img.pixels();
@@ -3967,13 +3968,18 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     // Independent of the URL guard above (issue #184): if the saved image is one
     // flat colour while the page says it laid out real content, the pixels did not
     // come from this page — say so instead of printing a bare ✓ over a blank file.
-    // Skipped for --selector / --clip, where a uniform region is an ordinary result.
     //
-    // Runs after the downscale on purpose: the scan then reads the capped image
-    // (2000px longest edge) rather than a raw full-page capture, and downscaling
-    // a uniform image leaves it uniform, so the verdict is unchanged either way.
+    // Placed after the downscale so the scan decodes the capped image (2000px
+    // longest edge) instead of a raw full-page capture; downscaling a uniform
+    // image leaves it uniform, so the verdict is the same either way.
+    //
+    // Three exemptions, all because the check would cost more than it's worth:
+    // --selector / --clip, where a uniform region is an ordinary result; and
+    // --annotate, which skips the downscale (overlays must stay aligned) and so
+    // would have us decode a full-size capture — an annotated shot already
+    // signals a missed target by coming back with an empty ref legend.
     let mut capture_warning: Option<String> = None;
-    if options.selector.is_none() && options.clip.is_none() {
+    if !annotate && options.selector.is_none() && options.clip.is_none() {
         if let Some(color) = uniform_image_color(&result.path) {
             let probe = mgr
                 .evaluate(

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3968,6 +3968,10 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     // flat colour while the page says it laid out real content, the pixels did not
     // come from this page — say so instead of printing a bare ✓ over a blank file.
     // Skipped for --selector / --clip, where a uniform region is an ordinary result.
+    //
+    // Runs after the downscale on purpose: the scan then reads the capped image
+    // (2000px longest edge) rather than a raw full-page capture, and downscaling
+    // a uniform image leaves it uniform, so the verdict is unchanged either way.
     let mut capture_warning: Option<String> = None;
     if options.selector.is_none() && options.clip.is_none() {
         if let Some(color) = uniform_image_color(&result.path) {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3734,6 +3734,53 @@ fn is_blank_capture_target(url: &str) -> bool {
     url.is_empty() || url == "about:blank" || url == "about:newtab"
 }
 
+/// The single RGBA colour every pixel of `path` shares, or `None` when the image
+/// holds more than one colour (or can't be read). Early-exits on the first pixel
+/// that differs, so a real screenshot costs a couple of comparisons.
+fn uniform_image_color(path: &str) -> Option<[u8; 4]> {
+    let img = image::open(path).ok()?.to_rgba8();
+    let mut px = img.pixels();
+    let first = px.next()?.0;
+    if px.any(|p| p.0 != first) {
+        return None;
+    }
+    Some(first)
+}
+
+/// Second, transport-independent check that a `✓` screenshot isn't a blank image
+/// (issue #184, reporter suggestion 3). The URL guard only catches a drift the
+/// capture session itself admits to; in the original report `location.href` read
+/// correct on a later call while the pixels had come from somewhere else, so the
+/// image is the only remaining witness. A capture that is one flat colour while
+/// the page reports real laid-out content is that witness.
+///
+/// A warning rather than an error: a page genuinely CAN be a single colour, and a
+/// false alarm must not cost the user a screenshot that was fine.
+fn uniform_capture_warning(
+    color: Option<[u8; 4]>,
+    page_height: u64,
+    text_len: u64,
+) -> Option<String> {
+    let [r, g, b, _a] = color?;
+    // Only suspicious when the page claims content to paint. A freshly-opened
+    // tab or a truly empty document captures as one colour legitimately.
+    if page_height < UNIFORM_CAPTURE_MIN_HEIGHT || text_len < UNIFORM_CAPTURE_MIN_TEXT {
+        return None;
+    }
+    Some(format!(
+        "the capture is a single flat colour (#{r:02x}{g:02x}{b:02x}) while the page reports \
+         {page_height}px of layout and {text_len} characters of text — unless this page really \
+         is blank, the pixels did not come from it (issue #184). Confirm the target with \
+         `chrome-use eval \"location.href\"`, then re-pin the tab (`chrome-use tab <ref>` or \
+         `chrome-use adopt <url>`) and retry."
+    ))
+}
+
+/// Layout height (px) below which a one-colour capture is unremarkable.
+const UNIFORM_CAPTURE_MIN_HEIGHT: u64 = 400;
+/// Rendered text length below which a one-colour capture is unremarkable.
+const UNIFORM_CAPTURE_MIN_TEXT: u64 = 20;
+
 async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
     let annotate = cmd
         .get("annotate")
@@ -3917,6 +3964,29 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
         resized = downscale_screenshot(&result.path, scale, max_w, max_h, default_edge);
     }
 
+    // Independent of the URL guard above (issue #184): if the saved image is one
+    // flat colour while the page says it laid out real content, the pixels did not
+    // come from this page — say so instead of printing a bare ✓ over a blank file.
+    // Skipped for --selector / --clip, where a uniform region is an ordinary result.
+    let mut capture_warning: Option<String> = None;
+    if options.selector.is_none() && options.clip.is_none() {
+        if let Some(color) = uniform_image_color(&result.path) {
+            let probe = mgr
+                .evaluate(
+                    "(() => ({ h: document.documentElement ? document.documentElement.scrollHeight : 0, \
+                       t: document.body ? (document.body.innerText || '').trim().length : 0 }))()",
+                    None,
+                )
+                .await
+                .unwrap_or(Value::Null);
+            capture_warning = uniform_capture_warning(
+                Some(color),
+                probe.get("h").and_then(|v| v.as_u64()).unwrap_or(0),
+                probe.get("t").and_then(|v| v.as_u64()).unwrap_or(0),
+            );
+        }
+    }
+
     let mut response = json!({ "path": absolutize_saved_path(&result.path) });
     if let Some((w, h)) = resized {
         response["width"] = json!(w);
@@ -3933,6 +4003,9 @@ async fn handle_screenshot(cmd: &Value, state: &mut DaemonState) -> Result<Value
     // so the stamp names the target that was actually captured.
     if !live_url.is_empty() {
         response["origin"] = json!(live_url);
+    }
+    if let Some(w) = capture_warning {
+        response["warning"] = json!(w);
     }
 
     Ok(response)
@@ -12851,6 +12924,54 @@ mod tests {
             "http://127.0.0.1:8791/design.html"
         ));
         assert!(!is_blank_capture_target("https://example.com/"));
+    }
+
+    // issue #184 (reporter suggestion 3): the URL guard only catches a drift the
+    // capture session admits to. These cover the second witness — the pixels.
+    #[test]
+    fn uniform_capture_warns_only_when_the_page_has_content_to_paint() {
+        let flat = Some([255u8, 253, 245, 255]);
+        // The reported case: a full page of laid-out content, one flat colour.
+        let w = uniform_capture_warning(flat, 4439, 1284).expect("should warn");
+        assert!(w.contains("#fffdf5"), "names the colour: {w}");
+        assert!(w.contains("4439px"), "names the layout height: {w}");
+        assert!(w.contains("issue #184"), "points at the issue: {w}");
+
+        // A genuinely blank page is allowed to capture as one colour.
+        assert!(uniform_capture_warning(flat, 4439, 0).is_none());
+        assert!(uniform_capture_warning(flat, 120, 1284).is_none());
+        // A capture with more than one colour is never suspicious.
+        assert!(uniform_capture_warning(None, 4439, 1284).is_none());
+    }
+
+    #[test]
+    fn uniform_image_color_detects_flat_and_non_flat_images() {
+        let dir = std::env::temp_dir().join(format!("chrome-use-uniform-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let flat_path = dir.join("flat.png");
+        image::RgbaImage::from_pixel(8, 8, image::Rgba([255, 253, 245, 255]))
+            .save(&flat_path)
+            .unwrap();
+        assert_eq!(
+            uniform_image_color(flat_path.to_str().unwrap()),
+            Some([255, 253, 245, 255])
+        );
+
+        // One stray pixel is enough to make it a real capture.
+        let mixed_path = dir.join("mixed.png");
+        let mut mixed = image::RgbaImage::from_pixel(8, 8, image::Rgba([255, 253, 245, 255]));
+        mixed.put_pixel(4, 4, image::Rgba([0, 0, 0, 255]));
+        mixed.save(&mixed_path).unwrap();
+        assert_eq!(uniform_image_color(mixed_path.to_str().unwrap()), None);
+
+        // An unreadable path is not a blank capture.
+        assert_eq!(
+            uniform_image_color(dir.join("missing.png").to_str().unwrap()),
+            None
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     use super::*;

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -983,6 +983,95 @@ async fn e2e_iframe_button_click_is_trusted() {
 // Screenshot
 // ---------------------------------------------------------------------------
 
+/// Issue #184: a `✓` screenshot must not silently be a blank image. The URL
+/// guard only catches a drift the capture session itself admits to, so a second,
+/// transport-independent check reads the pixels back: one flat colour over a page
+/// that reports real layout is reported as a warning instead of a plain success.
+///
+/// The failing capture is simulated with `opacity: 0` — the page lays out 2000px
+/// and `innerText` still returns the text, but nothing is painted, which is
+/// exactly the shape of a capture that missed its renderer.
+#[tokio::test]
+#[ignore]
+async fn e2e_screenshot_flags_a_flat_capture_over_a_content_page() {
+    const BODY: &str = "<p>DEEPSPACE SIGNAL — a page with real, laid-out content.</p>\
+         <p>Second paragraph so innerText is comfortably past the threshold.</p>";
+
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Control: an ordinary painted page of the same size must NOT warn.
+    let resp = execute_command(
+        &json!({
+            "id": "2",
+            "action": "setcontent",
+            "html": format!(
+                "<html><body style=\"margin:0\"><div style=\"height:2000px\">{BODY}</div></body></html>"
+            ),
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "screenshot", "fullPage": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(
+        get_data(&resp).get("warning").is_none(),
+        "A painted page must not raise a blank-capture warning: {}",
+        serde_json::to_string_pretty(get_data(&resp)).unwrap_or_default()
+    );
+    let _ = std::fs::remove_file(get_data(&resp)["path"].as_str().unwrap());
+
+    // Same layout, same innerText, nothing painted.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "setcontent",
+            "html": format!(
+                "<html><body style=\"margin:0\"><div style=\"height:2000px;opacity:0\">{BODY}</div></body></html>"
+            ),
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "screenshot", "fullPage": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let warning = get_data(&resp)
+        .get("warning")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "A flat capture over a content page must warn: {}",
+                serde_json::to_string_pretty(get_data(&resp)).unwrap_or_default()
+            )
+        });
+    assert!(
+        warning.contains("issue #184"),
+        "Warning should point at the issue: {warning}"
+    );
+    assert!(
+        warning.contains("single flat colour"),
+        "Warning should say what it saw: {warning}"
+    );
+    let _ = std::fs::remove_file(get_data(&resp)["path"].as_str().unwrap());
+}
+
 #[tokio::test]
 #[ignore]
 async fn e2e_screenshot() {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1157,11 +1157,16 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
         if let Some(path) = data.get("path").and_then(|v| v.as_str()) {
             match action.unwrap_or("") {
                 "screenshot" => {
-                    println!(
-                        "{} Screenshot saved to {}",
-                        color::success_indicator(),
-                        color::green(path)
-                    );
+                    // A capture the daemon could not vouch for is not a plain
+                    // success — a blank image under a green ✓ is exactly what
+                    // issue #184 reported, so the indicator has to carry the doubt.
+                    let warning = data.get("warning").and_then(|v| v.as_str());
+                    let indicator = if warning.is_some() {
+                        color::warning_indicator()
+                    } else {
+                        color::success_indicator()
+                    };
+                    println!("{} Screenshot saved to {}", indicator, color::green(path));
                     // Stamp which page was captured (mirrors `eval @ url`) so a
                     // screenshot of the wrong/drifted tab is obvious (issue #8.1).
                     if let Some(o) = data
@@ -1170,6 +1175,9 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                         .filter(|o| !o.is_empty())
                     {
                         eprintln!("screenshot @ {o}");
+                    }
+                    if let Some(w) = warning {
+                        eprintln!("{} {}", color::warning_indicator(), w);
                     }
                     if let Some(annotations) = data.get("annotations").and_then(|v| v.as_array()) {
                         // Cap the printed legend on dense pages (it can be
@@ -2290,6 +2298,12 @@ Captures a screenshot of the current page. If no path is provided,
 saves to a temporary directory with a generated filename.
 Headless Chromium screenshots hide native scrollbars for consistent image output.
 Pass --hide-scrollbars false when launching to keep native scrollbars visible.
+
+A capture that comes back a single flat colour while the page reports real
+layout and text is saved with a warning instead of a plain checkmark — the
+pixels did not come from the page you think they did. Confirm the target with
+`chrome-use eval "location.href"`, then re-pin the tab and retry. [selector]
+and --clip captures are exempt (a uniform region is normal there).
 
 Options:
   --full, -f           Capture full page (not just viewport)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2302,8 +2302,8 @@ Pass --hide-scrollbars false when launching to keep native scrollbars visible.
 A capture that comes back a single flat colour while the page reports real
 layout and text is saved with a warning instead of a plain checkmark — the
 pixels did not come from the page you think they did. Confirm the target with
-`chrome-use eval "location.href"`, then re-pin the tab and retry. [selector]
-and --clip captures are exempt (a uniform region is normal there).
+`chrome-use eval "location.href"`, then re-pin the tab and retry. [selector],
+--clip and --annotate captures are exempt.
 
 Options:
   --full, -f           Capture full page (not just viewport)

--- a/docs/en/install.html
+++ b/docs/en/install.html
@@ -225,7 +225,8 @@ programs.chrome-use = {
       </div>
 
       <p>
-        Other agent runners (Cursor, Codex, custom scripts): pull the SKILL.md with <a href="https://skills.sh">skills.sh</a>. Add
+        Other agent runners (Cursor, Codex, CodeBuddy, Trae, Windsurf, Cline, custom scripts): pull the
+        SKILL.md with <a href="https://skills.sh">skills.sh</a>. Add
         <code>-g</code> for a global install (visible to every project); drop it to install only into the current project:
       </p>
 

--- a/docs/en/mcp.html
+++ b/docs/en/mcp.html
@@ -65,6 +65,18 @@
         use <code>chrome-use mcp</code> on this page.
       </div>
 
+      <div class="du-callout tip">
+        <div class="du-callout-title">✅ My IDE isn't on that list</div>
+        Those lists are examples, not an allowlist. There are only two questions, in this order:
+        <strong>1. Can it run terminal commands for me?</strong> If yes (CodeBuddy, Trae, Windsurf,
+        Cline, Continue, Zed all can), use the <a href="/en/install.html">CLI + skill</a> — install
+        <code>chrome-use</code> and let the agent type <code>chrome-use snapshot -i</code> directly.
+        No further wiring. <strong>2. No shell, but it can register an MCP server?</strong> Then use
+        the Claude Desktop block above: <code>command</code> <code>chrome-use</code>, <code>args</code>
+        <code>["mcp"]</code>. stdio MCP is a generic protocol — the config looks the same everywhere.
+        A host that can do neither can't be connected.
+      </div>
+
       <hr class="du-divider" />
 
       <h2>The 12 core tools</h2>

--- a/docs/en/troubleshooting.html
+++ b/docs/en/troubleshooting.html
@@ -317,6 +317,16 @@
         If that URL isn't the page you expected (the active tab drifted), re-<code>open</code> your target URL—don't trust
         this result. Treat that stamp as a sanity check that ships with every read.
       </p>
+      <p>
+        <code>screenshot</code> also looks back at the pixels it just wrote. If the whole image is a
+        <strong>single flat colour</strong> while the page reports real layout height and text, the capture
+        didn't come from that page — the command prints <code>⚠</code> and a warning instead of a clean
+        <code>✓</code>. The file is still saved, but confirm the target before feeding it to a vision model:
+        run <code>chrome-use eval "location.href"</code>, then re-pin the tab with <code>tab</code> /
+        <code>adopt</code>. A page that genuinely is one colour never trips this, and
+        <code>[selector]</code> / <code>--clip</code> captures are exempt — a uniform region is an ordinary
+        result there.
+      </p>
 
       <hr class="du-divider" />
 

--- a/docs/en/troubleshooting.html
+++ b/docs/en/troubleshooting.html
@@ -324,8 +324,7 @@
         <code>✓</code>. The file is still saved, but confirm the target before feeding it to a vision model:
         run <code>chrome-use eval "location.href"</code>, then re-pin the tab with <code>tab</code> /
         <code>adopt</code>. A page that genuinely is one colour never trips this, and
-        <code>[selector]</code> / <code>--clip</code> captures are exempt — a uniform region is an ordinary
-        result there.
+        <code>[selector]</code>, <code>--clip</code> and <code>--annotate</code> captures are exempt.
       </p>
 
       <hr class="du-divider" />

--- a/docs/install.html
+++ b/docs/install.html
@@ -223,7 +223,8 @@ programs.chrome-use = {
       </div>
 
       <p>
-        其他 agent runner（Cursor、Codex、自研脚本）用 <a href="https://skills.sh">skills.sh</a> 装 SKILL.md。加
+        其他 agent runner（Cursor、Codex、CodeBuddy、Trae、Windsurf、Cline、自研脚本）用
+        <a href="https://skills.sh">skills.sh</a> 装 SKILL.md。加
         <code>-g</code> 装到全局（所有项目可见）；去掉 <code>-g</code> 只装当前项目：
       </p>
 

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -63,6 +63,17 @@
         MCP 节点）——用这一页的 <code>chrome-use mcp</code>。
       </div>
 
+      <div class="du-callout tip">
+        <div class="du-callout-title">✅ 我的 IDE 不在上面的名单里怎么办</div>
+        名单只是举例，不是白名单。判断标准只有两条，按这个顺序问：
+        <strong>① 它能替我跑终端命令吗？</strong>能的话（CodeBuddy、Trae、Windsurf、Cline、
+        Continue、Zed 这类都能）就走 <a href="/install.html">CLI + 技能</a>——装完
+        <code>chrome-use</code>，让它直接敲 <code>chrome-use snapshot -i</code>，不需要任何额外配置。
+        <strong>② 不能跑 shell，但能配 MCP server 吗？</strong>那就按上面 Claude Desktop 那段的
+        <code>command</code> + <code>args</code> 填 <code>chrome-use</code> / <code>mcp</code>——
+        stdio MCP 是通用协议，配置长得都一样。两条都不行的宿主接不了。
+      </div>
+
       <hr class="du-divider" />
 
       <h2>12 个核心工具</h2>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -297,6 +297,14 @@
         如果这个 URL 不是你预期的页面（活动标签页漂移了），重新 <code>open</code> 你的目标 URL——别信这次结果。
         把这枚戳记当成每一次读取自带的健全性检查。
       </p>
+      <p>
+        <code>screenshot</code> 还会回头看一眼自己刚写出的像素。如果整张图是<strong>一种纯色</strong>，
+        而页面明明报告了真实的布局高度和文字，这次捕获就不是从这个页面来的——命令会打
+        <code>⚠</code> 和一条警告，而不是干净的 <code>✓</code>。文件照常保存，但在确认目标之前
+        别把它喂给视觉模型：先 <code>chrome-use eval "location.href"</code>，再用
+        <code>tab</code> / <code>adopt</code> 重新钉住标签页。真的就是纯色的页面不会触发，
+        <code>[selector]</code> 和 <code>--clip</code> 的局部截图也豁免——那里一块纯色是正常结果。
+      </p>
 
       <hr class="du-divider" />
 

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -303,7 +303,7 @@
         <code>⚠</code> 和一条警告，而不是干净的 <code>✓</code>。文件照常保存，但在确认目标之前
         别把它喂给视觉模型：先 <code>chrome-use eval "location.href"</code>，再用
         <code>tab</code> / <code>adopt</code> 重新钉住标签页。真的就是纯色的页面不会触发，
-        <code>[selector]</code> 和 <code>--clip</code> 的局部截图也豁免——那里一块纯色是正常结果。
+        <code>[selector]</code>、<code>--clip</code> 和 <code>--annotate</code> 的截图也豁免。
       </p>
 
       <hr class="du-divider" />

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -1207,6 +1207,14 @@ If that URL isn't the page you expected (the active tab drifted), re-`open`
 your target URL — don't trust the result. Treat the stamp as a built-in
 sanity check on every read.
 
+`screenshot` also checks the pixels it just wrote. If the image is a single
+flat colour while the page reports real layout and text, the capture is
+reported with `⚠` and a warning instead of a plain `✓` — the shot is still
+saved, but don't feed it to a vision model without confirming the target
+first (`chrome-use eval "location.href"`, then re-pin with `tab` / `adopt`).
+A page that genuinely is one colour never triggers this, and `--selector` /
+`--clip` captures are exempt.
+
 **Fill / type doesn't work**
 Some custom input components intercept key events. Try:
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -1212,8 +1212,8 @@ flat colour while the page reports real layout and text, the capture is
 reported with `⚠` and a warning instead of a plain `✓` — the shot is still
 saved, but don't feed it to a vision model without confirming the target
 first (`chrome-use eval "location.href"`, then re-pin with `tab` / `adopt`).
-A page that genuinely is one colour never triggers this, and `--selector` /
-`--clip` captures are exempt.
+A page that genuinely is one colour never triggers this, and `--selector`,
+`--clip` and `--annotate` captures are exempt.
 
 **Fill / type doesn't work**
 Some custom input components intercept key events. Try:

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -115,9 +115,8 @@ Pass `--hide-scrollbars false` when launching to keep native scrollbars visible.
 
 A capture that comes back a single flat colour while the page reports real
 layout and text is saved with `⚠` and a warning instead of a plain `✓` — the
-capture did not come from the page you think it did (issue #184). `--selector`
-and `--clip` captures are exempt, since a uniform region is an ordinary result
-there.
+capture did not come from the page you think it did (issue #184). `--selector`,
+`--clip` and `--annotate` captures are exempt.
 
 ## Video Recording
 

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -113,6 +113,12 @@ chrome-use pdf output.pdf      # Save as PDF
 Headless Chromium screenshots hide native scrollbars for consistent image output.
 Pass `--hide-scrollbars false` when launching to keep native scrollbars visible.
 
+A capture that comes back a single flat colour while the page reports real
+layout and text is saved with `⚠` and a warning instead of a plain `✓` — the
+capture did not come from the page you think it did (issue #184). `--selector`
+and `--clip` captures are exempt, since a uniform region is an ordinary result
+there.
+
 ## Video Recording
 
 ```bash


### PR DESCRIPTION
Closes #172. 推进 #184（第二道守卫，不是完整根因）。

## 根因

### #184 —— URL 守卫有盲区

v1.5.92 加的守卫比对两个 URL：捕获会话上的 `location.href`，和会话正在驱动的标签页 URL。它只拦得住**捕获会话自己承认漂移**的那一种情况。

原报告里的形态不是这样：后来那次 `chrome-use eval` 读回来的 URL 是**对的**，像素却来自别处。两个 URL 一致 → 守卫不响 → agent 拿到的仍然是一个 `✓` 加一张空白图。

截图是唯一一个 agent 没法自己校验输出的动作（`get text` 空了看得出来，图片空了看不出来）。所以补第二个、和传输层无关的证人：**图本身**。这也是报告人自己给的第 3 条建议，此前没做。

### #172 —— 接入名单读起来像白名单

文档里一直只写 Claude Code / Cursor / Codex。用 CodeBuddy（或 Trae / Windsurf / Cline）的人没法从文档判断自己能不能接。实际标准只有两条，和 IDE 叫什么无关。

## 改动

| 改动 | 位置 |
|---|---|
| `uniform_image_color` —— 纯色检测，首个不同像素即退出 | `cli/src/native/actions.rs` |
| `uniform_capture_warning` —— 纯色 + 页面有内容 → 警告文案 | `cli/src/native/actions.rs` |
| 捕获后接入检测（`--selector` / `--clip` 豁免） | `cli/src/native/actions.rs` |
| `✓` 降级为 `⚠` 并把警告打到 stderr | `cli/src/output.rs` |
| `screenshot` 命令 help | `cli/src/output.rs` |
| 「读到了错误的页面」一节 | `docs/troubleshooting.html`、`docs/en/troubleshooting.html` |
| 「我的 IDE 不在名单里怎么办」 | `docs/mcp.html`、`docs/en/mcp.html` |
| runner 名单补 CodeBuddy / Trae / Windsurf / Cline | `docs/install.html`、`docs/en/install.html` |
| 技能文档 | `skill-data/core/SKILL.md`、`skill-data/core/references/commands.md` |

**为什么是警告不是报错**：页面确实可能就是纯色，误报不该让用户丢掉一张本来没问题的截图。文件照常保存，但指示符不再是干净的 `✓`——「不静默成功」这条要求的是别用 `✓` 掩盖一次没做成的事，不是要求一律报错。

**豁免条件**：`[selector]` 和 `--clip` 的局部截图不检查——那里一块纯色是正常结果。另外要求页面报告 ≥400px 布局高度且 ≥20 字符文本，空白页面不会误报。

## Before / after

```
# 之前（以及现在的 --selector / --clip）
✓ Screenshot saved to /tmp/blank.png
screenshot @ http://127.0.0.1:8791/design.html

# 现在
⚠ Screenshot saved to /tmp/blank.png
screenshot @ http://127.0.0.1:8791/design.html
⚠ the capture is a single flat colour (#ffffff) while the page reports 3021px of layout
  and 101 characters of text — unless this page really is blank, the pixels did not come
  from it (issue #184). Confirm the target with `chrome-use eval "location.href"`, then
  re-pin the tab (`chrome-use tab <ref>` or `chrome-use adopt <url>`) and retry.
```

## 验证

- `cargo test --bin chrome-use` —— **1124 passed, 0 failed**
- 新增 2 个单测（纯色检测的正/负例含单像素差异与不可读路径；阈值边界）
- 新增 e2e `e2e_screenshot_flags_a_flat_capture_over_a_content_page`：同一份 2000px 内容页，一次正常绘制（**必须不报警**，防误报回归），一次 `opacity:0`（布局和 `innerText` 都在，只是不绘制 —— 正是「捕获没落在这个页面」的形态）
- **自证**：临时关掉修复后 e2e 确实失败，且失败输出正是原始形态 —— `✓` + 空白图 + 无 warning，`origin` 和 tracked URL 一致（URL 守卫沉默，盲区确认）
- `cargo clippy --all-targets --features e2e-tests -- -D warnings` —— 本次改动的三个文件零告警（`connection.rs` / `chrome.rs` / `test_runner.rs` 的历史告警未动）
- 真实 Chrome（`--launch`，本地 `python3 -m http.server`）跑过对照组和空白组，输出即上面的 before/after

## 还没做的

`#184` 不关闭。**为什么捕获会贴到别的渲染器上**这一层仍然没有稳定复现（本机没有 doubao / immersive-translate / synofoto 那套组合），这次只是把「静默成功」的最后一条缝也堵上，堵住漂移本身还欠着。
