### PR TITLE
feat(relay): 给 8s 超时补上失败时的上下文 (#193)

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -4994,6 +4994,25 @@ mod tests {
     }
 
     /// Errors containing "not found" but NOT "element" should pass through unchanged.
+    /// The relay now appends per-command context to its timeout message
+    /// (in-flight count, oldest in-flight, worker age — issue #193). The
+    /// friendly rewrite must keep that context visible: it is the only place the
+    /// driver ever sees why the command timed out, and the prefix match that
+    /// selects this branch must not be thrown off by the suffix.
+    #[test]
+    fn test_to_ai_friendly_error_relay_timeout_keeps_diagnostics() {
+        let m = to_ai_friendly_error(
+            "relay timeout after 8000ms: chrome.debugger.sendCommand(Page.navigate). \
+             [diag in-flight=4 oldest-in-flight=21000ms worker-age=93000ms]",
+        );
+        assert!(m.contains("in-flight=4"));
+        assert!(m.contains("worker-age=93000ms"));
+        assert!(
+            m.contains("tab inspect <ref>"),
+            "still the relay-timeout hint"
+        );
+    }
+
     #[test]
     fn test_to_ai_friendly_error_ignores_non_element_not_found() {
         let err = "Chrome not found. Install Chrome or use --executable-path.";

--- a/extensions/ab-connect/relay-timeout.js
+++ b/extensions/ab-connect/relay-timeout.js
@@ -1,8 +1,55 @@
 export const RELAY_COMMAND_TIMEOUT_MS = 8000
 export const RELAY_TIMEOUT_ERROR_NAME = 'RelayTimeoutError'
 
+// How many past timeouts to keep for `getRelayTimeoutHistory()`. Small on
+// purpose: this is a diagnostic tail, not a log.
+const MAX_RECORDED_TIMEOUTS = 20
+
+// When THIS service-worker context started. MV3 tears the whole context down
+// when the worker is evicted, taking pending timers with it — so a timeout can
+// only ever fire in the same context that started the command. Recording the
+// context's age at timeout time is what makes the "worker was evicted
+// mid-command" hypothesis checkable instead of assumed: an age below the
+// elapsed budget would mean the worker restarted inside the window (#193).
+const workerStartedAt = Date.now()
+
+// Commands currently racing their timeout, so a timing-out command can report
+// how much company it had. Head-of-line blocking (every daemon multiplexes
+// through this one extension peer) shows up here as a high in-flight count and
+// an `oldest` far past the budget, where a genuinely blocked renderer times out
+// alone (#193).
+const inFlight = new Map()
+let nextCommandId = 1
+
+const recordedTimeouts = []
+
 export function isRelayTimeoutError(error) {
   return error?.name === RELAY_TIMEOUT_ERROR_NAME
+}
+
+// The last few timeouts with the context they failed in. Read it from the
+// service-worker console (`getRelayTimeoutHistory()` is reachable there via the
+// module) when a driver reports repeated timeouts.
+export function getRelayTimeoutHistory() {
+  return recordedTimeouts.slice()
+}
+
+export function relayInFlightCount() {
+  return inFlight.size
+}
+
+function describeContext(id, now) {
+  let oldestStartedAt = now
+  for (const entry of inFlight.values()) {
+    if (entry.startedAt < oldestStartedAt) oldestStartedAt = entry.startedAt
+  }
+  const self = inFlight.get(id)
+  return {
+    elapsedMs: now - (self ? self.startedAt : now),
+    inFlight: inFlight.size,
+    oldestInFlightMs: now - oldestStartedAt,
+    workerAgeMs: now - workerStartedAt,
+  }
 }
 
 export async function withRelayTimeout(
@@ -10,6 +57,8 @@ export async function withRelayTimeout(
   label,
   timeoutMs = RELAY_COMMAND_TIMEOUT_MS,
 ) {
+  const id = nextCommandId++
+  inFlight.set(id, { label, startedAt: Date.now() })
   let timer
   try {
     return await Promise.race([
@@ -17,11 +66,20 @@ export async function withRelayTimeout(
       new Promise((_, reject) => {
         timer = setTimeout(
           () => {
+            const diag = { label, ...describeContext(id, Date.now()) }
+            recordedTimeouts.push(diag)
+            if (recordedTimeouts.length > MAX_RECORDED_TIMEOUTS) recordedTimeouts.shift()
+            try {
+              console.warn('[ab-connect] relay command timed out', diag)
+            } catch {}
             const error = new Error(
               `relay timeout after ${timeoutMs}ms: ${label}. ` +
-                'The Chrome debugger stopped responding; restart the session and retry.',
+                'The Chrome debugger stopped responding; restart the session and retry. ' +
+                `[diag in-flight=${diag.inFlight} oldest-in-flight=${diag.oldestInFlightMs}ms ` +
+                `worker-age=${diag.workerAgeMs}ms]`,
             )
             error.name = RELAY_TIMEOUT_ERROR_NAME
+            error.relayDiagnostics = diag
             reject(error)
           },
           timeoutMs,
@@ -30,5 +88,6 @@ export async function withRelayTimeout(
     ])
   } finally {
     clearTimeout(timer)
+    inFlight.delete(id)
   }
 }

--- a/extensions/ab-connect/relay-timeout.test.js
+++ b/extensions/ab-connect/relay-timeout.test.js
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { isRelayTimeoutError, withRelayTimeout } from './relay-timeout.js'
+import {
+  getRelayTimeoutHistory,
+  isRelayTimeoutError,
+  relayInFlightCount,
+  withRelayTimeout,
+} from './relay-timeout.js'
 
 test('withRelayTimeout returns a completed debugger operation', async () => {
   assert.equal(await withRelayTimeout(Promise.resolve('ok'), 'Runtime.evaluate', 20), 'ok')
@@ -31,4 +36,43 @@ test('a late rejection remains handled after the timeout wins', async () => {
   await assert.rejects(withRelayTimeout(operation, 'Page.enable', 5), /relay timeout/)
   rejectOperation(new Error('late Chrome failure'))
   await new Promise((resolve) => setTimeout(resolve, 0))
+})
+
+test('a timeout reports the context it failed in (#193)', async () => {
+  const before = getRelayTimeoutHistory().length
+  // A second command sits in flight for the whole window, so the timing-out one
+  // must report company rather than looking like a lone blocked renderer.
+  const parallel = withRelayTimeout(new Promise(() => {}), 'Page.navigate', 200)
+  await assert.rejects(
+    withRelayTimeout(new Promise(() => {}), 'Runtime.evaluate', 20),
+    (error) => {
+      const diag = error.relayDiagnostics
+      assert.equal(diag.label, 'Runtime.evaluate')
+      assert.ok(diag.elapsedMs >= 20)
+      assert.equal(diag.inFlight, 2)
+      assert.ok(diag.oldestInFlightMs >= diag.elapsedMs)
+      // The worker cannot be younger than the command it timed out: a pending
+      // timer dies with its context, so an eviction mid-command never surfaces
+      // as this error at all.
+      assert.ok(diag.workerAgeMs >= diag.elapsedMs)
+      assert.match(error.message, /\[diag in-flight=2 oldest-in-flight=\d+ms worker-age=\d+ms\]/)
+      return true
+    },
+  )
+  assert.equal(getRelayTimeoutHistory().length, before + 1)
+  await assert.rejects(parallel, /relay timeout/)
+})
+
+test('a settled command stops counting as in flight', async () => {
+  await withRelayTimeout(Promise.resolve('ok'), 'Runtime.evaluate', 50)
+  assert.equal(relayInFlightCount(), 0)
+})
+
+test('the recorded timeout history stays bounded', async () => {
+  for (let i = 0; i < 25; i++) {
+    await assert.rejects(withRelayTimeout(new Promise(() => {}), `m${i}`, 1), /relay timeout/)
+  }
+  const history = getRelayTimeoutHistory()
+  assert.equal(history.length, 20)
+  assert.equal(history[history.length - 1].label, 'm24')
 })


### PR DESCRIPTION
Refs #193。这是那个 issue 明确要求的第一步：**先仪表化，再谈调常量**。

## 根因（现状）

`relay timeout after 8000ms: chrome.debugger.sendCommand(Page.navigate)` 只说了方法名。issue 里列的四种可能原因——渲染进程真卡、MV3 worker 中途被回收、relay 队头阻塞、报告者特定工作负载——在这条消息面前完全无法区分，所以 8s→15s 只是换个门槛。

## 改动

| 文件 | 改动 |
|---|---|
| `extensions/ab-connect/relay-timeout.js` | `withRelayTimeout` 登记在飞命令；超时时算出 `elapsedMs` / `inFlight` / `oldestInFlightMs` / `workerAgeMs`，写进错误消息、`console.warn`、以及长度 20 的环形缓冲（`getRelayTimeoutHistory()`） |
| `extensions/ab-connect/relay-timeout.test.js` | 3 个新单测：上下文正确、结算后不再计入在飞、历史有界 |
| `cli/src/native/browser.rs` | 单测锁定：诊断后缀不会破坏 `to_ai_friendly_error` 的前缀匹配，且诊断会原样透出给用户 |

`workerAgeMs` 是这里信息量最大的一条：MV3 回收 worker 会把待处理的 timer 一起销毁，所以超时**只可能**在发起该命令的上下文里触发——如果实测中 `workerAgeMs` 永远 ≥ `elapsedMs`，「worker 中途被回收」这条假设就对这类错误直接排除了。`inFlight` 高且 `oldestInFlightMs` 远超预算则指向队头阻塞；孤零零一条超时指向渲染进程真卡。

## Before / After

```
before: relay timeout after 8000ms: chrome.debugger.sendCommand(Page.navigate). The Chrome debugger stopped responding; restart the session and retry.
after:  relay timeout after 8000ms: chrome.debugger.sendCommand(Page.navigate). The Chrome debugger stopped responding; restart the session and retry. [diag in-flight=4 oldest-in-flight=21000ms worker-age=93000ms]
```

## 刻意没做

- **不改 `RELAY_COMMAND_TIMEOUT_MS`**。
- **不改 `to_ai_friendly_error` 的提示文案**——它现在断言「page JavaScript blocks the main thread」，issue 明确说在定位到真因之前不要动这句。
- 没加新 CLI 命令（诊断走错误消息和 SW console，零新增命令面）。

## 验证

- `node --test extensions/ab-connect/*.test.js` → 7 pass
- 回归自证：把 `relay-timeout.js` 换回 HEAD 版本，新测试 0 pass / 1 fail；换回来 7 pass
- `cargo test --bin chrome-use` → 1134 passed, 0 failed
- `cargo clippy --all-targets` → 仅 `connection.rs` / `chrome.rs` / `test_runner.rs` 三条历史遗留告警，改动文件零告警
- `cargo fmt` 已跑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved relay timeout errors with clearer diagnostic details and troubleshooting guidance.
  - Added visibility into concurrent commands and recent timeout activity.
  - Ensured completed commands are removed from active tracking and diagnostic history remains bounded.

- **Tests**
  - Added coverage for concurrent timeout diagnostics, command cleanup, and retained timeout history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->