### PR TITLE
fix: resolve #201-#206 (idle detach, press/xpath, CJK read-back, click focus, cwd session, shadow-DOM snapshot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ own tabs. When `--session` is omitted, chrome-use derives a stable per-agent
 session from supported runner IDs, including Codex's `CODEX_THREAD_ID`. A plain
 shell with no runner ID retains the `default` session; set
 `AGENT_BROWSER_SESSION_ID` or pass `--session` for parallel workers there.
+The derived name is `cu-<repo>-<tag>`, where `<repo>` is only the cwd
+basename: a command run from another directory reuses the live daemon that
+already carries the same agent tag, so an agent keeps its tabs and refs across
+`cd`. Explicit `--session` / `AGENT_BROWSER_SESSION` always win.
 
 Manage those workers with `chrome-use session list`, stop one gracefully with
 `chrome-use session stop [name]`, or reclaim all session daemons with
@@ -481,11 +485,23 @@ Bare descriptions never click automatically. Candidate rows include role/name,
 visible text, computed cursor, and compact `id` / `data-testid` / class selector
 anchors so you can choose an explicit follow-up action.
 
+Selectors starting with `//`, `/`, `(`, `./` or `..` are treated as XPath
+automatically (no `xpath=` prefix). Keep in mind that `text()` only tests the
+first direct text node, so a label split across nodes (React `{a} - {b}`) or
+nested in a child never matches; use `contains(normalize-space(.), '…')`,
+`find "<label>"`, or a snapshot `@ref` instead. "Element not found" errors keep
+the selector and the resolver's diagnosis, and an XPath with `text()` that
+matched nothing explains this gotcha.
+
 Within the same document, unchanged DOM nodes keep their `@ref` across repeated
 snapshots even when a modal or list inserts other nodes. Navigation and tab
 switches still invalidate refs. `snapshot -i` also surfaces deliberate cursor
 styles such as `grab` and `col-resize`, plus compact DOM anchors for otherwise
-indistinguishable generic controls.
+indistinguishable generic controls. When the accessibility tree yields no refs
+at all (web-component SPAs whose whole page lives inside shadow roots),
+`snapshot` automatically lists actionable elements from a DOM walk through open
+and closed shadow roots; those refs work with `click`/`type`/`fill` like any
+other, the JSON says `source: "dom"`, and `snapshot --dom` forces that path.
 
 `screenshot --annotate` refreshes its labels from the current document without
 hard-resetting that identity map. A ref from the immediately preceding snapshot

--- a/README.zh.md
+++ b/README.zh.md
@@ -66,6 +66,7 @@ chrome-use 让**任意** agent（Claude Code、Cursor、Codex、你自己的脚�
 ![架构](assets/architecture.png)
 
 每个 `--session` 拿到**自己的彩色标签组**，多个 agent 共用同一个真实浏览器、互不干扰，也不动你自己的标签页。
+省略 `--session` 时会按 agent/终端 id 派生 `cu-<目录名>-<tag>`；换到别的目录执行时会复用已经带着同一个 agent tag 的守护进程，标签和 ref 不会因为 `cd` 丢失（显式 `--session` / `AGENT_BROWSER_SESSION` 优先）。
 
 ## 为什么用扩展（而非裸调试端口）
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1474,6 +1474,9 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     "-u" | "--urls" => {
                         obj.insert("urls".to_string(), json!(true));
                     }
+                    "--dom" => {
+                        obj.insert("dom".to_string(), json!(true));
+                    }
                     "-d" | "--depth" => {
                         if let Some(d) = rest.get(i + 1) {
                             if let Ok(n) = d.parse::<i32>() {

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -2090,7 +2090,10 @@ mod tests {
             "cu-repo-a-3f9a1c"
         );
         // The candidate itself is live → keep it (no surprise switch).
-        let live = vec!["cu-repo-a-3f9a1c".to_string(), "cu-repo-b-3f9a1c".to_string()];
+        let live = vec![
+            "cu-repo-a-3f9a1c".to_string(),
+            "cu-repo-b-3f9a1c".to_string(),
+        ];
         assert_eq!(
             reuse_live_session_name("cu-repo-b-3f9a1c", "3f9a1c", &live),
             "cu-repo-b-3f9a1c"
@@ -2107,7 +2110,10 @@ mod tests {
             reuse_live_session_name("cu-repo-b-3f9a1c", "3f9a1c", &live),
             "cu-3f9a1c"
         );
-        assert_eq!(reuse_live_session_name("cu-x-3f9a1c", "3f9a1c", &[]), "cu-x-3f9a1c");
+        assert_eq!(
+            reuse_live_session_name("cu-x-3f9a1c", "3f9a1c", &[]),
+            "cu-x-3f9a1c"
+        );
     }
 
     #[test]

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -568,7 +568,64 @@ fn scan_conventional_agent_id(vars: &[(String, String)]) -> Option<(String, Stri
 /// `default` — unchanged behaviour, since there's nothing stable to isolate on.
 /// `--session` / `AGENT_BROWSER_SESSION` are resolved before this and override it.
 fn default_session_name() -> String {
-    session_name_for(pick_agent_id(&env::vars().collect::<Vec<_>>()))
+    let picked = pick_agent_id(&env::vars().collect::<Vec<_>>());
+    let candidate = session_name_for(picked.clone());
+    match picked {
+        Some(agent_id) => {
+            reuse_live_session_name(&candidate, &session_tag(&agent_id), &live_session_names())
+        }
+        None => candidate,
+    }
+}
+
+/// Session names that currently have a daemon socket / pid file, i.e. the
+/// sessions an agent could already be driving.
+fn live_session_names() -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(crate::connection::get_socket_dir()) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            name.strip_suffix(".sock")
+                .or_else(|| name.strip_suffix(".pid"))
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+/// Keep one agent on ONE session when it changes directory.
+///
+/// The derived name is `cu-<repo>-<tag>`: `<tag>` is the agent's identity, the
+/// repo basename only a readable prefix. Taken literally per invocation, a
+/// helper step that `cd`s into another directory to read local data mints a
+/// different name, lands on a fresh daemon with no snapshot, and every `@ref`
+/// from the previous step fails as "Unknown ref" — with nothing hinting at the
+/// working directory as the cause (issue #205). So when a live daemon already
+/// carries this agent's tag under another prefix, reuse that name: the tab
+/// group, refs and state stay put across `cd`. Explicit `--session` /
+/// `AGENT_BROWSER_SESSION` never reach here.
+fn reuse_live_session_name(candidate: &str, tag: &str, live: &[String]) -> String {
+    if live.iter().any(|n| n == candidate) {
+        return candidate.to_string();
+    }
+    let bare = format!("cu-{tag}");
+    let suffix = format!("-{tag}");
+    let mut matches: Vec<&String> = live
+        .iter()
+        .filter(|n| *n == &bare || (n.starts_with("cu-") && n.ends_with(&suffix)))
+        .collect();
+    matches.sort();
+    matches
+        .first()
+        .map(|n| (*n).clone())
+        .unwrap_or_else(|| candidate.to_string())
+}
+
+/// The short identity tag a session name ends with.
+fn session_tag(agent_id: &str) -> String {
+    format!("{:06x}", session_hash(agent_id) & 0x00ff_ffff)
 }
 
 /// Choose the id to key the session on, in tier order: an explicit/known agent
@@ -619,7 +676,7 @@ fn session_name_for(agent_id: Option<String>) -> String {
     let Some(agent_id) = agent_id else {
         return "default".to_string();
     };
-    let tag = format!("{:06x}", session_hash(&agent_id) & 0x00ff_ffff);
+    let tag = session_tag(&agent_id);
     let repo = env::current_dir()
         .ok()
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
@@ -2013,6 +2070,35 @@ mod tests {
         // A different task (different id) -> a different session, no collision.
         let two = session_name_for(pick_agent_id(&env(&[("CODEX_THREAD_ID", "thread-two")])));
         assert_ne!(one, two, "two agents must not collide");
+    }
+
+    #[test]
+    fn cd_keeps_the_agent_on_its_live_session() {
+        // Same agent tag, different repo prefix → reuse the live one (#205).
+        let live = vec!["cu-repo-a-3f9a1c".to_string(), "default".to_string()];
+        assert_eq!(
+            reuse_live_session_name("cu-repo-b-3f9a1c", "3f9a1c", &live),
+            "cu-repo-a-3f9a1c"
+        );
+        // The candidate itself is live → keep it (no surprise switch).
+        let live = vec!["cu-repo-a-3f9a1c".to_string(), "cu-repo-b-3f9a1c".to_string()];
+        assert_eq!(
+            reuse_live_session_name("cu-repo-b-3f9a1c", "3f9a1c", &live),
+            "cu-repo-b-3f9a1c"
+        );
+        // A different agent's session never gets borrowed.
+        let live = vec!["cu-repo-a-ffffff".to_string()];
+        assert_eq!(
+            reuse_live_session_name("cu-repo-b-3f9a1c", "3f9a1c", &live),
+            "cu-repo-b-3f9a1c"
+        );
+        // A tag-only name (cwd unreadable) also matches.
+        let live = vec!["cu-3f9a1c".to_string()];
+        assert_eq!(
+            reuse_live_session_name("cu-repo-b-3f9a1c", "3f9a1c", &live),
+            "cu-3f9a1c"
+        );
+        assert_eq!(reuse_live_session_name("cu-x-3f9a1c", "3f9a1c", &[]), "cu-x-3f9a1c");
     }
 
     #[test]

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -666,7 +666,16 @@ pub fn describe_default_session() -> (String, Option<String>) {
     let vars: Vec<(String, String)> = env::vars().collect();
     let picked = pick_agent_id_with_source(&vars);
     let source = picked.as_ref().map(|(k, _)| k.clone());
-    (session_name_for(picked.map(|(_, id)| id)), source)
+    let Some((_, agent_id)) = picked else {
+        return (session_name_for(None), source);
+    };
+    // Same reuse rule as `default_session_name`, so `doctor` names the session
+    // a command from this directory would actually join (#205).
+    let candidate = session_name_for(Some(agent_id.clone()));
+    (
+        reuse_live_session_name(&candidate, &session_tag(&agent_id), &live_session_names()),
+        source,
+    )
 }
 
 /// Render the session name for a chosen agent id. `None` keeps the historical

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -429,7 +429,7 @@ impl DaemonState {
             safari_driver: None,
             webdriver_backend: None,
             backend_type: BackendType::Cdp,
-            ref_map: RefMap::new(),
+            ref_map: RefMap::with_session_label(env::var("AGENT_BROWSER_SESSION").ok().as_deref()),
             domain_filter: Arc::new(RwLock::new(
                 env::var("AGENT_BROWSER_ALLOWED_DOMAINS")
                     .ok()
@@ -3659,6 +3659,50 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     )
     .await?;
 
+    // DOM-walk fallback (issue #206). On some web-component SPAs the AX tree
+    // comes back as a few bare `generic` nodes with nothing to ref — even
+    // though the page is fully rendered inside (open) shadow roots and a
+    // screenshot shows headings, links and a form. Rather than print
+    // "(no interactive elements)" and leave the agent hand-writing a
+    // shadow-root walker in `eval`, list the actionable elements straight from
+    // `DOM.getDocument(pierce:true)`. `snapshot --dom` forces this path.
+    let dom_forced = cmd.get("dom").and_then(|v| v.as_bool()).unwrap_or(false);
+    let mut dom_note: Option<String> = None;
+    let tree = if options.selector.is_none()
+        && (dom_forced || state.ref_map.entries_sorted().is_empty())
+    {
+        match snapshot::take_dom_snapshot(
+            &mgr.client,
+            &session_id,
+            &mut state.ref_map,
+            state.active_frame_id.as_deref(),
+        )
+        .await
+        {
+            Ok((dom_tree, n)) if dom_forced || n > 0 => {
+                dom_note = Some(if dom_forced {
+                    "Listed from a DOM walk (snapshot --dom): open and closed shadow roots and \
+                     same-process child documents are pierced; roles/names are derived from \
+                     tags and attributes, not the accessibility tree. Refs work with click/type/fill."
+                        .to_string()
+                } else {
+                    "The accessibility tree for this page was empty (its content lives inside \
+                     shadow DOM), so this listing comes from a DOM walk through the shadow roots. \
+                     Roles/names are derived from tags and attributes; refs work with click/type/fill."
+                        .to_string()
+                });
+                if n == 0 {
+                    "(no interactive elements)".to_string()
+                } else {
+                    dom_tree
+                }
+            }
+            _ => tree,
+        }
+    } else {
+        tree
+    };
+
     // `--filter <regex>` (issue #65): for desktop-shell web apps (Synology DSM,
     // NAS/router panels) one snapshot holds many app windows — keep only the
     // matching lines + their ancestor context so the target controls aren't
@@ -3684,6 +3728,10 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
 
     let ref_count = refs.len();
     let mut out = json!({ "snapshot": tree, "origin": url, "refs": refs });
+    if let Some(note) = dom_note {
+        out["note"] = json!(note);
+        out["source"] = json!("dom");
+    }
 
     // Auto-trigger: if this domain has site adapters, surface them so the agent
     // pulls structured data instead of walking the tree. `with_site_hint` reads
@@ -4497,8 +4545,31 @@ async fn handle_type(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
     .await?;
     if commit_enter {
         interaction::commit_with_enter(&mgr.client, &session_id).await?;
+        return Ok(json!({ "typed": text, "committed": commit_enter }));
     }
-    Ok(json!({ "typed": text, "committed": commit_enter }))
+    // Read the field back and say so when the page rewrote what was typed. A
+    // Latin-only address form silently dropped every CJK character while `type`
+    // still reported ✓ Done (issue #203); the keystrokes were delivered, the
+    // page's own input filter discarded them. Warning, not error: masks and
+    // formatters legitimately rewrite input, and the read-back lets the agent
+    // judge.
+    let mut out = json!({ "typed": text, "committed": commit_enter });
+    if let Some((read_back, warning)) = interaction::read_back_after_type(
+        &mgr.client,
+        &session_id,
+        &state.ref_map,
+        selector,
+        text,
+        &state.iframe_sessions,
+    )
+    .await
+    {
+        out["readBack"] = json!(read_back);
+        if let Some(w) = warning {
+            out["warning"] = json!(w);
+        }
+    }
+    Ok(out)
 }
 
 /// Atomic combobox select: `pick <selector> --option "<text>"`. Opens the control
@@ -4664,9 +4735,39 @@ async fn handle_press(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         ));
     }
 
+    // Does the page even listen for this key? A custom dropdown whose only
+    // commit path is a mouse `onclick` has no keydown handler at all, so
+    // `press ArrowDown` / `press Enter` dispatched fine, changed nothing, and
+    // still printed a cheerful ✓ — costing rounds of retries before the agent
+    // gave up on the keyboard path (issue #202). Probe BEFORE dispatching (Enter
+    // may navigate away) and only for keys whose browser default does nothing
+    // useful on this target; a probe failure is silence, never an error.
+    let key_listeners = if interaction::key_effect_depends_on_listeners(
+        &actual_key,
+        modifiers,
+        target.as_deref(),
+    ) {
+        interaction::count_key_listeners_on_active_element(&mgr.client, &dispatch_session).await
+    } else {
+        None
+    };
+
     interaction::press_key_with_modifiers(&mgr.client, &dispatch_session, &actual_key, modifiers)
         .await?;
-    Ok(press_result(key, target, &actual_key, json!({})))
+    let mut out = press_result(key, target.clone(), &actual_key, json!({}));
+    if let Some(found) = key_listeners {
+        out["keyListeners"] = json!(found);
+        if found == 0 && out.get("warning").is_none() {
+            let where_it_went = target.as_deref().unwrap_or("the focused element");
+            out["warning"] = json!(format!(
+                "{key} reached <{where_it_went}>, but no keydown/keyup/keypress listener is registered \
+                 on it, its ancestors, document or window — the page cannot react to this key beyond \
+                 the browser default, so nothing app-visible happened. If this was meant to drive a \
+                 custom dropdown/list, `click` the option itself (`snapshot -i` lists it)."
+            ));
+        }
+    }
+    Ok(out)
 }
 
 /// Build the `press` response, naming the element the key went to and warning
@@ -9296,7 +9397,7 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
             let entry = state
                 .ref_map
                 .get(&ref_id)
-                .ok_or_else(|| format!("Unknown ref: {}", ref_id))?;
+                .ok_or_else(|| state.ref_map.unknown_ref_error(&ref_id))?;
             let backend_node_id = entry
                 .backend_node_id
                 .ok_or_else(|| format!("Ref {} has no backend node id", ref_id))?;

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -567,16 +567,26 @@ pub fn to_ai_friendly_error(error: &str) -> String {
             .to_string();
     }
     if lower.contains("element not found") || lower.contains("no element") {
+        // The resolver already diagnosed the miss (an XPath `text()` gotcha, a
+        // placeholder rendered on an inner span, …): keep that verbatim — the old
+        // wholesale replacement threw the selector AND the hint away and always
+        // blamed a closed shadow root / cross-origin iframe, two rare causes that
+        // sent people down the wrong path (issue #202).
+        if error.contains("Hint:") || error.contains("Run `snapshot -i`") {
+            return error.to_string();
+        }
         // Selectors / `find` match the page DOM, which can't see inside a CLOSED
         // shadow root or a cross-origin iframe — but `snapshot -i` (the CDP
         // accessibility tree) pierces both. Also nudge to verify the exact
         // label, since translations differ (real case: LinkedIn's Save button is
         // labelled 收藏, not 保存 — issue #55).
-        return "Element not found in the page DOM. If it's inside a CLOSED shadow root or a \
-                cross-origin iframe, selectors/`find` can't reach it — run `snapshot -i` (it \
-                pierces both via the accessibility tree) and `click` the @ref. Also verify the \
-                exact label/text: translations differ (e.g. a \"Save\" button may be labelled 收藏)."
-            .to_string();
+        return format!(
+            "{error}\nHint: the selector matched nothing in the page DOM. Check the exact \
+             label/text first (translations differ: a \"Save\" button may be labelled 收藏), and \
+             for text matching prefer `find \"<label>\"` / `snapshot -i` + @ref over CSS/XPath. \
+             If the element lives in a CLOSED shadow root or a cross-origin iframe, selectors/`find` \
+             can't reach it — `snapshot -i` pierces both via the accessibility tree."
+        );
     }
     error.to_string()
 }
@@ -4967,10 +4977,18 @@ mod tests {
 
     #[test]
     fn test_to_ai_friendly_error_not_found() {
-        let m = to_ai_friendly_error("Element not found");
-        assert!(m.starts_with("Element not found"));
+        let m = to_ai_friendly_error("Element not found: #save");
+        assert!(m.starts_with("Element not found: #save"), "selector kept: {m}");
         // directs to snapshot -i (which pierces closed shadow / cross-origin iframes)
         assert!(m.contains("snapshot -i") && m.contains("shadow root"));
+    }
+
+    #[test]
+    fn test_to_ai_friendly_error_not_found_keeps_a_specific_diagnosis() {
+        // A resolver that already explained the miss must not have its
+        // explanation replaced by the generic shadow-root/iframe guess (#202).
+        let specific = "Element not found: //*[contains(text(),'x')]\nHint: XPath `text()` matches only the FIRST direct text node";
+        assert_eq!(to_ai_friendly_error(specific), specific);
     }
 
     #[test]

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -5065,8 +5065,10 @@ mod tests {
 
     #[test]
     fn test_to_ai_friendly_error_catches_no_element() {
+        // The original text (which names the selector) is kept and the
+        // guidance is appended, instead of replacing the whole message (#202).
         let m = to_ai_friendly_error("No element found for css 'x'");
-        assert!(m.starts_with("Element not found"));
+        assert!(m.starts_with("No element found for css 'x'"), "{m}");
         assert!(m.contains("snapshot -i"));
     }
 

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -4978,7 +4978,10 @@ mod tests {
     #[test]
     fn test_to_ai_friendly_error_not_found() {
         let m = to_ai_friendly_error("Element not found: #save");
-        assert!(m.starts_with("Element not found: #save"), "selector kept: {m}");
+        assert!(
+            m.starts_with("Element not found: #save"),
+            "selector kept: {m}"
+        );
         // directs to snapshot -i (which pierces closed shadow / cross-origin iframes)
         assert!(m.contains("snapshot -i") && m.contains("shadow root"));
     }

--- a/cli/src/native/dom_snapshot.rs
+++ b/cli/src/native/dom_snapshot.rs
@@ -72,7 +72,11 @@ pub fn render(elems: &[DomElem], refs: &[String]) -> String {
         } else {
             format!(" {:?}", el.name)
         };
-        lines.push(format!("{indent}- {}{name} [{}]", el.role, attrs.join(", ")));
+        lines.push(format!(
+            "{indent}- {}{name} [{}]",
+            el.role,
+            attrs.join(", ")
+        ));
     }
     lines.join("\n")
 }
@@ -130,10 +134,20 @@ fn text_of(node: &Value, out: &mut String) {
         }
         return;
     }
-    for child in node.get("children").and_then(Value::as_array).into_iter().flatten() {
+    for child in node
+        .get("children")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
         text_of(child, out);
     }
-    for sr in node.get("shadowRoots").and_then(Value::as_array).into_iter().flatten() {
+    for sr in node
+        .get("shadowRoots")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
         text_of(sr, out);
     }
 }
@@ -158,10 +172,20 @@ fn collect_label_texts(node: &Value, out: &mut std::collections::HashMap<String,
             }
         }
     }
-    for child in node.get("children").and_then(Value::as_array).into_iter().flatten() {
+    for child in node
+        .get("children")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
         collect_label_texts(child, out);
     }
-    for sr in node.get("shadowRoots").and_then(Value::as_array).into_iter().flatten() {
+    for sr in node
+        .get("shadowRoots")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
         collect_label_texts(sr, out);
     }
     if let Some(doc) = node.get("contentDocument") {
@@ -211,7 +235,11 @@ fn classify(node: &Value, labels: &std::collections::HashMap<String, String>) ->
                 }
             }
             "BUTTON" | "SUMMARY" => "button".to_string(),
-            "INPUT" => match attr(node, "type").unwrap_or("text").to_ascii_lowercase().as_str() {
+            "INPUT" => match attr(node, "type")
+                .unwrap_or("text")
+                .to_ascii_lowercase()
+                .as_str()
+            {
                 "hidden" => return None,
                 "checkbox" => "checkbox".to_string(),
                 "radio" => "radio".to_string(),
@@ -231,7 +259,10 @@ fn classify(node: &Value, labels: &std::collections::HashMap<String, String>) ->
             }
             _ => {
                 let ce = attr(node, "contenteditable").map(|v| v.to_ascii_lowercase());
-                if matches!(ce.as_deref(), Some("") | Some("true") | Some("plaintext-only")) {
+                if matches!(
+                    ce.as_deref(),
+                    Some("") | Some("true") | Some("plaintext-only")
+                ) {
                     "textbox".to_string()
                 } else if has_attr(node, "onclick") {
                     "button".to_string()
@@ -335,10 +366,20 @@ fn walk(
             return;
         }
     }
-    for child in node.get("children").and_then(Value::as_array).into_iter().flatten() {
+    for child in node
+        .get("children")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
         walk(child, labels, frame_depth, pending_frame_label, out);
     }
-    for sr in node.get("shadowRoots").and_then(Value::as_array).into_iter().flatten() {
+    for sr in node
+        .get("shadowRoots")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
         walk(sr, labels, frame_depth, pending_frame_label, out);
     }
     if let Some(doc) = node.get("contentDocument") {
@@ -378,12 +419,27 @@ mod tests {
         let mut host = el("APP-ROOT", 1, &[], vec![]);
         host["shadowRoots"] = json!([shadow(vec![
             el("H1", 2, &[], vec![text("Contact Us")]),
-            el("A", 3, &[("href", "/topic")], vec![text(" Developer  Program ")]),
+            el(
+                "A",
+                3,
+                &[("href", "/topic")],
+                vec![text(" Developer  Program ")]
+            ),
             el("BUTTON", 4, &[("disabled", "")], vec![text("Continue")]),
             el("LABEL", 5, &[("for", "email")], vec![text("Email address")]),
-            el("INPUT", 6, &[("id", "email"), ("type", "email"), ("required", "")], vec![]),
+            el(
+                "INPUT",
+                6,
+                &[("id", "email"), ("type", "email"), ("required", "")],
+                vec![]
+            ),
             el("INPUT", 7, &[("type", "hidden"), ("name", "csrf")], vec![]),
-            el("DIV", 8, &[("style", "display: none")], vec![el("BUTTON", 9, &[], vec![text("hidden")])]),
+            el(
+                "DIV",
+                8,
+                &[("style", "display: none")],
+                vec![el("BUTTON", 9, &[], vec![text("hidden")])]
+            ),
             el("SCRIPT", 10, &[], vec![text("var x = 1")]),
         ])]);
         let doc = json!({ "nodeType": 9, "nodeName": "#document", "children": [el("BODY", 0, &[], vec![host])] });
@@ -407,11 +463,30 @@ mod tests {
             0,
             &[],
             vec![
-                el("INPUT", 1, &[("type", "checkbox"), ("checked", ""), ("aria-label", "Agree")], vec![]),
+                el(
+                    "INPUT",
+                    1,
+                    &[
+                        ("type", "checkbox"),
+                        ("checked", ""),
+                        ("aria-label", "Agree"),
+                    ],
+                    vec![],
+                ),
                 el("INPUT", 2, &[("type", "submit"), ("value", "Send")], vec![]),
                 el("DIV", 3, &[("role", "button")], vec![text("Custom")]),
-                el("DIV", 4, &[("contenteditable", "true"), ("placeholder", "Write…")], vec![]),
-                el("SELECT", 5, &[("name", "country")], vec![el("OPTION", 6, &[("selected", "")], vec![text("JP")])]),
+                el(
+                    "DIV",
+                    4,
+                    &[("contenteditable", "true"), ("placeholder", "Write…")],
+                    vec![],
+                ),
+                el(
+                    "SELECT",
+                    5,
+                    &[("name", "country")],
+                    vec![el("OPTION", 6, &[("selected", "")], vec![text("JP")])],
+                ),
                 el("DIV", 7, &[("role", "presentation")], vec![text("nope")]),
                 el("SPAN", 8, &[], vec![text("plain")]),
                 el("A", 9, &[], vec![text("no href")]),
@@ -419,7 +494,10 @@ mod tests {
         );
         let doc = json!({ "nodeType": 9, "nodeName": "#document", "children": [body] });
         let elems = collect_interactive(&doc);
-        let got: Vec<(String, String)> = elems.iter().map(|e| (e.role.clone(), e.name.clone())).collect();
+        let got: Vec<(String, String)> = elems
+            .iter()
+            .map(|e| (e.role.clone(), e.name.clone()))
+            .collect();
         assert_eq!(
             got,
             vec![

--- a/cli/src/native/dom_snapshot.rs
+++ b/cli/src/native/dom_snapshot.rs
@@ -1,0 +1,455 @@
+//! DOM-walk fallback for `snapshot` (issue #206).
+//!
+//! `snapshot` reads the CDP accessibility tree, which normally pierces open AND
+//! closed shadow roots. On some web-component SPAs (developer.apple.com/contact
+//! — a fully rendered page whose entire content lives inside shadow roots) the
+//! AX tree nevertheless comes back as a handful of bare `generic` nodes, so
+//! `snapshot` printed three lines and `snapshot -i` said "(no interactive
+//! elements)" while a screenshot showed a normal page and the agent had to
+//! hand-write a recursive shadow-root walker in `eval` to get anything done.
+//!
+//! This module builds the same kind of listing from `DOM.getDocument(pierce:
+//! true)` — which reaches open and closed shadow roots and same-process child
+//! documents — with refs keyed by `backendNodeId`, so `click @ref` / `type
+//! @ref` / `fill @ref` work exactly as with AX-minted refs. The tree walk and
+//! rendering are pure so they can be unit-tested on a synthetic DOM.Node JSON.
+
+use serde_json::Value;
+
+/// One interactive (or heading) element found by the DOM walk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DomElem {
+    pub backend_node_id: i64,
+    pub role: String,
+    pub name: String,
+    /// `heading` level (h1..h6) when the element is a heading.
+    pub level: Option<u8>,
+    pub disabled: bool,
+    /// Nesting depth of the child document the element sits in (0 = main).
+    pub frame_depth: usize,
+    /// Title/URL of the child document, set on the first element of each frame
+    /// so the renderer can print an `iframe` header line.
+    pub frame_label: Option<String>,
+    /// Extra attributes worth printing: `[checked]`, `[selected]`, `[expanded]`.
+    pub attrs: Vec<String>,
+}
+
+/// Walk a `DOM.getDocument` tree (any depth, `pierce: true`) and collect the
+/// elements an agent can act on, in document order.
+pub fn collect_interactive(doc: &Value) -> Vec<DomElem> {
+    let mut labels = std::collections::HashMap::new();
+    collect_label_texts(doc, &mut labels);
+    let mut out = Vec::new();
+    walk(doc, &labels, 0, &mut None, &mut out);
+    out
+}
+
+/// Render the collected elements as snapshot lines (`- role "name" [ref=eN]`).
+/// `refs` must be parallel to `elems` (the ref id minted for each).
+pub fn render(elems: &[DomElem], refs: &[String]) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for (el, ref_id) in elems.iter().zip(refs) {
+        if let Some(label) = &el.frame_label {
+            let indent = "  ".repeat(el.frame_depth.saturating_sub(1));
+            if label.is_empty() {
+                lines.push(format!("{indent}- iframe"));
+            } else {
+                lines.push(format!("{indent}- iframe {:?}", label));
+            }
+        }
+        let indent = "  ".repeat(el.frame_depth);
+        let mut attrs: Vec<String> = Vec::new();
+        if let Some(l) = el.level {
+            attrs.push(format!("level={l}"));
+        }
+        attrs.extend(el.attrs.iter().cloned());
+        if el.disabled {
+            attrs.push("disabled".to_string());
+        }
+        attrs.push(format!("ref={ref_id}"));
+        let name = if el.name.is_empty() {
+            String::new()
+        } else {
+            format!(" {:?}", el.name)
+        };
+        lines.push(format!("{indent}- {}{name} [{}]", el.role, attrs.join(", ")));
+    }
+    lines.join("\n")
+}
+
+fn attr<'a>(node: &'a Value, name: &str) -> Option<&'a str> {
+    let attrs = node.get("attributes")?.as_array()?;
+    let mut i = 0;
+    while i + 1 < attrs.len() {
+        if attrs[i].as_str()?.eq_ignore_ascii_case(name) {
+            return attrs[i + 1].as_str();
+        }
+        i += 2;
+    }
+    None
+}
+
+fn has_attr(node: &Value, name: &str) -> bool {
+    attr(node, name).is_some()
+}
+
+fn norm(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn cap(s: String, max: usize) -> String {
+    if s.chars().count() <= max {
+        s
+    } else {
+        let head: String = s.chars().take(max).collect();
+        format!("{head}…")
+    }
+}
+
+/// Text of a subtree (pierced), skipping script/style/template/noscript.
+fn text_of(node: &Value, out: &mut String) {
+    let node_type = node.get("nodeType").and_then(Value::as_i64).unwrap_or(0);
+    let name = node.get("nodeName").and_then(Value::as_str).unwrap_or("");
+    if node_type == 3 {
+        if let Some(t) = node.get("nodeValue").and_then(Value::as_str) {
+            out.push(' ');
+            out.push_str(t);
+        }
+        return;
+    }
+    if node_type == 1 && is_skipped_tag(name) {
+        return;
+    }
+    if node_type == 1 && attr(node, "aria-hidden") == Some("true") {
+        return;
+    }
+    if node_type == 1 && name.eq_ignore_ascii_case("IMG") {
+        if let Some(alt) = attr(node, "alt") {
+            out.push(' ');
+            out.push_str(alt);
+        }
+        return;
+    }
+    for child in node.get("children").and_then(Value::as_array).into_iter().flatten() {
+        text_of(child, out);
+    }
+    for sr in node.get("shadowRoots").and_then(Value::as_array).into_iter().flatten() {
+        text_of(sr, out);
+    }
+}
+
+fn is_skipped_tag(tag: &str) -> bool {
+    matches!(
+        tag.to_ascii_uppercase().as_str(),
+        "SCRIPT" | "STYLE" | "TEMPLATE" | "NOSCRIPT" | "HEAD" | "TITLE" | "META" | "LINK"
+    )
+}
+
+/// `<label for=id>` texts, so an input can be named by its label.
+fn collect_label_texts(node: &Value, out: &mut std::collections::HashMap<String, String>) {
+    let name = node.get("nodeName").and_then(Value::as_str).unwrap_or("");
+    if name.eq_ignore_ascii_case("LABEL") {
+        if let Some(target) = attr(node, "for") {
+            let mut t = String::new();
+            text_of(node, &mut t);
+            let t = norm(&t);
+            if !t.is_empty() {
+                out.entry(target.to_string()).or_insert(t);
+            }
+        }
+    }
+    for child in node.get("children").and_then(Value::as_array).into_iter().flatten() {
+        collect_label_texts(child, out);
+    }
+    for sr in node.get("shadowRoots").and_then(Value::as_array).into_iter().flatten() {
+        collect_label_texts(sr, out);
+    }
+    if let Some(doc) = node.get("contentDocument") {
+        collect_label_texts(doc, out);
+    }
+}
+
+fn hidden_by_style(node: &Value) -> bool {
+    if has_attr(node, "hidden") || attr(node, "aria-hidden") == Some("true") {
+        return true;
+    }
+    let style = attr(node, "style")
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .replace(' ', "");
+    style.contains("display:none") || style.contains("visibility:hidden")
+}
+
+/// Role + whether the element is one we list, from tag/type/role attributes.
+/// Mirrors the AX roles `snapshot -i` prints so refs read the same either way.
+fn classify(node: &Value, labels: &std::collections::HashMap<String, String>) -> Option<DomElem> {
+    let tag = node
+        .get("nodeName")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    let explicit_role = attr(node, "role").map(|r| r.trim().to_ascii_lowercase());
+    let mut level = None;
+    let mut attrs = Vec::new();
+    let role: String = match explicit_role.as_deref() {
+        Some(r)
+            if crate::native::snapshot::is_interactive_role(r)
+                || matches!(r, "heading" | "dialog" | "alertdialog") =>
+        {
+            if r == "heading" {
+                level = attr(node, "aria-level").and_then(|l| l.parse().ok());
+            }
+            r.to_string()
+        }
+        Some("presentation") | Some("none") => return None,
+        _ => match tag.as_str() {
+            "A" | "AREA" => {
+                if has_attr(node, "href") {
+                    "link".to_string()
+                } else {
+                    return None;
+                }
+            }
+            "BUTTON" | "SUMMARY" => "button".to_string(),
+            "INPUT" => match attr(node, "type").unwrap_or("text").to_ascii_lowercase().as_str() {
+                "hidden" => return None,
+                "checkbox" => "checkbox".to_string(),
+                "radio" => "radio".to_string(),
+                "submit" | "button" | "reset" | "image" => "button".to_string(),
+                "range" => "slider".to_string(),
+                "number" => "spinbutton".to_string(),
+                "search" => "searchbox".to_string(),
+                "file" => "button".to_string(),
+                _ => "textbox".to_string(),
+            },
+            "TEXTAREA" => "textbox".to_string(),
+            "SELECT" => "combobox".to_string(),
+            "OPTION" => "option".to_string(),
+            "H1" | "H2" | "H3" | "H4" | "H5" | "H6" => {
+                level = tag[1..].parse().ok();
+                "heading".to_string()
+            }
+            _ => {
+                let ce = attr(node, "contenteditable").map(|v| v.to_ascii_lowercase());
+                if matches!(ce.as_deref(), Some("") | Some("true") | Some("plaintext-only")) {
+                    "textbox".to_string()
+                } else if has_attr(node, "onclick") {
+                    "button".to_string()
+                } else {
+                    return None;
+                }
+            }
+        },
+    };
+    if hidden_by_style(node) {
+        return None;
+    }
+    let backend_node_id = node.get("backendNodeId").and_then(Value::as_i64)?;
+
+    // Accessible name, in roughly the AX precedence: aria-label, <label for>,
+    // placeholder, value (buttons), title, then visible text.
+    let mut name = attr(node, "aria-label").map(norm).unwrap_or_default();
+    if name.is_empty() {
+        if let Some(id) = attr(node, "id") {
+            if let Some(l) = labels.get(id) {
+                name = l.clone();
+            }
+        }
+    }
+    if name.is_empty() {
+        if let Some(p) = attr(node, "placeholder") {
+            name = norm(p);
+        }
+    }
+    if name.is_empty() && role == "button" && tag == "INPUT" {
+        if let Some(v) = attr(node, "value") {
+            name = norm(v);
+        }
+    }
+    if name.is_empty() {
+        if let Some(t) = attr(node, "title") {
+            name = norm(t);
+        }
+    }
+    if name.is_empty() && !matches!(role.as_str(), "textbox" | "searchbox" | "combobox") {
+        let mut t = String::new();
+        text_of(node, &mut t);
+        name = norm(&t);
+    }
+    if name.is_empty() {
+        if let Some(n) = attr(node, "name") {
+            name = norm(n);
+        }
+    }
+    let name = cap(name, 80);
+
+    if role == "checkbox" || role == "radio" {
+        if has_attr(node, "checked") || attr(node, "aria-checked") == Some("true") {
+            attrs.push("checked".to_string());
+        }
+    }
+    if role == "option" && has_attr(node, "selected") {
+        attrs.push("selected".to_string());
+    }
+    if let Some(exp) = attr(node, "aria-expanded") {
+        attrs.push(format!("expanded={exp}"));
+    }
+    if has_attr(node, "required") || attr(node, "aria-required") == Some("true") {
+        attrs.push("required".to_string());
+    }
+    let disabled = has_attr(node, "disabled") || attr(node, "aria-disabled") == Some("true");
+
+    Some(DomElem {
+        backend_node_id,
+        role,
+        name,
+        level,
+        disabled,
+        frame_depth: 0,
+        frame_label: None,
+        attrs,
+    })
+}
+
+fn walk(
+    node: &Value,
+    labels: &std::collections::HashMap<String, String>,
+    frame_depth: usize,
+    pending_frame_label: &mut Option<String>,
+    out: &mut Vec<DomElem>,
+) {
+    let node_type = node.get("nodeType").and_then(Value::as_i64).unwrap_or(0);
+    let tag = node.get("nodeName").and_then(Value::as_str).unwrap_or("");
+    if node_type == 1 {
+        if is_skipped_tag(tag) {
+            return;
+        }
+        if let Some(mut el) = classify(node, labels) {
+            el.frame_depth = frame_depth;
+            el.frame_label = pending_frame_label.take();
+            out.push(el);
+        }
+        // A hidden container hides everything under it; listing its controls
+        // would offer refs that can't be clicked.
+        if hidden_by_style(node) {
+            return;
+        }
+    }
+    for child in node.get("children").and_then(Value::as_array).into_iter().flatten() {
+        walk(child, labels, frame_depth, pending_frame_label, out);
+    }
+    for sr in node.get("shadowRoots").and_then(Value::as_array).into_iter().flatten() {
+        walk(sr, labels, frame_depth, pending_frame_label, out);
+    }
+    if let Some(doc) = node.get("contentDocument") {
+        let title = attr(node, "title")
+            .or_else(|| attr(node, "name"))
+            .or_else(|| attr(node, "src"))
+            .unwrap_or("")
+            .to_string();
+        let mut label = Some(cap(norm(&title), 60));
+        walk(doc, labels, frame_depth + 1, &mut label, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn el(tag: &str, bid: i64, attrs: &[(&str, &str)], children: Vec<Value>) -> Value {
+        let flat: Vec<Value> = attrs
+            .iter()
+            .flat_map(|(k, v)| [json!(k), json!(v)])
+            .collect();
+        json!({ "nodeType": 1, "nodeName": tag, "backendNodeId": bid, "attributes": flat, "children": children })
+    }
+    fn text(t: &str) -> Value {
+        json!({ "nodeType": 3, "nodeName": "#text", "nodeValue": t })
+    }
+    fn shadow(children: Vec<Value>) -> Value {
+        json!({ "nodeType": 11, "nodeName": "#document-fragment", "children": children })
+    }
+
+    #[test]
+    fn lists_controls_inside_shadow_roots_with_names_and_refs() {
+        // developer.apple.com/contact shape: everything under a custom element's
+        // shadow root, light DOM empty.
+        let mut host = el("APP-ROOT", 1, &[], vec![]);
+        host["shadowRoots"] = json!([shadow(vec![
+            el("H1", 2, &[], vec![text("Contact Us")]),
+            el("A", 3, &[("href", "/topic")], vec![text(" Developer  Program ")]),
+            el("BUTTON", 4, &[("disabled", "")], vec![text("Continue")]),
+            el("LABEL", 5, &[("for", "email")], vec![text("Email address")]),
+            el("INPUT", 6, &[("id", "email"), ("type", "email"), ("required", "")], vec![]),
+            el("INPUT", 7, &[("type", "hidden"), ("name", "csrf")], vec![]),
+            el("DIV", 8, &[("style", "display: none")], vec![el("BUTTON", 9, &[], vec![text("hidden")])]),
+            el("SCRIPT", 10, &[], vec![text("var x = 1")]),
+        ])]);
+        let doc = json!({ "nodeType": 9, "nodeName": "#document", "children": [el("BODY", 0, &[], vec![host])] });
+        let elems = collect_interactive(&doc);
+        let refs: Vec<String> = (1..=elems.len()).map(|i| format!("e{i}")).collect();
+        let out = render(&elems, &refs);
+        assert_eq!(
+            out,
+            "- heading \"Contact Us\" [level=1, ref=e1]\n\
+             - link \"Developer Program\" [ref=e2]\n\
+             - button \"Continue\" [disabled, ref=e3]\n\
+             - textbox \"Email address\" [required, ref=e4]"
+        );
+        assert_eq!(elems[3].backend_node_id, 6);
+    }
+
+    #[test]
+    fn roles_from_type_role_and_contenteditable() {
+        let body = el(
+            "BODY",
+            0,
+            &[],
+            vec![
+                el("INPUT", 1, &[("type", "checkbox"), ("checked", ""), ("aria-label", "Agree")], vec![]),
+                el("INPUT", 2, &[("type", "submit"), ("value", "Send")], vec![]),
+                el("DIV", 3, &[("role", "button")], vec![text("Custom")]),
+                el("DIV", 4, &[("contenteditable", "true"), ("placeholder", "Write…")], vec![]),
+                el("SELECT", 5, &[("name", "country")], vec![el("OPTION", 6, &[("selected", "")], vec![text("JP")])]),
+                el("DIV", 7, &[("role", "presentation")], vec![text("nope")]),
+                el("SPAN", 8, &[], vec![text("plain")]),
+                el("A", 9, &[], vec![text("no href")]),
+            ],
+        );
+        let doc = json!({ "nodeType": 9, "nodeName": "#document", "children": [body] });
+        let elems = collect_interactive(&doc);
+        let got: Vec<(String, String)> = elems.iter().map(|e| (e.role.clone(), e.name.clone())).collect();
+        assert_eq!(
+            got,
+            vec![
+                ("checkbox".into(), "Agree".into()),
+                ("button".into(), "Send".into()),
+                ("button".into(), "Custom".into()),
+                ("textbox".into(), "Write…".into()),
+                ("combobox".into(), "country".into()),
+                ("option".into(), "JP".into()),
+            ]
+        );
+        assert_eq!(elems[0].attrs, vec!["checked".to_string()]);
+    }
+
+    #[test]
+    fn child_documents_get_an_iframe_header_and_indent() {
+        let mut iframe = el("IFRAME", 1, &[("title", "Sign in")], vec![]);
+        iframe["contentDocument"] = json!({ "nodeType": 9, "nodeName": "#document", "children": [
+            el("BODY", 2, &[], vec![el("BUTTON", 3, &[], vec![text("Go")])])
+        ]});
+        let doc = json!({ "nodeType": 9, "nodeName": "#document", "children": [el("BODY", 0, &[], vec![iframe])] });
+        let elems = collect_interactive(&doc);
+        let out = render(&elems, &["e1".to_string()]);
+        assert_eq!(out, "- iframe \"Sign in\"\n  - button \"Go\" [ref=e1]");
+    }
+
+    #[test]
+    fn empty_dom_yields_nothing() {
+        let doc = json!({ "nodeType": 9, "nodeName": "#document", "children": [el("BODY", 0, &[], vec![text("hi")])] });
+        assert!(collect_interactive(&doc).is_empty());
+        assert_eq!(render(&[], &[]), "");
+    }
+}

--- a/cli/src/native/dom_snapshot.rs
+++ b/cli/src/native/dom_snapshot.rs
@@ -314,10 +314,10 @@ fn classify(node: &Value, labels: &std::collections::HashMap<String, String>) ->
     }
     let name = cap(name, 80);
 
-    if role == "checkbox" || role == "radio" {
-        if has_attr(node, "checked") || attr(node, "aria-checked") == Some("true") {
-            attrs.push("checked".to_string());
-        }
+    if (role == "checkbox" || role == "radio")
+        && (has_attr(node, "checked") || attr(node, "aria-checked") == Some("true"))
+    {
+        attrs.push("checked".to_string());
     }
     if role == "option" && has_attr(node, "selected") {
         attrs.push("selected".to_string());

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -114,6 +114,10 @@ pub struct RefEntry {
     /// AX fingerprint captured at snapshot time, used by adaptive relocation when
     /// the node is gone and the role/name/nth re-query also fails.
     pub fingerprint: Option<ElementFingerprint>,
+    /// Minted by the DOM-walk fallback snapshot (issue #206), not the AX tree.
+    /// Such a ref is verified against the DOM (the node still exists) rather
+    /// than the accessibility tree, which on that page had nothing to compare.
+    pub dom_sourced: bool,
 }
 
 pub struct RefMap {
@@ -121,6 +125,8 @@ pub struct RefMap {
     next_ref: usize,
     stable_refs: HashMap<StableRefKey, StableRefEntry>,
     snapshot_generation: u64,
+    /// The session this map belongs to, for error messages. Empty = unknown.
+    session_label: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -152,7 +158,54 @@ impl RefMap {
             next_ref: 1,
             stable_refs: HashMap::new(),
             snapshot_generation: 0,
+            session_label: String::new(),
         }
+    }
+
+    /// A map that knows which session it serves, so "Unknown ref" can name it.
+    pub fn with_session_label(session: Option<&str>) -> Self {
+        let mut m = Self::new();
+        m.session_label = session.unwrap_or("").to_string();
+        m
+    }
+
+    /// The error for a `@ref` this map does not hold. Says WHICH session
+    /// answered and whether it has any refs at all: an agent that `cd`-ed into
+    /// another directory (or ran from another terminal) hits a different session
+    /// whose map is empty, and a bare "Unknown ref" read like a stale-page
+    /// problem — several rounds of re-snapshotting later the working directory
+    /// turned out to be the cause (issue #205).
+    pub fn unknown_ref_error(&self, ref_id: &str) -> String {
+        let session = if self.session_label.is_empty() {
+            String::new()
+        } else {
+            format!(" `{}`", self.session_label)
+        };
+        if self.map.is_empty() {
+            return format!(
+                "Unknown ref: {ref_id} — session{session} has NO snapshot refs at all: no `snapshot` \
+                 has run in this session yet (or the page navigated since). If you took the \
+                 snapshot from another directory or terminal, it lives in a different session: \
+                 `session list` shows them; pin one with `--session <name>` or \
+                 AGENT_BROWSER_SESSION=<name>. Otherwise run `snapshot -i` here and use its refs."
+            );
+        }
+        let mut ids: Vec<usize> = self
+            .map
+            .keys()
+            .filter_map(|k| k.strip_prefix('e').and_then(|n| n.parse().ok()))
+            .collect();
+        ids.sort_unstable();
+        let range = match (ids.first(), ids.last()) {
+            (Some(lo), Some(hi)) if lo != hi => format!(", e{lo}…e{hi}"),
+            (Some(lo), _) => format!(", e{lo}"),
+            _ => String::new(),
+        };
+        format!(
+            "Unknown ref: {ref_id} — not in the current snapshot of session{session} ({} refs{range}). \
+             Refs are re-minted by each `snapshot`; run `snapshot -i` again and use a fresh ref.",
+            self.map.len()
+        )
     }
 
     /// Start a new snapshot of the same document.
@@ -245,8 +298,16 @@ impl RefMap {
                 selector: None,
                 frame_id: frame_id.map(|s| s.to_string()),
                 fingerprint: None,
+                dom_sourced: false,
             },
         );
+    }
+
+    /// Flag a ref as minted by the DOM-walk fallback snapshot (#206).
+    pub fn mark_dom_sourced(&mut self, ref_id: &str) {
+        if let Some(entry) = self.map.get_mut(ref_id) {
+            entry.dom_sourced = true;
+        }
     }
 
     /// Attach an AX fingerprint to an existing ref (set during snapshot, used by
@@ -275,6 +336,7 @@ impl RefMap {
                 selector: Some(selector),
                 frame_id: None,
                 fingerprint: None,
+                dom_sourced: false,
             },
         );
     }
@@ -506,6 +568,15 @@ async fn confirmed_backend_node_id(
         return Ok(backend_node_id);
     }
 
+    // A DOM-fallback ref (#206) came from a page whose accessibility tree was
+    // empty, so an AX identity probe would only ever say "not in the tree".
+    // Verify against the DOM instead: the node must still exist and be the same
+    // kind of element the snapshot listed.
+    if entry.dom_sourced {
+        return verify_dom_sourced_ref(client, effective_session_id, backend_node_id, ref_id, entry)
+            .await;
+    }
+
     let RefCheck::Suspect(err) = verify_ref_identity(
         client,
         effective_session_id,
@@ -571,7 +642,7 @@ pub async fn resolve_element_center(
     if let Some(ref_id) = parse_ref(selector_or_ref) {
         let entry = ref_map
             .get(&ref_id)
-            .ok_or_else(|| format!("Unknown ref: {}", ref_id))?;
+            .ok_or_else(|| ref_map.unknown_ref_error(&ref_id))?;
 
         let effective_session_id =
             resolve_frame_session(entry.frame_id.as_deref(), session_id, iframe_sessions);
@@ -685,7 +756,7 @@ pub async fn resolve_element_object_id(
     if let Some(ref_id) = parse_ref(selector_or_ref) {
         let entry = ref_map
             .get(&ref_id)
-            .ok_or_else(|| format!("Unknown ref: {}", ref_id))?;
+            .ok_or_else(|| ref_map.unknown_ref_error(&ref_id))?;
 
         let effective_session_id =
             resolve_frame_session(entry.frame_id.as_deref(), session_id, iframe_sessions);
@@ -798,6 +869,9 @@ pub async fn resolve_element_object_id(
         // inner <span>, not the real <input>, so the CSS selector matches nothing
         // and the generic "closed shadow root / cross-origin iframe" hint sends
         // people down the wrong path (#90.4). Point at the closest textual match.
+        if let Some(hint) = xpath_miss_hint(selector_or_ref) {
+            return Err(format!("Element not found: {}\n{}", selector_or_ref, hint));
+        }
         if let Some(hint) = suggest_textual_match(client, session_id, selector_or_ref).await {
             return Err(format!("Element not found: {}. {}", selector_or_ref, hint));
         }
@@ -937,6 +1011,37 @@ fn resolve_frame_session<'a>(
         .and_then(|fid| iframe_sessions.get(fid))
         .map(|s| s.as_str())
         .unwrap_or(session_id)
+}
+
+/// DOM-side identity check for a ref minted by the DOM-walk fallback (#206):
+/// `DOM.describeNode` must still resolve the backend node, and its tag must be
+/// the one the snapshot classified. Anything else means the page re-rendered
+/// and the agent needs a fresh `snapshot`.
+async fn verify_dom_sourced_ref(
+    client: &CdpClient,
+    session_id: &str,
+    backend_node_id: i64,
+    ref_id: &str,
+    entry: &RefEntry,
+) -> Result<i64, String> {
+    let described: Result<Value, String> = tokio::time::timeout(
+        identity_probe_budget(),
+        client.send_command(
+            "DOM.describeNode",
+            Some(serde_json::json!({ "backendNodeId": backend_node_id })),
+            Some(session_id),
+        ),
+    )
+    .await
+    .unwrap_or_else(|_| Err("probe timed out".to_string()));
+    match described {
+        Ok(v) if v.get("node").is_some() => Ok(backend_node_id),
+        _ => Err(format!(
+            "Ref {ref_id} ({} \"{}\", from the DOM fallback snapshot) is no longer in the \
+             document — the page re-rendered. Run `snapshot -i` again and use a fresh ref.",
+            entry.role, entry.name
+        )),
+    }
 }
 
 /// Verify that the cached backendNodeId still has the same accessible role
@@ -1273,8 +1378,44 @@ pub(super) fn extract_ax_string(value: &Option<AXValue>) -> String {
 }
 
 /// Build a JS expression that finds a DOM element by CSS selector or XPath.
+/// The XPath expression a selector denotes, if it is one. An explicit `xpath=`
+/// prefix always wins; a bare selector that starts like a location path (`//`,
+/// `/`, `(`, `./`, `..`) is XPath too — none of those can begin a CSS
+/// selector, and feeding `//*[contains(text(),'x')]` to `querySelector` used to
+/// throw, fall through to the visible-text matcher, and report the row as
+/// "not found" even though it was right there (issue #202).
+pub(crate) fn xpath_of(selector: &str) -> Option<&str> {
+    if let Some(x) = selector.strip_prefix("xpath=") {
+        return Some(x);
+    }
+    let t = selector.trim_start();
+    if t.starts_with('/') || t.starts_with('(') || t.starts_with("./") || t.starts_with("..") {
+        return Some(selector);
+    }
+    None
+}
+
+/// The XPath `text()` gotcha, spelled out for the error message. `text()` is a
+/// node-set; `contains(text(), …)` string-converts only its FIRST node, so a
+/// row rendered as `<div>{a} - {b}</div>` (three sibling text nodes) or a label
+/// nested in a child element never matches — the row is visible, open, in the
+/// light DOM, and the selector still misses (issue #202).
+pub(crate) fn xpath_miss_hint(selector: &str) -> Option<String> {
+    let xpath = xpath_of(selector)?;
+    if !xpath.contains("text()") {
+        return None;
+    }
+    Some(
+        "Hint: XPath `text()` matches only the FIRST direct text node of an element, so text \
+         split across nodes (React `{a} - {b}`) or nested in a child never matches. Use \
+         `contains(normalize-space(.), '…')` on the element instead, or skip XPath: `find \
+         \"<label>\"` / `text=<label>` / `snapshot -i` and act on the @ref."
+            .to_string(),
+    )
+}
+
 fn build_find_element_js(selector: &str) -> String {
-    if let Some(xpath) = selector.strip_prefix("xpath=") {
+    if let Some(xpath) = xpath_of(selector) {
         return format!(
             "document.evaluate({}, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue",
             serde_json::to_string(xpath).unwrap_or_default()
@@ -1316,7 +1457,7 @@ fn build_find_element_js(selector: &str) -> String {
 
 /// Build a JS expression that counts matching DOM elements by CSS selector or XPath.
 fn build_count_elements_js(selector: &str) -> String {
-    if let Some(xpath) = selector.strip_prefix("xpath=") {
+    if let Some(xpath) = xpath_of(selector) {
         format!(
             "document.evaluate({}, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength",
             serde_json::to_string(xpath).unwrap_or_default()
@@ -1372,7 +1513,10 @@ async fn resolve_by_selector(
 
     match (x, y) {
         (Some(x), Some(y)) => Ok((x, y)),
-        _ => Err(format!("Element not found: {}", selector)),
+        _ => match xpath_miss_hint(selector) {
+            Some(hint) => Err(format!("Element not found: {}\n{}", selector, hint)),
+            None => Err(format!("Element not found: {}", selector)),
+        },
     }
 }
 
@@ -2265,6 +2409,24 @@ mod tests {
     }
 
     #[test]
+    fn test_unknown_ref_error_says_whether_the_session_has_any_refs() {
+        // Empty map: the agent is talking to a session that never snapshotted —
+        // typically after a `cd` moved it onto another session (#205).
+        let empty = RefMap::with_session_label(Some("cu-tools-3f9a1c"));
+        let e = empty.unknown_ref_error("e240");
+        assert!(e.starts_with("Unknown ref: e240"), "{e}");
+        assert!(e.contains("cu-tools-3f9a1c") && e.contains("NO snapshot refs"), "{e}");
+        assert!(e.contains("--session"), "{e}");
+
+        let mut m = RefMap::with_session_label(Some("s3"));
+        m.add("e1".to_string(), Some(1), "link", "a", None);
+        m.add("e7".to_string(), Some(2), "button", "b", None);
+        let e = m.unknown_ref_error("e240");
+        assert!(e.contains("2 refs, e1…e7"), "{e}");
+        assert!(e.contains("snapshot -i"), "{e}");
+    }
+
+    #[test]
     fn test_parse_ref_equals_prefix() {
         assert_eq!(parse_ref("ref=e1"), Some("e1".to_string()));
     }
@@ -2454,6 +2616,32 @@ mod tests {
         let js = build_selector_js("xpath=//button[@id='ok']");
         assert!(js.contains("document.evaluate(\"//button[@id='ok']\", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)"));
         assert!(!js.contains("document.querySelector"));
+    }
+
+    #[test]
+    fn test_bare_xpath_is_detected_without_prefix() {
+        // `//…`, `/…`, `(…)`, `./…`, `..` can't start a CSS selector, so they are
+        // XPath even without the `xpath=` prefix (issue #202).
+        assert_eq!(xpath_of("//*[contains(text(),'x')]"), Some("//*[contains(text(),'x')]"));
+        assert_eq!(xpath_of("(//li)[2]"), Some("(//li)[2]"));
+        assert_eq!(xpath_of("./span"), Some("./span"));
+        assert_eq!(xpath_of("xpath=//a"), Some("//a"));
+        assert_eq!(xpath_of("#id"), None);
+        assert_eq!(xpath_of(".class > a"), None);
+        assert_eq!(xpath_of("button"), None);
+        let js = build_selector_js("//button[@id='ok']");
+        assert!(js.contains("document.evaluate(\"//button[@id='ok']\""));
+        assert!(build_count_elements_js("//li").contains("snapshotLength"));
+    }
+
+    #[test]
+    fn test_xpath_text_miss_gets_the_split_text_hint() {
+        let hint = xpath_miss_hint("//*[contains(text(),'LudoAdmin')]").unwrap();
+        assert!(hint.contains("FIRST direct text node"));
+        assert!(hint.contains("normalize-space(.)"));
+        // Only XPath that actually uses text() earns the hint.
+        assert!(xpath_miss_hint("//button[@id='ok']").is_none());
+        assert!(xpath_miss_hint("#missing").is_none());
     }
 
     #[test]

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -573,8 +573,14 @@ async fn confirmed_backend_node_id(
     // Verify against the DOM instead: the node must still exist and be the same
     // kind of element the snapshot listed.
     if entry.dom_sourced {
-        return verify_dom_sourced_ref(client, effective_session_id, backend_node_id, ref_id, entry)
-            .await;
+        return verify_dom_sourced_ref(
+            client,
+            effective_session_id,
+            backend_node_id,
+            ref_id,
+            entry,
+        )
+        .await;
     }
 
     let RefCheck::Suspect(err) = verify_ref_identity(
@@ -2415,7 +2421,10 @@ mod tests {
         let empty = RefMap::with_session_label(Some("cu-tools-3f9a1c"));
         let e = empty.unknown_ref_error("e240");
         assert!(e.starts_with("Unknown ref: e240"), "{e}");
-        assert!(e.contains("cu-tools-3f9a1c") && e.contains("NO snapshot refs"), "{e}");
+        assert!(
+            e.contains("cu-tools-3f9a1c") && e.contains("NO snapshot refs"),
+            "{e}"
+        );
         assert!(e.contains("--session"), "{e}");
 
         let mut m = RefMap::with_session_label(Some("s3"));
@@ -2622,7 +2631,10 @@ mod tests {
     fn test_bare_xpath_is_detected_without_prefix() {
         // `//…`, `/…`, `(…)`, `./…`, `..` can't start a CSS selector, so they are
         // XPath even without the `xpath=` prefix (issue #202).
-        assert_eq!(xpath_of("//*[contains(text(),'x')]"), Some("//*[contains(text(),'x')]"));
+        assert_eq!(
+            xpath_of("//*[contains(text(),'x')]"),
+            Some("//*[contains(text(),'x')]")
+        );
         assert_eq!(xpath_of("(//li)[2]"), Some("(//li)[2]"));
         assert_eq!(xpath_of("./span"), Some("./span"));
         assert_eq!(xpath_of("xpath=//a"), Some("//a"));

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::cdp::client::CdpClient;
 use super::cdp::types::*;
@@ -371,7 +371,7 @@ async fn dom_click(
         .send_command_typed::<_, Value>(
             "Runtime.callFunctionOn",
             &CallFunctionOnParams {
-                function_declaration: "function() { this.click(); }".to_string(),
+                function_declaration: DOM_CLICK_WITH_FOCUS_JS.to_string(),
                 object_id: Some(object_id),
                 arguments: None,
                 return_by_value: Some(true),
@@ -383,6 +383,43 @@ async fn dom_click(
     wait_for_paint_settled(client, &effective_session_id).await;
     Ok(())
 }
+
+/// `element.click()` plus the focus move a REAL mouse click performs.
+///
+/// A synthetic `.click()` fires the click handlers but never moves keyboard
+/// focus, so on the relay (where a left click is DOM-dispatched by default)
+/// `click <input>` followed by `press Meta+a` / `press Backspace` landed on
+/// whichever field was focused BEFORE the click — one step behind, and on a
+/// half-filled form that select-all + delete wiped the wrong field (issue #204).
+/// Mirror what a trusted click does: focus the nearest focusable element
+/// (the input itself, or a focusable ancestor such as a `<label>`'s control /
+/// a `[tabindex]` wrapper) unless the click handler already moved focus
+/// elsewhere. Focus is deliberately NOT touched when nothing focusable is
+/// involved: blurring the current field on a click into empty space would fire
+/// blur-validation the page did not ask for.
+const DOM_CLICK_WITH_FOCUS_JS: &str = r#"function() {
+    const el = this;
+    const doc = el.ownerDocument || document;
+    const deepActive = () => {
+        let ae = doc.activeElement;
+        while (ae && ae.shadowRoot && ae.shadowRoot.activeElement) ae = ae.shadowRoot.activeElement;
+        return ae;
+    };
+    const before = deepActive();
+    el.click();
+    const after = deepActive();
+    if (after !== before) return 'moved-by-handler';
+    const focusable = el.closest
+        ? el.closest('input, textarea, select, button, a[href], [contenteditable=""], [contenteditable="true"], [tabindex], summary')
+        : null;
+    let target = focusable;
+    if (!target && el.tagName === 'LABEL' && el.control) target = el.control;
+    if (!target) return 'no-focusable';
+    if (target.disabled) return 'disabled';
+    if (target === after || (target.contains && target.contains(after))) return 'already';
+    try { target.focus({ preventScroll: true }); } catch (e) { return 'focus-failed'; }
+    return 'focused';
+}"#;
 
 /// Move the on-page cursor onto the element a DOM click is about to hit, then
 /// mark the click — the visible half of what `Input.dispatchMouseEvent` gives
@@ -1498,19 +1535,127 @@ async fn verify_fill_value(
     // HTML text controls normalize CRLF to LF. Compare that standardized form
     // while preserving every other byte, including leading spaces in YAML.
     if !fill_values_match(expected, actual, engine) {
-        let detail = if actual.is_empty() && !expected.is_empty() {
-            "read back an empty value".to_string()
-        } else {
-            format!(
-                "read back {} characters after writing {}",
-                actual.chars().count(),
-                expected.chars().count()
-            )
-        };
-        return Err(format!("fill verification failed for {engine}: {detail}"));
+        return Err(format!(
+            "fill verification failed for {engine}: {}",
+            fill_mismatch_detail(expected, actual)
+        ));
     }
 
     Ok(())
+}
+
+/// Describe a fill/type read-back mismatch so truncation is VISIBLE: what was
+/// written, what the field holds now, and — when every non-ASCII character
+/// vanished while the ASCII survived — that the page filtered the input (a
+/// Latin-only address field, issue #203) rather than the keystrokes failing.
+pub(crate) fn fill_mismatch_detail(expected: &str, actual: &str) -> String {
+    let mut detail = if actual.is_empty() && !expected.is_empty() {
+        format!("read back an empty value after writing {}", quote_short(expected))
+    } else {
+        format!(
+            "read back {} ({} chars) after writing {} ({} chars)",
+            quote_short(actual),
+            actual.chars().count(),
+            quote_short(expected),
+            expected.chars().count()
+        )
+    };
+    if non_ascii_was_dropped(expected, actual) {
+        detail.push_str(
+            ". Only the ASCII characters survived: the page rejected the non-Latin text (a \
+             Latin-only / masked field), so re-typing won't help — check the field's input \
+             rules or supply a romanized value",
+        );
+    }
+    detail
+}
+
+/// True when `expected` carried non-ASCII characters and none of them made it
+/// into `actual`, while `actual` is otherwise consistent with the ASCII part.
+pub(crate) fn non_ascii_was_dropped(expected: &str, actual: &str) -> bool {
+    let non_ascii: Vec<char> = expected.chars().filter(|c| !c.is_ascii()).collect();
+    if non_ascii.is_empty() {
+        return false;
+    }
+    !actual.chars().any(|c| non_ascii.contains(&c))
+}
+
+fn quote_short(s: &str) -> String {
+    const MAX: usize = 60;
+    if s.chars().count() <= MAX {
+        format!("{s:?}")
+    } else {
+        let head: String = s.chars().take(MAX).collect();
+        format!("{:?}…", head)
+    }
+}
+
+/// After `type`, read the field's current value and compare it with what was
+/// typed. Returns `(read_back, warning)`; `None` when the value can't be read
+/// (non-editable target, probe failure) so the caller stays silent. `type`
+/// appends, so the check is containment, not equality.
+pub async fn read_back_after_type(
+    client: &CdpClient,
+    session_id: &str,
+    ref_map: &RefMap,
+    selector_or_ref: &str,
+    typed: &str,
+    iframe_sessions: &HashMap<String, String>,
+) -> Option<(String, Option<String>)> {
+    if typed.trim().is_empty() {
+        return None;
+    }
+    let (object_id, effective_session_id) = resolve_element_object_id(
+        client,
+        session_id,
+        ref_map,
+        selector_or_ref,
+        iframe_sessions,
+    )
+    .await
+    .ok()?;
+    wait_for_paint_settled(client, &effective_session_id).await;
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: read_editable_value_function(),
+                object_id: Some(object_id),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(&effective_session_id),
+        )
+        .await
+        .ok()?;
+    if result.exception_details.is_some() {
+        return None;
+    }
+    let data = result.result.value?;
+    if !data.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        return None;
+    }
+    let actual = data.get("value").and_then(Value::as_str)?.to_string();
+    Some((actual.clone(), type_read_back_warning(typed, &actual)))
+}
+
+/// The warning `type` attaches when the field does not hold what was typed.
+/// Whitespace is normalized (textarea/contenteditable read-backs fold it), and
+/// a CRLF/LF difference never counts.
+pub(crate) fn type_read_back_warning(typed: &str, actual: &str) -> Option<String> {
+    let norm = |s: &str| s.replace("\r\n", "\n").split_whitespace().collect::<Vec<_>>().join(" ");
+    let t = norm(typed);
+    let a = norm(actual);
+    if t.is_empty() || a.contains(&t) {
+        return None;
+    }
+    Some(format!(
+        "the field does not contain what was typed: {}. The keystrokes were delivered; \
+         the page rewrote or rejected them (an input filter, mask or formatter). Verify with \
+         `get value` before moving on",
+        fill_mismatch_detail(typed, actual)
+    ))
 }
 
 fn fill_values_match(expected: &str, actual: &str, engine: &str) -> bool {
@@ -2316,6 +2461,154 @@ pub fn descriptor_is_unfocused(descriptor: &str) -> bool {
     matches!(descriptor, "body" | "html" | "none")
 }
 
+/// Would this key do anything app-visible ONLY if the page listens for it?
+///
+/// Arrow/Home/End/Page keys on a text field just move the caret, Escape has no
+/// default, and Enter outside a form/button/textarea submits nothing — so on a
+/// target with no key listener they provably no-op (issue #202). Keys with a
+/// real browser default (Tab moves focus, Backspace deletes, printable keys
+/// insert, Enter in a `<form>` submits) are left alone, as are command chords
+/// (Ctrl/Meta + key): select-all/copy work without any listener.
+pub fn key_effect_depends_on_listeners(
+    key_name: &str,
+    modifiers: Option<i32>,
+    target_descriptor: Option<&str>,
+) -> bool {
+    if modifiers.is_some_and(|m| m & (2 | 4) != 0) {
+        return false;
+    }
+    let Some(target) = target_descriptor else {
+        return false;
+    };
+    if descriptor_is_unfocused(target) {
+        // Nothing focused: `press_result` already warns for Enter; arrows scroll.
+        return false;
+    }
+    let tag = target.split(['#', '[', '.']).next().unwrap_or("");
+    let text_like = matches!(tag, "input" | "textarea") || target.contains("contenteditable");
+    match key_name.to_ascii_lowercase().as_str() {
+        "arrowup" | "arrowdown" | "arrowleft" | "arrowright" | "home" | "end" | "pageup"
+        | "pagedown" => text_like && tag != "select",
+        "escape" => true,
+        // Enter: a textarea inserts a newline, a button/link activates, and a
+        // field inside a <form> submits — only a bare input has no default. The
+        // form membership isn't in the descriptor, so the probe below also
+        // reports it and the caller stays quiet when a form would submit.
+        "enter" => tag == "input",
+        _ => false,
+    }
+}
+
+/// Count keydown/keyup/keypress listeners reachable from the focused element:
+/// on the element itself, every ancestor (React 17+ delegates at the root
+/// container, older React and jQuery at `document`), the document and the
+/// window. Uses `DOMDebugger.getEventListeners`, which sees `addEventListener`
+/// registrations AND `onkeydown` attributes/properties. Returns `None` when the
+/// probe can't run (no focused element, budget exhausted) or when the element
+/// is inside a `<form>` where Enter has a submit default — the caller then
+/// stays silent rather than guessing. Best-effort and capped: one
+/// `getEventListeners` per ancestor, at most ~40 calls, 1.5s overall.
+pub async fn count_key_listeners_on_active_element(
+    client: &CdpClient,
+    session_id: &str,
+) -> Option<usize> {
+    tokio::time::timeout(
+        std::time::Duration::from_millis(1500),
+        count_key_listeners_inner(client, session_id),
+    )
+    .await
+    .ok()
+    .flatten()
+}
+
+async fn count_key_listeners_inner(client: &CdpClient, session_id: &str) -> Option<usize> {
+    // Collect [active element, ...ancestors, document, window] as ONE remote
+    // array so the listener walk needs no per-node DOM traversal round-trips.
+    let chain: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &EvaluateParams {
+                expression: r#"(() => {
+                    let el = document.activeElement;
+                    while (el && el.shadowRoot && el.shadowRoot.activeElement) el = el.shadowRoot.activeElement;
+                    if (!el || el === document.body || el === document.documentElement) return null;
+                    if (el.form || (el.closest && el.closest('form'))) return null;
+                    const out = [];
+                    let n = el;
+                    while (n && out.length < 40) {
+                        out.push(n);
+                        n = n.parentNode || (n.host ? n.host : null);
+                        if (n && n.nodeType === 11) n = n.host;
+                    }
+                    if (!out.includes(document)) out.push(document);
+                    out.push(window);
+                    return out;
+                })()"#
+                    .to_string(),
+                return_by_value: Some(false),
+                await_promise: Some(false),
+            },
+            Some(session_id),
+        )
+        .await
+        .ok()?;
+    if chain.exception_details.is_some() {
+        return None;
+    }
+    let array_id = chain.result.object_id?;
+    let props: Value = client
+        .send_command(
+            "Runtime.getProperties",
+            Some(json!({ "objectId": array_id, "ownProperties": true })),
+            Some(session_id),
+        )
+        .await
+        .ok()?;
+    let mut node_ids: Vec<String> = Vec::new();
+    for p in props.get("result").and_then(Value::as_array)? {
+        let name = p.get("name").and_then(Value::as_str).unwrap_or("");
+        if name.parse::<usize>().is_err() {
+            continue;
+        }
+        if let Some(oid) = p
+            .get("value")
+            .and_then(|v| v.get("objectId"))
+            .and_then(Value::as_str)
+        {
+            node_ids.push(oid.to_string());
+        }
+    }
+    if node_ids.is_empty() {
+        return None;
+    }
+    let mut found = 0usize;
+    for oid in node_ids {
+        let listeners: Value = client
+            .send_command(
+                "DOMDebugger.getEventListeners",
+                Some(json!({ "objectId": oid })),
+                Some(session_id),
+            )
+            .await
+            .ok()?;
+        if let Some(list) = listeners.get("listeners").and_then(Value::as_array) {
+            found += list
+                .iter()
+                .filter(|l| {
+                    matches!(
+                        l.get("type").and_then(Value::as_str),
+                        Some("keydown") | Some("keyup") | Some("keypress")
+                    )
+                })
+                .count();
+        }
+        if found > 0 {
+            break;
+        }
+    }
+    Some(found)
+}
+
 pub async fn clear(
     client: &CdpClient,
     session_id: &str,
@@ -2841,6 +3134,47 @@ mod tests {
             "first line different line",
             "contenteditable"
         ));
+    }
+
+    #[test]
+    fn test_fill_mismatch_detail_shows_both_values_and_flags_dropped_cjk() {
+        // Issue #203: the old message said "read back an empty value" and nothing
+        // else, so a Latin-only field silently eating CJK looked like a transport bug.
+        let d = fill_mismatch_detail("狛江市", "");
+        assert!(d.contains("\"狛江市\""), "{d}");
+        assert!(d.contains("Only the ASCII characters survived"), "{d}");
+        let d = fill_mismatch_detail("西野川1-25-57", "1-25-57");
+        assert!(d.contains("\"1-25-57\"") && d.contains("\"西野川1-25-57\""), "{d}");
+        assert!(d.contains("Latin-only"), "{d}");
+        // Pure-ASCII mismatch: no CJK diagnosis.
+        let d = fill_mismatch_detail("hello", "hell");
+        assert!(!d.contains("ASCII"), "{d}");
+        assert!(d.contains("(4 chars)") && d.contains("(5 chars)"), "{d}");
+    }
+
+    #[test]
+    fn test_type_read_back_warning_only_when_text_is_missing() {
+        assert!(type_read_back_warning("狛江市", "東京都狛江市").is_none());
+        let w = type_read_back_warning("西野川1-25-57", "1-25-57").unwrap();
+        assert!(w.contains("rewrote or rejected"), "{w}");
+        assert!(w.contains("ASCII"), "{w}");
+        assert!(type_read_back_warning("", "x").is_none());
+    }
+
+    #[test]
+    fn test_key_effect_depends_on_listeners() {
+        // Arrows on a bare text input do nothing without a handler (#202).
+        assert!(key_effect_depends_on_listeners("ArrowDown", None, Some("input#q")));
+        assert!(key_effect_depends_on_listeners("Enter", None, Some("input[name=\"x\"]")));
+        assert!(key_effect_depends_on_listeners("Escape", None, Some("div#modal")));
+        // Native defaults / chords / unfocused targets are left alone.
+        assert!(!key_effect_depends_on_listeners("ArrowDown", None, Some("select#s")));
+        assert!(!key_effect_depends_on_listeners("Enter", None, Some("textarea#t")));
+        assert!(!key_effect_depends_on_listeners("Enter", None, Some("button#go")));
+        assert!(!key_effect_depends_on_listeners("Tab", None, Some("input#q")));
+        assert!(!key_effect_depends_on_listeners("a", Some(4), Some("input#q")));
+        assert!(!key_effect_depends_on_listeners("ArrowDown", None, Some("body")));
+        assert!(!key_effect_depends_on_listeners("ArrowDown", None, None));
     }
 
     #[test]

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -1550,7 +1550,10 @@ async fn verify_fill_value(
 /// Latin-only address field, issue #203) rather than the keystrokes failing.
 pub(crate) fn fill_mismatch_detail(expected: &str, actual: &str) -> String {
     let mut detail = if actual.is_empty() && !expected.is_empty() {
-        format!("read back an empty value after writing {}", quote_short(expected))
+        format!(
+            "read back an empty value after writing {}",
+            quote_short(expected)
+        )
     } else {
         format!(
             "read back {} ({} chars) after writing {} ({} chars)",
@@ -1644,7 +1647,12 @@ pub async fn read_back_after_type(
 /// Whitespace is normalized (textarea/contenteditable read-backs fold it), and
 /// a CRLF/LF difference never counts.
 pub(crate) fn type_read_back_warning(typed: &str, actual: &str) -> Option<String> {
-    let norm = |s: &str| s.replace("\r\n", "\n").split_whitespace().collect::<Vec<_>>().join(" ");
+    let norm = |s: &str| {
+        s.replace("\r\n", "\n")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
     let t = norm(typed);
     let a = norm(actual);
     if t.is_empty() || a.contains(&t) {
@@ -3144,7 +3152,10 @@ mod tests {
         assert!(d.contains("\"狛江市\""), "{d}");
         assert!(d.contains("Only the ASCII characters survived"), "{d}");
         let d = fill_mismatch_detail("西野川1-25-57", "1-25-57");
-        assert!(d.contains("\"1-25-57\"") && d.contains("\"西野川1-25-57\""), "{d}");
+        assert!(
+            d.contains("\"1-25-57\"") && d.contains("\"西野川1-25-57\""),
+            "{d}"
+        );
         assert!(d.contains("Latin-only"), "{d}");
         // Pure-ASCII mismatch: no CJK diagnosis.
         let d = fill_mismatch_detail("hello", "hell");
@@ -3164,16 +3175,52 @@ mod tests {
     #[test]
     fn test_key_effect_depends_on_listeners() {
         // Arrows on a bare text input do nothing without a handler (#202).
-        assert!(key_effect_depends_on_listeners("ArrowDown", None, Some("input#q")));
-        assert!(key_effect_depends_on_listeners("Enter", None, Some("input[name=\"x\"]")));
-        assert!(key_effect_depends_on_listeners("Escape", None, Some("div#modal")));
+        assert!(key_effect_depends_on_listeners(
+            "ArrowDown",
+            None,
+            Some("input#q")
+        ));
+        assert!(key_effect_depends_on_listeners(
+            "Enter",
+            None,
+            Some("input[name=\"x\"]")
+        ));
+        assert!(key_effect_depends_on_listeners(
+            "Escape",
+            None,
+            Some("div#modal")
+        ));
         // Native defaults / chords / unfocused targets are left alone.
-        assert!(!key_effect_depends_on_listeners("ArrowDown", None, Some("select#s")));
-        assert!(!key_effect_depends_on_listeners("Enter", None, Some("textarea#t")));
-        assert!(!key_effect_depends_on_listeners("Enter", None, Some("button#go")));
-        assert!(!key_effect_depends_on_listeners("Tab", None, Some("input#q")));
-        assert!(!key_effect_depends_on_listeners("a", Some(4), Some("input#q")));
-        assert!(!key_effect_depends_on_listeners("ArrowDown", None, Some("body")));
+        assert!(!key_effect_depends_on_listeners(
+            "ArrowDown",
+            None,
+            Some("select#s")
+        ));
+        assert!(!key_effect_depends_on_listeners(
+            "Enter",
+            None,
+            Some("textarea#t")
+        ));
+        assert!(!key_effect_depends_on_listeners(
+            "Enter",
+            None,
+            Some("button#go")
+        ));
+        assert!(!key_effect_depends_on_listeners(
+            "Tab",
+            None,
+            Some("input#q")
+        ));
+        assert!(!key_effect_depends_on_listeners(
+            "a",
+            Some(4),
+            Some("input#q")
+        ));
+        assert!(!key_effect_depends_on_listeners(
+            "ArrowDown",
+            None,
+            Some("body")
+        ));
         assert!(!key_effect_depends_on_listeners("ArrowDown", None, None));
     }
 

--- a/cli/src/native/mod.rs
+++ b/cli/src/native/mod.rs
@@ -14,6 +14,8 @@ pub mod cookies;
 pub mod daemon;
 #[allow(dead_code)]
 pub mod diff;
+
+pub mod dom_snapshot;
 #[allow(dead_code)]
 pub mod element;
 #[allow(dead_code)]

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -30,6 +30,12 @@ const INTERACTIVE_ROLES: &[&str] = &[
     "Iframe",
 ];
 
+/// Whether `role` is one `snapshot -i` lists as actionable (shared with the
+/// DOM-walk fallback so both paths label controls the same way).
+pub fn is_interactive_role(role: &str) -> bool {
+    INTERACTIVE_ROLES.contains(&role)
+}
+
 const CONTENT_ROLES: &[&str] = &[
     "heading",
     "cell",
@@ -394,6 +400,59 @@ impl RoleNameTracker {
 /// `frame_id` so clicks resolve into the right frame (issue #36). Capped to keep
 /// a pathological frame tree from blowing up the snapshot.
 const MAX_IFRAME_DEPTH: usize = 3;
+
+/// DOM-walk fallback snapshot (issue #206). Reads the whole document with
+/// `pierce: true` — open AND closed shadow roots, same-process child documents
+/// — and lists the actionable elements with refs keyed by `backendNodeId`, so
+/// `click @ref` / `type @ref` / `fill @ref` work as with AX-minted refs.
+/// Returns the rendered listing and the number of elements found. Used when
+/// the AX tree came back empty on a page that clearly has content, or on
+/// demand via `snapshot --dom`.
+pub async fn take_dom_snapshot(
+    client: &CdpClient,
+    session_id: &str,
+    ref_map: &mut RefMap,
+    frame_id: Option<&str>,
+) -> Result<(String, usize), String> {
+    client
+        .send_command_no_params("DOM.enable", Some(session_id))
+        .await?;
+    let doc: Value = client
+        .send_command(
+            "DOM.getDocument",
+            Some(serde_json::json!({ "depth": -1, "pierce": true })),
+            Some(session_id),
+        )
+        .await?;
+    let root = doc
+        .get("root")
+        .ok_or_else(|| "DOM.getDocument returned no root".to_string())?;
+    let elems = super::dom_snapshot::collect_interactive(root);
+    let mut tracker = RoleNameTracker::new();
+    let mut refs: Vec<String> = Vec::with_capacity(elems.len());
+    let mut nths: Vec<usize> = Vec::with_capacity(elems.len());
+    for (idx, el) in elems.iter().enumerate() {
+        nths.push(tracker.track(&el.role, &el.name, idx));
+    }
+    let duplicates = tracker.get_duplicates();
+    for (el, nth) in elems.iter().zip(nths) {
+        let key = format!("{}:{}", el.role, el.name);
+        let actual_nth = duplicates.contains_key(&key).then_some(nth);
+        let ref_id = ref_map.snapshot_ref(Some(el.backend_node_id), frame_id, &el.role, &el.name);
+        ref_map.add_with_frame(
+            ref_id.clone(),
+            Some(el.backend_node_id),
+            &el.role,
+            &el.name,
+            actual_nth,
+            frame_id,
+        );
+        ref_map.mark_dom_sourced(&ref_id);
+        refs.push(ref_id);
+    }
+    let count = elems.len();
+    Ok((super::dom_snapshot::render(&elems, &refs), count))
+}
 
 pub async fn take_snapshot(
     client: &CdpClient,

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1519,8 +1519,18 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
 
-        // Default success
-        println!("{} Done", color::success_indicator());
+        // Default success. A soft warning carried in the data (e.g. `type`
+        // read back a value that does not contain what was typed, #203) must
+        // not hide behind a bare ✓ — surface it on stderr.
+        let data_warning = data.get("warning").and_then(|v| v.as_str());
+        if data_warning.is_some() {
+            println!("{} Done", color::warning_indicator());
+        } else {
+            println!("{} Done", color::success_indicator());
+        }
+        if let Some(w) = data_warning {
+            eprintln!("{} {}", color::warning_indicator(), w);
+        }
     } else {
         // Success response with no data payload — still confirm the command ran
         // instead of printing nothing (a silent exit 0 looks like a no-op and

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1652,6 +1652,18 @@ Usage: chrome-use click <selector> [--new-tab]
 Clicks on the specified element. The selector can be a CSS selector,
 XPath, or an element reference from snapshot (e.g., @e1).
 
+A selector starting with `//`, `/`, `(`, `./` or `..` is treated as XPath
+automatically (no `xpath=` prefix). Note that `text()` only tests the FIRST
+direct text node, so a label split across nodes (React `{a} - {b}`) or nested
+in a child never matches; use `contains(normalize-space(.), '...')`,
+`find "<label>"`, `text=<label>`, or `snapshot -i` + @ref instead. An
+"Element not found" error keeps the selector and the resolver's diagnosis.
+
+Over the extension relay a left click is dispatched through the DOM. The
+clicked element (or its nearest focusable ancestor / a label's control)
+receives keyboard focus like a real click, so `click <input>` followed by
+`press Meta+a` lands on that input.
+
 A bare-number argument is treated as a viewport coordinate, not a
 selector — `click 449 320` clicks the pixel point (no element needed).
 
@@ -1706,7 +1718,11 @@ The written value is read back from the control or editor model and compared
 exactly before success is reported. If Monaco hides its model API, fill uses
 one trusted editor paste, reads the selected model back through the editor's
 copy handler, and restores the browser clipboard. If that cannot be verified,
-fill fails loudly instead of reporting a false success.
+fill fails loudly instead of reporting a false success. Verification
+errors quote both values (`read back "" after writing "狛江市"`); when every
+non-ASCII character vanished while ASCII survived, the error says the page
+filtered non-Latin input (a Latin-only / masked field), so re-typing the
+same text will not help.
 For framework inputs (React/Vue/Angular) the value goes through the native
 setter so the form registers it (no more "pristine" Save no-ops).
 
@@ -1734,6 +1750,11 @@ Usage: chrome-use type <selector> <text>
 
 Types text into the specified element character by character.
 Unlike fill, this does not clear existing content first.
+
+After typing, the field is read back. If it does not contain the typed
+text (the page rewrote or filtered the input), a ⚠ warning quotes what was
+typed and what the field now holds; the exit code stays 0 and the JSON
+gains `readBack`.
 
 Options:
   --key-events         Send real per-character keyDown/keyUp instead of
@@ -1969,7 +1990,18 @@ Presses a key or key combination. Supports special keys and modifiers.
 
 The key goes to whatever the page currently has focused, so the output names
 that element ("Pressed Enter → textarea[name=q]"). Use --selector to focus a
-target first when you can't be sure focus is where you left it.
+target first when you can't be sure focus is where you left it. A preceding
+`click <input>` moves focus to that input, also over the extension relay
+where clicks are DOM-dispatched, so click-then-press works.
+
+For keys whose only effect depends on page JavaScript (Arrow/Home/End/
+PageUp/PageDown on a text field, Escape, Enter on a bare input outside a
+form) press probes for keydown/keyup/keypress listeners on the focused
+element, its ancestors, document and window. With none found it still
+exits 0 but prints a ⚠ warning that the page cannot react to the key
+(click the option instead); the JSON gains `keyListeners: <count>`. Chords
+(Control/Meta+key), Tab, Backspace, printable keys and native defaults are
+not probed.
 
 Aliases: key
 
@@ -2397,6 +2429,13 @@ Options:
                        ancestor context; refs preserved. For desktop-shell apps
                        (Synology DSM, NAS/router panels) where one snapshot holds
                        many windows. e.g. -f "SSH|端口|应用|确定"
+  --dom                List actionable elements from a DOM walk (open AND closed
+                       shadow roots, same-process child documents) instead of
+                       the accessibility tree. Used automatically when the AX
+                       tree yields no refs at all (web-component SPAs whose
+                       whole page lives in shadow roots); the JSON then carries
+                       `source: "dom"` plus a `note`, and roles/names are
+                       derived from tags and attributes. Refs work as usual.
 
 Global Options:
   --json               Output as JSON
@@ -2408,6 +2447,7 @@ Examples:
   chrome-use snapshot -i --urls
   chrome-use snapshot --compact --depth 5
   chrome-use snapshot -s "#main-content"
+  chrome-use snapshot -i --dom             # force the shadow-root DOM walk
 "##
         }
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -123,7 +123,8 @@
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span>         <span class="du-cmt"># 仅可交互元素（推荐）</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-c</span>         <span class="du-cmt"># 精简输出</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-d</span> 3       <span class="du-cmt"># 限制深度为 3</span>
-<span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-s</span> <span class="du-str">"#main"</span> <span class="du-cmt"># 限定到 CSS 选择器范围</span></code></pre>
+<span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-s</span> <span class="du-str">"#main"</span> <span class="du-cmt"># 限定到 CSS 选择器范围</span>
+<span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">--dom</span>   <span class="du-cmt"># 从 DOM 遍历列出可操作元素（穿透 shadow root；AX 树无 ref 时自动启用）</span></code></pre>
       </div>
       <div class="du-callout tip">
         <div class="du-callout-title">✅ 小贴士</div>
@@ -145,7 +146,7 @@
 <span class="du-prompt">$</span> chrome-use focus @e1           <span class="du-cmt"># 聚焦元素</span>
 <span class="du-prompt">$</span> chrome-use fill @e2 <span class="du-str">"text"</span>     <span class="du-cmt"># 清空后输入</span>
 <span class="du-prompt">$</span> chrome-use type @e2 <span class="du-str">"text"</span>     <span class="du-cmt"># 直接输入（不清空）</span>
-<span class="du-prompt">$</span> chrome-use press Enter         <span class="du-cmt"># 在当前焦点按键（别名：key），输出报告落点</span>
+<span class="du-prompt">$</span> chrome-use press Enter         <span class="du-cmt"># 在当前焦点按键（别名：key），输出报告落点；页面没有监听器时 ⚠ 警告</span>
 <span class="du-prompt">$</span> chrome-use press Enter --selector @e2  <span class="du-cmt"># 先聚焦目标再按（别名：--on）</span>
 <span class="du-prompt">$</span> chrome-use press Control+a     <span class="du-cmt"># 组合键</span>
 <span class="du-prompt">$</span> chrome-use keydown Shift       <span class="du-cmt"># 按住键</span>
@@ -163,11 +164,13 @@
 <span class="du-prompt">$</span> chrome-use download-url https://example.com/file.pdf ./file.pdf
 <span class="du-prompt">$</span> chrome-use downloads <span class="du-flag">--limit</span> 10 <span class="du-flag">--json</span> <span class="du-cmt"># 机器可读的 Chrome 下载记录</span></code></pre>
       </div>
-      <p><code>fill</code> 会在返回成功前回读控件或富编辑器 model，并精确比较结果。若 Monaco 隐藏了 model API，则通过一次可信的编辑器 paste 写入，再通过编辑器 copy 处理器精确回读，并在结束后恢复浏览器剪贴板。paste 无法校验或回读不一致时会报错，不会静默成功。</p>
+      <p><code>fill</code> 会在返回成功前回读控件或富编辑器 model，并精确比较结果。若 Monaco 隐藏了 model API，则通过一次可信的编辑器 paste 写入，再通过编辑器 copy 处理器精确回读，并在结束后恢复浏览器剪贴板。paste 无法校验或回读不一致时会报错，不会静默成功。报错会同时引用两边的值（如 <code>read back "" after writing "狛江市"</code>）；若非 ASCII 字符全部消失而 ASCII 仍在，会明确指出页面过滤了非拉丁输入（仅限拉丁 / 带掩码的字段），重打一遍没有用。<code>type</code> 也会回读：字段里没有刚输入的文本时打印 ⚠ 警告（退出码仍为 0，JSON 多出 <code>readBack</code>）。</p>
+      <p><code>press</code> 对只靠页面 JavaScript 才有效果的键（文本框上的 Arrow/Home/End/PageUp/PageDown、Escape、表单外裸输入框上的 Enter）会探测从焦点元素到 window 有没有 keydown/keyup/keypress 监听器；一个都没有时仍退出 0，但打印 ⚠ 警告说明页面无法响应该键，建议直接 <code>click</code> 目标选项（JSON 多出 <code>keyListeners</code>）。组合键、Tab、Backspace、可打印字符不探测。</p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ 点击"成功但没反应"</div>
         自动补全 / 菜单 <code>&lt;li&gt;</code> 项常在输入框失焦时关闭。若 <code>click</code> 报成功但页面没反应，
-        用 <code>AGENT_BROWSER_CLICK_MODE=dom</code> 重试该次点击 —— DOM 派发不会像真实指针那样移动焦点，选项仍会被选中。
+        用 <code>AGENT_BROWSER_CLICK_MODE=dom</code> 重试该次点击 —— 普通 <code>&lt;li&gt;</code> 没有可聚焦目标，输入框保持焦点，选项仍会被选中。
+        注意 DOM 派发的点击（扩展中继下左键点击的默认方式）现在会像真实点击一样移动焦点：被点元素、最近的可聚焦祖先或 label 对应的控件会获得焦点（除非点击处理器已经自己移动了焦点），所以 <code>click &lt;input&gt;</code> 再 <code>press Meta+a</code> 落在这个输入框上，而不是上一个焦点。
       </div>
 
       <!-- ============================================================ -->

--- a/docs/debugger-banner-silence.html
+++ b/docs/debugger-banner-silence.html
@@ -101,7 +101,11 @@
   <h2>现在怎么做</h2>
   <aside class="now">
     <p><strong>大多数人根本不用管这条提示条。</strong> 扩展 0.5.5 起，agent 只 attach 自己新建的标签页，
-    你正在看的标签页不会被 attach，也就不会弹这条横幅（链路原理见 <a href="/how-it-works.html">它怎么工作</a>）。</p>
+    你正在看的标签页不会被 attach，也就不会弹这条横幅（链路原理见 <a href="/how-it-works.html">它怎么工作</a>）。
+    扩展 0.5.19 起，连 agent 自己标签页上的横幅也会自行消失：某个标签 30 秒没有 agent 活动就释放调试器，
+    标签仍被中继记着，下一条命令透明地重新 attach 并重放已启用的 domain。时长在扩展选项页
+    「Release idle tabs after」里可调（0 = 从不释放）；点 Cancel 现在会被尊重，agent 下一条命令之前不再自动重连。
+    代价是被动采集（network / console 日志）在释放期间会漏事件。</p>
   </aside>
   <p>万一你确实撞见它（某个 agent 标签页被 attach、横幅碍事），跑一次下面这条，在提示处按回车即可：</p>
   <pre><code>chrome-use extension connect

--- a/docs/en/commands.html
+++ b/docs/en/commands.html
@@ -129,6 +129,7 @@
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span>         <span class="du-cmt"># interactive elements only (recommended)</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-c</span>         <span class="du-cmt"># compact output</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-d</span> 3       <span class="du-cmt"># limit depth to 3</span>
+<span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">--dom</span>   <span class="du-cmt"># actionable elements from a DOM walk (pierces shadow roots; automatic when the AX tree has no refs)</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-s</span> <span class="du-str">"#main"</span> <span class="du-cmt"># scope to a CSS selector</span></code></pre>
       </div>
       <div class="du-callout tip">
@@ -152,7 +153,7 @@
 <span class="du-prompt">$</span> chrome-use focus @e1           <span class="du-cmt"># focus the element</span>
 <span class="du-prompt">$</span> chrome-use fill @e2 <span class="du-str">"text"</span>     <span class="du-cmt"># clear then type</span>
 <span class="du-prompt">$</span> chrome-use type @e2 <span class="du-str">"text"</span>     <span class="du-cmt"># type directly (no clear)</span>
-<span class="du-prompt">$</span> chrome-use press Enter         <span class="du-cmt"># press a key (alias: key)</span>
+<span class="du-prompt">$</span> chrome-use press Enter         <span class="du-cmt"># press a key (alias: key); ⚠ warns when the page has no listener for it</span>
 <span class="du-prompt">$</span> chrome-use press Control+a     <span class="du-cmt"># key combo</span>
 <span class="du-prompt">$</span> chrome-use keydown Shift       <span class="du-cmt"># hold a key down</span>
 <span class="du-prompt">$</span> chrome-use keyup Shift         <span class="du-cmt"># release a key</span>
@@ -169,12 +170,16 @@
 <span class="du-prompt">$</span> chrome-use download-url https://example.com/file.pdf ./file.pdf
 <span class="du-prompt">$</span> chrome-use downloads <span class="du-flag">--limit</span> 10 <span class="du-flag">--json</span> <span class="du-cmt"># machine-readable Chrome downloads</span></code></pre>
       </div>
-      <p><code>fill</code> reads the resulting control or rich-editor model value back and compares it exactly before reporting success. If Monaco hides its model API, one trusted editor paste is verified through the editor's copy handler and the browser clipboard is restored afterward. An unverifiable paste or mismatched readback is an error, not a silent success.</p>
+      <p><code>fill</code> reads the resulting control or rich-editor model value back and compares it exactly before reporting success. If Monaco hides its model API, one trusted editor paste is verified through the editor's copy handler and the browser clipboard is restored afterward. An unverifiable paste or mismatched readback is an error, not a silent success. The error quotes both values (e.g. <code>read back "" after writing "狛江市"</code>); when every non-ASCII character vanished while ASCII survived it says the page filtered non-Latin input (a Latin-only / masked field), so re-typing will not help. <code>type</code> reads the field back too: if it does not contain the typed text, a ⚠ warning is printed (exit 0, JSON gains <code>readBack</code>).</p>
+      <p><code>press</code> probes, for keys whose only effect depends on page JavaScript (Arrow/Home/End/PageUp/PageDown on a text field, Escape, Enter on a bare input outside a form), whether any keydown/keyup/keypress listener exists from the focused element up to window. With none found it still exits 0 but prints a ⚠ warning that the page cannot react to the key and suggests <code>click</code>ing the option instead (JSON gains <code>keyListeners</code>). Chords, Tab, Backspace and printable keys are not probed.</p>
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ Click "succeeds but nothing happens"</div>
         Autocomplete / menu <code>&lt;li&gt;</code> items often close when the input loses focus. If <code>click</code>
         reports success but the page doesn't react, retry that click with <code>AGENT_BROWSER_CLICK_MODE=dom</code> —
-        DOM dispatch doesn't move focus the way a real pointer does, so the option still gets selected.
+        a plain <code>&lt;li&gt;</code> has no focusable target, so the input keeps focus and the option still gets selected.
+        Note that a DOM-dispatched click (the relay's default for left clicks) now moves focus like a real click: the clicked
+        element, its nearest focusable ancestor, or a label's control receives focus unless the handler already moved it,
+        so <code>click &lt;input&gt;</code> then <code>press Meta+a</code> lands on that input rather than the previously focused field.
       </div>
 
       <!-- ============================================================ -->

--- a/docs/en/finding.html
+++ b/docs/en/finding.html
@@ -117,7 +117,18 @@
         </div>
 <pre><code><span class="du-prompt">$</span> chrome-use click <span class="du-str">"#submit"</span>
 <span class="du-prompt">$</span> chrome-use fill <span class="du-str">"input[name=email]"</span> <span class="du-str">"user@test.com"</span>
-<span class="du-prompt">$</span> chrome-use click <span class="du-str">"button.primary"</span></code></pre>
+<span class="du-prompt">$</span> chrome-use click <span class="du-str">"button.primary"</span>
+<span class="du-prompt">$</span> chrome-use click <span class="du-str">"//button[@type='submit']"</span>   <span class="du-cmt"># starts with //, /, (, ./ or .. = XPath, no xpath= prefix needed</span></code></pre>
+      </div>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ XPath text() only tests the first direct text node</div>
+        <code>//button[text()='Save']</code> never matches when the text is split across nodes (React's
+        <code>{a} - {b}</code>) or nested in a child element. Use <code>contains(normalize-space(.), '…')</code>, or
+        <code>find "&lt;label&gt;"</code> / <code>text=&lt;label&gt;</code> / <code>snapshot -i</code> + <code>@ref</code>.
+        When an XPath containing <code>text()</code> matches nothing, the error explains this gotcha, and
+        "Element not found" now keeps the selector and the resolver's specific diagnosis instead of always blaming a
+        closed shadow root / cross-origin iframe.
       </div>
 
       <hr class="du-divider" />

--- a/docs/en/how-it-works.html
+++ b/docs/en/how-it-works.html
@@ -138,7 +138,7 @@
         Its permission footprint is 7 items, with no <code>&lt;all_urls&gt;</code>. Two properties that matter for fingerprinting:
       </p>
       <ol>
-        <li>it <strong>attaches only to the agent's own tabs</strong>. The page you're looking at is never attached, so you never see the "chrome-use has started debugging this browser" banner (since extension 0.5.5, it attaches only agent-owned tabs).</li>
+        <li>it <strong>attaches only to the agent's own tabs</strong>. The page you're looking at is never attached, so you never see the "chrome-use has started debugging this browser" banner (since extension 0.5.5, it attaches only agent-owned tabs; since 0.5.19 an agent tab idle for 30 seconds releases its debugger, so the banner clears itself and the next command re-attaches transparently).</li>
         <li>this path <strong>injects no JS patches</strong>. The page sees your real Chrome, real cookies, real fingerprint, so CreepJS reads 0% bot. The anti-detection isn't disguise; there's simply nothing to disguise (see <a href="/en/stealth.html">Stealth &amp; Anti-detection</a>).</li>
       </ol>
       <p>In other words, the extension is the only process in the chain that touches the page, and it touches it with the same protocol as DevTools.</p>

--- a/docs/en/interacting.html
+++ b/docs/en/interacting.html
@@ -82,6 +82,15 @@
         or just use <code>eval</code> to select that item in the page.
       </div>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ DOM-dispatched clicks move focus too</div>
+        Over the extension relay a left click is dispatched through the DOM. It now hands focus to the clicked
+        element (or its nearest focusable ancestor / a label's control) like a real click, unless the click handler
+        already moved focus. So <code>click &lt;input&gt;</code> followed by <code>press Meta+a</code> lands on that
+        input, not on the previously focused field. A plain <code>&lt;li&gt;</code> has no focusable target, so the
+        autocomplete trick above still holds.
+      </div>
+
       <hr class="du-divider" />
 
       <!-- ============ Typing text ============ -->
@@ -127,6 +136,16 @@
         that actually gets typed.
       </div>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ Page rewrote the input? type warns, fill errors</div>
+        After <code>type</code> the field is read back: if it does not contain the typed text, a ⚠ warning quotes
+        what was written and what the field now holds (exit 0, JSON gains <code>readBack</code>). A <code>fill</code>
+        verification failure quotes both values too, e.g. <code>read back "" after writing "狛江市"</code>; when every
+        non-ASCII character vanished while ASCII survived, it says the page filtered non-Latin input (a Latin-only /
+        masked field), so re-typing will not help. Both deliver CJK fine on normal fields; these messages are about
+        pages that rewrite input.
+      </div>
+
       <hr class="du-divider" />
 
       <!-- ============ Keyboard ============ -->
@@ -146,6 +165,16 @@
 <span class="du-prompt">$</span> chrome-use keydown d                   <span class="du-cmt"># hold a key down (no auto release)</span>
 <span class="du-prompt">$</span> chrome-use keyup d                     <span class="du-cmt"># release—use as a pair to "hold to move"</span>
                                        <span class="du-cmt"># in a game: keydown d; sleep; keyup d</span></code></pre>
+      </div>
+
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ A warning when the key provably did nothing</div>
+        For keys whose only effect depends on page JavaScript (Arrow/Home/End/PageUp/PageDown on a text field,
+        Escape, Enter on a bare input outside a form), <code>press</code> probes for keydown/keyup/keypress listeners
+        on the focused element, its ancestors, document and window. With none found it still exits 0 but prints a
+        ⚠ warning that the page cannot react to the key and suggests <code>click</code>ing the option instead; the
+        JSON gains <code>keyListeners: &lt;count&gt;</code>. Chords (Ctrl/Meta+key), Tab, Backspace, printable keys and
+        native defaults are not probed.
       </div>
 
       <div class="du-callout note">

--- a/docs/en/reading.html
+++ b/docs/en/reading.html
@@ -71,6 +71,7 @@
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">-u</span>              <span class="du-cmt"># include href url on links</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">-c</span>              <span class="du-cmt"># compact: drop empty structural nodes</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">-d</span> 3            <span class="du-cmt"># depth limit of 3 levels</span>
+<span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">--dom</span>            <span class="du-cmt"># list actionable elements from a DOM walk (pierces shadow roots)</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">--json</span>             <span class="du-cmt"># machine-readable output</span></code></pre>
       </div>
 
@@ -286,6 +287,17 @@ URL: https://example.com/login
         Only a <strong>semantically empty</strong> clickable <code>&lt;div&gt;</code> inside a closed root
         can dodge both the AX tree and the cursor-element scan.
       </div>
+
+      <h3>Whole page inside shadow roots: automatic DOM-walk fallback</h3>
+      <p>
+        Some web-component SPAs (developer.apple.com/contact, for example) render the entire page inside shadow
+        roots and the accessibility tree comes back with no refs at all. <code>snapshot</code> / <code>snapshot -i</code>
+        then no longer print "(no interactive elements)": they automatically list actionable elements from a
+        <code>DOM.getDocument(pierce:true)</code> walk (open and closed shadow roots, same-process child documents).
+        Those <code>[ref=eN]</code> work with <code>click</code> / <code>type</code> / <code>fill</code> like normal refs;
+        the JSON carries <code>source: "dom"</code> plus a <code>note</code> line, and roles / names are derived from
+        tags and attributes. <code>snapshot --dom</code> forces that path.
+      </p>
 
       <hr class="du-divider" />
 

--- a/docs/en/real-chrome.html
+++ b/docs/en/real-chrome.html
@@ -310,7 +310,9 @@
         The extension attaches Chrome's debugger <strong>only to agent-owned tabs</strong> (ones it created, or ones you
         <code>adopt</code>), never to the user's own tabs—so Chrome's "chrome-use started debugging this browser" banner
         never covers a page the user is using (it only shows on attached tabs, and the agent's are all background tabs).
-        No Chrome restart, fully seamless.
+        No Chrome restart, fully seamless. Since extension 0.5.19 an agent tab idle for 30 seconds releases its debugger
+        automatically and the banner disappears; the next command re-attaches transparently (the delay is configurable on
+        the extension options page, 0 = never).
       </div>
 
       <h2>Read a tab the user already has open: adopt</h2>

--- a/docs/en/sessions.html
+++ b/docs/en/sessions.html
@@ -174,6 +174,18 @@
         need it, and use <code>session list</code> to see which sessions are still active:
       </p>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ A cd does not lose the session</div>
+        The derived name is <code>cu-&lt;repo&gt;-&lt;tag&gt;</code>: <code>&lt;tag&gt;</code> comes from the agent /
+        terminal id and <code>&lt;repo&gt;</code> is only the cwd basename. Running a command from another directory
+        used to mint a different name and hit a fresh daemon with no refs ("Unknown ref"). Now, when a live daemon
+        already carries the same agent tag under another prefix, that session is reused, so an agent keeps its tabs and
+        refs across <code>cd</code>. Explicit <code>--session &lt;name&gt;</code> / <code>AGENT_BROWSER_SESSION</code>
+        still win. The "Unknown ref" error now names the session that answered and says whether it has any refs at all
+        (none: "no snapshot has run in this session; if you snapshotted from another directory or terminal, use
+        <code>session list</code> and pin with <code>--session</code>"), or lists the ref range it does have.
+      </div>
+
       <div class="du-code">
         <div class="du-code-head">
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>

--- a/docs/en/troubleshooting.html
+++ b/docs/en/troubleshooting.html
@@ -104,6 +104,13 @@
         within one document, so inserting or removing a modal does not renumber later controls. Re-snapshot to confirm
         the current node and ref.
       </p>
+      <p>
+        "Unknown ref" is a different case: the error names the session that answered and says whether it holds any refs.
+        "no snapshot has run in this session" means the command reached another session (you snapshotted from a different
+        directory or terminal); run <code>session list</code> and pin with <code>--session</code>. The same agent tag now
+        reuses its daemon across <code>cd</code>, see <a href="/en/sessions.html">Sessions &amp; concurrency</a>. If the
+        error lists the ref range the session does have, the page changed; just re-snapshot.
+      </p>
 
       <div class="du-code">
         <div class="du-code-head">
@@ -233,7 +240,12 @@
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ Note</div>
         After upgrading, the bar still appears briefly while an agent is actively driving its own tabs (inherent to
-        the <code>chrome.debugger</code> API) and disappears once the session detaches. To silence even that window,
+        the <code>chrome.debugger</code> API). Since extension 0.5.19 it goes away by itself: after 30 seconds without
+        agent activity on a tab the extension releases the debugger from it and the bar disappears; the tab stays known
+        to the relay and the next command re-attaches transparently, replaying the enabled CDP domains. The delay is
+        configurable on the extension options page ("Release idle tabs after", 0 = never). Clicking Cancel on the bar
+        is now honoured: no automatic re-attach until the agent's next command. Trade-off: passive captures
+        (network / console logging) miss events during a released interval. To silence even that window,
         run <code>chrome-use extension connect --silent</code> once—after a confirmation it restarts Chrome with
         <code>--silent-debugger-extension-api</code>; tabs and logins are restored by Chrome itself, and the bar is
         gone for good. Background and trade-offs in <a href="/debugger-banner-silence.html">the deep-dive (Chinese)</a>.

--- a/docs/finding.html
+++ b/docs/finding.html
@@ -116,7 +116,16 @@
         </div>
 <pre><code><span class="du-prompt">$</span> chrome-use click <span class="du-str">"#submit"</span>
 <span class="du-prompt">$</span> chrome-use fill <span class="du-str">"input[name=email]"</span> <span class="du-str">"user@test.com"</span>
-<span class="du-prompt">$</span> chrome-use click <span class="du-str">"button.primary"</span></code></pre>
+<span class="du-prompt">$</span> chrome-use click <span class="du-str">"button.primary"</span>
+<span class="du-prompt">$</span> chrome-use click <span class="du-str">"//button[@type='submit']"</span>   <span class="du-cmt"># 以 //、/、(、./ 或 .. 开头即视为 XPath，无需 xpath= 前缀</span></code></pre>
+      </div>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ XPath 的 text() 只看第一个直接文本节点</div>
+        <code>//button[text()='Save']</code> 在文本被拆成多个节点（React 的 <code>{a} - {b}</code>）或嵌在子元素里时永远匹配不到。
+        改用 <code>contains(normalize-space(.), '…')</code>，或者 <code>find "&lt;label&gt;"</code> / <code>text=&lt;label&gt;</code> /
+        <code>snapshot -i</code> + <code>@ref</code>。带 <code>text()</code> 的 XPath 匹配为空时，报错会直接解释这个坑；
+        「Element not found」也会保留原选择器和解析器的具体诊断，不再一律归咎于 closed shadow root / 跨源 iframe。
       </div>
 
       <hr class="du-divider" />

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -149,7 +149,7 @@
         权限足迹是 7 项，没有 <code>&lt;all_urls&gt;</code>。两条对指纹重要的性质：
       </p>
       <ol>
-        <li>它<strong>只附加 agent 自己的标签</strong>。你正在看的页面不会被 attach，也就不会出现「chrome-use 已开始调试此浏览器」的横幅（扩展 0.5.5 起，只 attach agent 拥有的标签）。</li>
+        <li>它<strong>只附加 agent 自己的标签</strong>。你正在看的页面不会被 attach，也就不会出现「chrome-use 已开始调试此浏览器」的横幅（扩展 0.5.5 起，只 attach agent 拥有的标签；0.5.19 起，agent 标签页闲置 30 秒会自动释放调试器，横幅自行消失，下一条命令再透明重连）。</li>
         <li>这条路径<strong>不注入任何 JS 补丁</strong>。页面看到的就是你真实的 Chrome、真实的 cookie、真实的指纹，所以 CreepJS 测出来是 0% bot。反检测靠的不是伪装，是根本没有东西需要伪装（见 <a href="/stealth.html">反检测与隐身</a>）。</li>
       </ol>
       <p>换句话说，扩展是整条链路里唯一碰得到页面的进程，而它碰页面的方式和 DevTools 是同一套协议。</p>

--- a/docs/interacting.html
+++ b/docs/interacting.html
@@ -82,6 +82,14 @@
         或直接用 <code>eval</code> 在页面里选中那一项。
       </div>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ DOM 派发的点击也会移动焦点</div>
+        扩展中继下左键点击是通过 DOM 派发的。它现在会像真实点击一样把焦点交给被点元素
+        （或最近的可聚焦祖先 / label 对应的控件），除非点击处理器已经自己移动了焦点。
+        所以 <code>click &lt;input&gt;</code> 之后 <code>press Meta+a</code> 落在这个输入框上，
+        不再落到上一个焦点字段。普通 <code>&lt;li&gt;</code> 没有可聚焦目标，上面的 autocomplete 技巧依然成立。
+      </div>
+
       <hr class="du-divider" />
 
       <!-- ============ 输入文本 ============ -->
@@ -125,6 +133,15 @@
         两者都是各自独立的 flag，不会污染实际打进去的文本。
       </div>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ 页面改写了输入？type 会警告，fill 会报错</div>
+        <code>type</code> 打完会回读字段：如果里面没有刚输入的文本，会打印 ⚠ 警告，引用写入的内容和字段当前的值
+        （退出码仍为 0，JSON 多出 <code>readBack</code>）。<code>fill</code> 校验失败时的报错同样引用两边的值，
+        例如 <code>read back "" after writing "狛江市"</code>；若非 ASCII 字符全部消失而 ASCII 仍在，
+        会指出页面过滤了非拉丁输入（仅限拉丁 / 带掩码的字段），重打一遍没有用。正常字段上两者都能正确输入中日韩文，
+        这些提示针对的是会改写输入的页面。
+      </div>
+
       <hr class="du-divider" />
 
       <!-- ============ 键盘 ============ -->
@@ -147,6 +164,14 @@
 <span class="du-prompt">$</span> chrome-use keydown d                   <span class="du-cmt"># 按住某键不放（不自动抬起）</span>
 <span class="du-prompt">$</span> chrome-use keyup d                     <span class="du-cmt"># 抬起——成对用来「按住移动」</span>
                                        <span class="du-cmt"># 游戏里：keydown d; sleep; keyup d</span></code></pre>
+      </div>
+
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ 按键「确实什么都没做」时会有警告</div>
+        对只靠页面 JavaScript 才有效果的键（文本框上的 Arrow/Home/End/PageUp/PageDown、Escape、表单外裸输入框上的 Enter），
+        <code>press</code> 会探测从焦点元素、祖先到 document / window 有没有 keydown/keyup/keypress 监听器。
+        一个都没有时仍退出 0，但会打印 ⚠ 警告说明页面无法响应该键，建议直接 <code>click</code> 目标选项；
+        JSON 多出 <code>keyListeners: &lt;count&gt;</code>。组合键（Ctrl/Meta+键）、Tab、Backspace、可打印字符和原生默认行为不探测。
       </div>
 
       <div class="du-callout note">

--- a/docs/reading.html
+++ b/docs/reading.html
@@ -71,6 +71,7 @@
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">-u</span>              <span class="du-cmt"># 链接上带出 href url</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">-c</span>              <span class="du-cmt"># 紧凑：去掉空的结构节点</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">-d</span> 3            <span class="du-cmt"># 深度上限 3 层</span>
+<span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">-i</span> <span class="du-flag">--dom</span>            <span class="du-cmt"># 从 DOM 遍历列出可操作元素（穿透 shadow root）</span>
 <span class="du-prompt">$</span> chrome-use snapshot <span class="du-flag">--json</span>             <span class="du-cmt"># 机器可读输出</span></code></pre>
       </div>
 
@@ -285,6 +286,16 @@ URL: https://example.com/login
         只有 closed root 里那种<strong>无语义</strong>的可点击 <code>&lt;div&gt;</code>
         才可能同时躲过 AX 树和光标元素扫描。
       </div>
+
+      <h3>整页都在 shadow root 里：自动退回 DOM 遍历</h3>
+      <p>
+        有些 Web Components 单页应用（如 developer.apple.com/contact）整个页面都渲染在 shadow root 里，
+        可访问性树一个 ref 都给不出。这时 <code>snapshot</code> / <code>snapshot -i</code> 不再打印
+        「(no interactive elements)」，而是自动改用 <code>DOM.getDocument(pierce:true)</code> 遍历
+        （open 与 closed shadow root、同进程子文档）列出可操作元素。这些 <code>[ref=eN]</code> 照常可用于
+        <code>click</code> / <code>type</code> / <code>fill</code>；JSON 里带 <code>source: "dom"</code> 和一行
+        <code>note</code> 说明来源，role / name 由标签和属性推导。<code>snapshot --dom</code> 可强制走这条路径。
+      </p>
 
       <hr class="du-divider" />
 

--- a/docs/real-chrome.html
+++ b/docs/real-chrome.html
@@ -293,7 +293,8 @@
         扩展<strong>只对 agent 拥有的标签页</strong>（它创建的，或你 <code>adopt</code> 的）attach Chrome 调试器，
         绝不对用户自己的标签页 attach——所以 Chrome 那条「chrome-use started debugging this browser」的横幅
         永远不会盖住用户正在用的页面（它只出现在被 attach 的标签页上，而 agent 的都是后台标签页）。
-        无需重启 Chrome，完全无缝。
+        无需重启 Chrome，完全无缝。扩展 0.5.19 起，agent 标签页 30 秒没有活动就会自动释放调试器、横幅消失，
+        下一条命令再透明地重新 attach（时长在扩展选项页可调，0 = 从不释放）。
       </div>
 
       <h2>读取用户已经打开的标签页：adopt</h2>

--- a/docs/sessions.html
+++ b/docs/sessions.html
@@ -160,6 +160,16 @@
         <code>session list</code> 看还有哪些活跃会话：
       </p>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ 换目录不会丢会话</div>
+        派生出的名字是 <code>cu-&lt;repo&gt;-&lt;tag&gt;</code>：<code>&lt;tag&gt;</code> 来自 agent / 终端 id，
+        <code>&lt;repo&gt;</code> 只是当前目录的 basename。以前换个目录执行就会造出另一个名字、打到一个没有任何 ref 的新守护进程
+        （报 「Unknown ref」）。现在只要有一个活着的守护进程带着同一个 agent tag（前缀不同），就会复用它，
+        agent 的标签和 ref 跨 <code>cd</code> 保留。显式 <code>--session &lt;name&gt;</code> / <code>AGENT_BROWSER_SESSION</code> 仍然优先。
+        「Unknown ref」报错现在会说明是哪个会话在应答、它有没有 ref：一个都没有时提示「此会话尚未运行过 snapshot；如果你在别的目录或终端做的快照，
+        用 <code>session list</code> 找到它并用 <code>--session</code> 钉住」，否则列出它实际持有的 ref 范围。
+      </div>
+
       <div class="du-code">
         <div class="du-code-head">
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -99,6 +99,12 @@
         或已经发生导航/切换标签页。同一文档里的同一个 backend DOM 节点会跨 snapshot 保持 ref，
         弹窗插入/删除不会再让后续控件整体改号。遇到错误时重新快照，确认当前节点与 ref。
       </p>
+      <p>
+        「Unknown ref」是另一回事：它会说明是哪个会话在应答、这个会话有没有 ref。提示「此会话尚未运行过 snapshot」
+        说明命令打到了另一个会话（比如在别的目录或终端做的快照），用 <code>session list</code> 找到它并用
+        <code>--session</code> 钉住；同一个 agent tag 现在会跨 <code>cd</code> 复用守护进程，见
+        <a href="/sessions.html">会话与并发</a>。如果报错列出了它实际持有的 ref 范围，那就是页面变了，重新快照即可。
+      </p>
 
       <div class="du-code">
         <div class="du-code-head">
@@ -220,8 +226,11 @@
       </p>
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ 说明</div>
-        升级后 agent 主动驱动自己的标签页时，提示条仍会短暂出现（这是 <code>chrome.debugger</code> API 的固有行为），
-        任务结束 detach 后自动消失。若想连这一段也静音，跑一次
+        升级后 agent 主动驱动自己的标签页时，提示条仍会短暂出现（这是 <code>chrome.debugger</code> API 的固有行为）。
+        扩展 0.5.19 起它会自己消失：某个标签页 30 秒没有 agent 活动，扩展就释放该标签的调试器，提示条随之消失；
+        标签仍被中继记着，下一条命令会透明地重新 attach（已启用的 CDP domain 会重放）。时长在扩展选项页
+        「Release idle tabs after」里可调（0 = 从不释放）。点提示条上的 Cancel 现在会被尊重，agent 下一条命令之前不会自动重连。
+        代价：被动采集（network / console 日志）在释放期间会漏掉事件。若想连这一段也静音，跑一次
         <code>chrome-use extension connect --silent</code>——它会在确认后重启 Chrome 并带上
         <code>--silent-debugger-extension-api</code>，标签页和登录态由 Chrome 自动恢复，之后彻底无提示条。
         背景与方案取舍见 <a href="/debugger-banner-silence.html">深入：静音 debugger 提示条</a>。

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -29,6 +29,12 @@ import {
   navigateTabWithBrowserFallback,
 } from './tab-navigation.js'
 import { targetInfoForTab } from './target-info.js'
+import {
+  IDLE_DETACH_DEFAULT_SECS,
+  idleDetachMsFrom,
+  rememberReplayable as rememberReplayableIn,
+  selectIdleTabs,
+} from './idle-detach.js'
 
 const HOST_NAME = 'com.agent_browser.connect'
 const SKIP_URL = /^(chrome|chrome-extension|devtools|chrome-untrusted|edge|about):/i
@@ -394,13 +400,24 @@ function setBadge(tabId, kind) {
 let cursorEnabled = false
 let notifyEnabled = false
 let lastConnected = null
+// Idle auto-detach (issue #201): release chrome.debugger from a tab after this
+// long with no CDP traffic, so Chrome's "started debugging this browser" bar
+// shows only while an agent is actually driving — like Codex's own extension —
+// instead of staying up for hours after the last command. The tab stays known
+// to the relay (same `cb-tab-<id>` session); the next command re-attaches and
+// replays the enabled domains transparently. 0 = never detach (old behaviour).
+let idleDetachMs = IDLE_DETACH_DEFAULT_SECS * 1000
 
 function loadUxSettings() {
   try {
-    chrome.storage.sync.get({ ab_cursor: false, ab_notify: false }, (s) => {
-      cursorEnabled = !!s.ab_cursor
-      notifyEnabled = !!s.ab_notify
-    })
+    chrome.storage.sync.get(
+      { ab_cursor: false, ab_notify: false, ab_idle_detach_secs: IDLE_DETACH_DEFAULT_SECS },
+      (s) => {
+        cursorEnabled = !!s.ab_cursor
+        notifyEnabled = !!s.ab_notify
+        idleDetachMs = idleDetachMsFrom(s.ab_idle_detach_secs)
+      },
+    )
   } catch {}
 }
 loadUxSettings()
@@ -409,6 +426,7 @@ try {
     if (area !== 'sync') return
     if ('ab_cursor' in ch) cursorEnabled = !!ch.ab_cursor.newValue
     if ('ab_notify' in ch) notifyEnabled = !!ch.ab_notify.newValue
+    if ('ab_idle_detach_secs' in ch) idleDetachMs = idleDetachMsFrom(ch.ab_idle_detach_secs.newValue)
   })
 } catch {}
 
@@ -830,7 +848,7 @@ async function handleForwardCdpCommand(msg) {
       audible: Boolean(tab.audible),
       discarded: Boolean(tab.discarded),
       frozen: Boolean(tab.frozen),
-      debuggerAttached: Boolean(entry),
+      debuggerAttached: Boolean(entry && entry.attached !== false),
       windowId: tab.windowId,
     }
   }
@@ -986,6 +1004,27 @@ async function handleForwardCdpCommand(msg) {
       ? sessionId
       : undefined
 
+  // Idle auto-detach bookkeeping (issue #201): re-attach a released tab before
+  // the command and count in-flight commands so the sweep never detaches under
+  // a running one. State-setting commands are remembered for replay.
+  const entry = tabs.get(tabId)
+  if (entry && entry.attached === false) await reattachTab(tabId, entry)
+  if (entry) {
+    entry.inflight++
+    entry.lastActivity = Date.now()
+    if (!childSid) rememberReplayable(entry, method, params)
+  }
+  try {
+    return await dispatchToTab(tabId, method, params, childSid)
+  } finally {
+    if (entry) {
+      entry.inflight = Math.max(0, entry.inflight - 1)
+      entry.lastActivity = Date.now()
+    }
+  }
+}
+
+async function dispatchToTab(tabId, method, params, childSid) {
   // Re-enabling Runtime can leave a stale state; bounce it (matches upstream).
   if (method === 'Runtime.enable') {
     try {
@@ -1014,7 +1053,8 @@ async function handleForwardCdpCommand(msg) {
 
 async function attachTab(tabId, transactionIsActive) {
   const existing = tabs.get(tabId)
-  if (existing) return existing
+  if (existing && existing.attached !== false) return existing
+  if (existing) return await reattachTab(tabId, existing)
   const dbg = { tabId }
   try {
     await withRelayTimeout(
@@ -1086,7 +1126,7 @@ async function attachTab(tabId, transactionIsActive) {
     throw new Error('attachTab: duplicate transaction cancelled')
   }
   const sessionId = `cb-tab-${tabId}`
-  const entry = { sessionId, targetId }
+  const entry = newTabEntry(sessionId, targetId, true)
   tabs.set(tabId, entry)
   sessionToTab.set(sessionId, tabId)
   rememberSessionTarget(sessionId, targetId)
@@ -1109,6 +1149,85 @@ async function attachTab(tabId, transactionIsActive) {
     'chrome.debugger.sendCommand(Target.setAutoAttach)',
   ).catch(() => {})
   return entry
+}
+
+function newTabEntry(sessionId, targetId, attached) {
+  return {
+    sessionId,
+    targetId,
+    // false while idle-detached (issue #201): the relay still knows the tab, the
+    // debugger is simply released until the next command.
+    attached,
+    lastActivity: Date.now(),
+    inflight: 0,
+    // State-setting commands (X.enable, Emulation.set*, …) the daemon sent on
+    // this tab, replayed after an idle re-attach so the session looks untouched.
+    replay: new Map(),
+  }
+}
+
+function rememberReplayable(entry, method, params) {
+  if (entry && entry.replay) rememberReplayableIn(entry.replay, method, params)
+}
+
+// Re-attach an idle-detached tab and restore its session state. The `cb-tab-<id>`
+// session id is stable, so the daemon's binding needs no update.
+async function reattachTab(tabId, entry) {
+  if (entry.attached !== false) return entry
+  if (entry.reattaching) return await entry.reattaching
+  entry.reattaching = (async () => {
+    const dbg = { tabId }
+    try {
+      await withRelayTimeout(chrome.debugger.attach(dbg, '1.3'), 'chrome.debugger.attach')
+    } catch (e) {
+      const msg = String((e && e.message) || e)
+      if (!/already attached|already being debugged/i.test(msg)) throw e
+    }
+    entry.attached = true
+    entry.userDetached = false
+    entry.lastActivity = Date.now()
+    setBadge(tabId, port ? 'on' : 'connecting')
+    const arm = async (method, params) => {
+      try {
+        await withRelayTimeout(
+          chrome.debugger.sendCommand(dbg, method, params),
+          `chrome.debugger.sendCommand(${method})`,
+        )
+      } catch {}
+    }
+    await arm('Page.enable')
+    await arm('Target.setAutoAttach', { autoAttach: true, flatten: true, waitForDebuggerOnStart: false })
+    for (const { method, params } of entry.replay.values()) {
+      if (method === 'Page.enable' || method === 'Target.setAutoAttach') continue
+      await arm(method, params)
+    }
+    return entry
+  })()
+  try {
+    return await entry.reattaching
+  } finally {
+    entry.reattaching = null
+  }
+}
+
+// Release the debugger from a tab with no CDP traffic for `idleDetachMs`, but
+// keep the relay's record of it: no Target.detachedFromTarget goes to the host,
+// so the daemon keeps its session and the next command transparently
+// re-attaches. Child (OOPIF) sessions die with the attachment; Target.setAutoAttach
+// re-announces them on re-attach.
+function softDetachTab(tabId, entry, reason) {
+  if (!entry || entry.attached === false) return
+  entry.attached = false
+  entry.lastActivity = Date.now()
+  if (reason === 'user') entry.userDetached = true
+  for (const [sid, tid] of childSessionToTab.entries()) if (tid === tabId) childSessionToTab.delete(sid)
+  if (reason !== 'user') chrome.debugger.detach({ tabId }).catch(() => {})
+}
+
+function sweepIdleTabs() {
+  for (const tabId of selectIdleTabs(tabs.entries(), Date.now(), idleDetachMs)) {
+    softDetachTab(tabId, tabs.get(tabId), 'idle')
+  }
 }
 
 function detachTab(tabId, notify) {
@@ -1150,14 +1269,41 @@ async function reattachOwnedTabs() {
       continue
     }
     if (nativeDuplicateTabs.has(tabId)) continue
-    if (!tabs.has(tabId)) {
-      try {
-        await attachTab(tabId)
-      } catch {
-        // Restricted page or transient — leave owned; next pass retries.
-      }
-    }
+    if (!tabs.has(tabId)) await announceOwnedTabLazily(tabId)
   }
+}
+
+// Make an owned tab known to the relay again WITHOUT attaching the debugger
+// (issue #201): the targetId comes from chrome.debugger.getTargets(), which
+// needs no attachment and shows no banner. The first command re-attaches. Falls
+// back to a real attach only when the target can't be identified that way.
+async function announceOwnedTabLazily(tabId) {
+  let info = null
+  try {
+    info = targetInfoForTab(
+      await withRelayTimeout(chrome.debugger.getTargets(), 'chrome.debugger.getTargets'),
+      tabId,
+    )
+  } catch {}
+  if (!info || !info.targetId) {
+    try {
+      await attachTab(tabId)
+    } catch {
+      // Restricted page or transient — leave owned; next pass retries.
+    }
+    return
+  }
+  // A debugger attachment lingering from a previous worker instance keeps the
+  // banner up with nobody driving; release it. (An attachment that isn't ours —
+  // DevTools — makes the call fail harmlessly.)
+  await chrome.debugger.detach({ tabId }).catch(() => {})
+  const sessionId = `cb-tab-${tabId}`
+  const entry = newTabEntry(sessionId, String(info.targetId), false)
+  tabs.set(tabId, entry)
+  sessionToTab.set(sessionId, tabId)
+  rememberSessionTarget(sessionId, entry.targetId)
+  setBadge(tabId, port ? 'on' : 'connecting')
+  await announceAttachedTab(tabId, entry, info)
 }
 
 async function announceAttachedTab(tabId, entry, targetInfo, scopeHints) {
@@ -1226,6 +1372,17 @@ chrome.debugger.onDetach.addListener((source, reason) =>
   void whenReady(async () => {
     const tabId = source.tabId
     if (!tabId) return
+    const known = tabs.get(tabId)
+    // Our own idle release (#201) — nothing to recover, the entry is kept.
+    if (known && known.attached === false) return
+    // The user clicked Cancel on the debugger bar: honour it. Keep the tab known
+    // (no detachedFromTarget to the host, no owned-tab re-attach from the alarm —
+    // that is what made the bar come back within seconds) and re-attach only when
+    // the agent's next command needs the tab.
+    if (reason === 'canceled_by_user' && known) {
+      softDetachTab(tabId, known, 'user')
+      return
+    }
     detachTab(tabId, true)
     // A cross-process navigation (e.g. an SSO redirect like
     // login.account.rakuten.com that swaps the render process / spawns OOPIFs)
@@ -1240,7 +1397,7 @@ chrome.debugger.onDetach.addListener((source, reason) =>
     // The swapped-in process needs a moment to settle; retry with backoff.
     for (let i = 0; i < 6; i++) {
       await new Promise((r) => setTimeout(r, 250 + i * 200))
-      if (tabs.has(tabId)) return // already re-attached (e.g. via onUpdated)
+      if (tabs.get(tabId)?.attached !== undefined && tabs.get(tabId).attached !== false) return // already re-attached (e.g. via onUpdated)
       if (nativeDuplicateTabs.has(tabId)) return
       const tab = await chrome.tabs.get(tabId).catch(() => null)
       if (!tab || !eligible(tab)) return // tab gone or now a restricted page
@@ -1303,7 +1460,13 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) =>
       await announceAttachedTab(tabId, attached)
       return
     }
-    if (changeInfo.status === 'complete' && eligible(tab) && !tabs.has(tabId) && port) {
+    // Only tabs that are ours (agent-created) or opened BY ours (an OAuth popup
+    // that was still about:blank when created) — never the user's own tabs.
+    const ours =
+      ownedTabs.has(tabId) ||
+      (typeof tab?.openerTabId === 'number' &&
+        (ownedTabs.has(tab.openerTabId) || tabs.has(tab.openerTabId)))
+    if (changeInfo.status === 'complete' && eligible(tab) && !tabs.has(tabId) && port && ours) {
       try {
         await attachTab(tabId)
       } catch {}
@@ -1377,6 +1540,7 @@ function scheduleKeepalivePing() {
   if (keepaliveTimer) clearTimeout(keepaliveTimer)
   keepaliveTimer = setTimeout(() => {
     keepaliveTimer = null
+    sweepIdleTabs()
     if (!port) return // disconnected; connectHost() will restart the loop
     postToHost({ method: 'ping' }) // host pongs (or ignores); the send is what matters
     scheduleKeepalivePing()
@@ -1391,6 +1555,7 @@ chrome.alarms.create('keepalive', { periodInMinutes: 0.4 })
 chrome.alarms.onAlarm.addListener((a) => {
   if (a.name !== 'keepalive') return
   void whenReady(() => {
+    sweepIdleTabs()
     if (!port) connectHost()
     else {
       void reattachOwnedTabs()

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -1397,7 +1397,7 @@ chrome.debugger.onDetach.addListener((source, reason) =>
     // The swapped-in process needs a moment to settle; retry with backoff.
     for (let i = 0; i < 6; i++) {
       await new Promise((r) => setTimeout(r, 250 + i * 200))
-      if (tabs.get(tabId)?.attached !== undefined && tabs.get(tabId).attached !== false) return // already re-attached (e.g. via onUpdated)
+      if (tabs.get(tabId)?.attached) return // already re-attached (e.g. via onUpdated)
       if (nativeDuplicateTabs.has(tabId)) return
       const tab = await chrome.tabs.get(tabId).catch(() => null)
       if (!tab || !eligible(tab)) return // tab gone or now a restricted page

--- a/extensions/ab-connect/idle-detach.js
+++ b/extensions/ab-connect/idle-detach.js
@@ -1,0 +1,46 @@
+// Idle auto-detach rules (issue #201), kept free of `chrome.*` globals so the
+// service worker's release/replay decisions are unit-testable.
+
+export const IDLE_DETACH_DEFAULT_SECS = 30
+
+/** Parse the options-page setting (seconds) into milliseconds; 0 = never. */
+export function idleDetachMsFrom(secs) {
+  const n = Number(secs)
+  if (!Number.isFinite(n) || n < 0) return IDLE_DETACH_DEFAULT_SECS * 1000
+  return Math.round(n * 1000)
+}
+
+// CDP methods whose effect must survive an idle detach/re-attach. Everything
+// else is a one-shot action (navigate, click, evaluate) or a read.
+export const REPLAYABLE_METHOD =
+  /^(?:[A-Za-z]+\.enable|Emulation\.set\w+|Network\.set\w+|Page\.setLifecycleEventsEnabled|Page\.setBypassCSP|Page\.setInterceptFileChooserDialog|Page\.addScriptToEvaluateOnNewDocument|Runtime\.addBinding|Security\.setIgnoreCertificateErrors|Target\.setAutoAttach)$/
+
+/**
+ * Record a state-setting command on a tab entry's replay map (insertion
+ * order = replay order; a repeat of the same method moves to the end with its
+ * latest params). `X.disable` forgets `X.enable`.
+ */
+export function rememberReplayable(replay, method, params) {
+  if (!replay) return
+  const m = /^([A-Za-z]+)\.disable$/.exec(method)
+  if (m) {
+    replay.delete(`${m[1]}.enable`)
+    return
+  }
+  if (!REPLAYABLE_METHOD.test(method)) return
+  const multi = method === 'Page.addScriptToEvaluateOnNewDocument' || method === 'Runtime.addBinding'
+  const key = multi ? `${method} ${JSON.stringify(params ?? null)}` : method
+  replay.delete(key)
+  replay.set(key, { method, params })
+}
+
+/** Tab ids whose attachment should be released now. */
+export function selectIdleTabs(entries, now, idleMs) {
+  if (!(idleMs > 0)) return []
+  const out = []
+  for (const [tabId, entry] of entries) {
+    if (!entry || entry.attached === false || entry.inflight > 0 || entry.reattaching) continue
+    if (now - entry.lastActivity >= idleMs) out.push(tabId)
+  }
+  return out
+}

--- a/extensions/ab-connect/idle-detach.test.js
+++ b/extensions/ab-connect/idle-detach.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { idleDetachMsFrom, rememberReplayable, selectIdleTabs } from './idle-detach.js'
+
+test('idle setting parses seconds, 0 disables, garbage falls back to the default (#201)', () => {
+  assert.equal(idleDetachMsFrom(45), 45000)
+  assert.equal(idleDetachMsFrom('10'), 10000)
+  assert.equal(idleDetachMsFrom(0), 0)
+  assert.equal(idleDetachMsFrom(-3), 30000)
+  assert.equal(idleDetachMsFrom(undefined), 30000)
+})
+
+test('only quiet, attached, non-busy tabs are released', () => {
+  const now = 100000
+  const entries = [
+    [1, { attached: true, inflight: 0, lastActivity: now - 31000 }], // idle → release
+    [2, { attached: true, inflight: 0, lastActivity: now - 5000 }], // recent
+    [3, { attached: true, inflight: 1, lastActivity: now - 60000 }], // command running
+    [4, { attached: false, inflight: 0, lastActivity: now - 60000 }], // already released
+    [5, { attached: true, inflight: 0, lastActivity: now - 60000, reattaching: Promise.resolve() }],
+  ]
+  assert.deepEqual(selectIdleTabs(entries, now, 30000), [1])
+  assert.deepEqual(selectIdleTabs(entries, now, 0), [], '0 = never detach')
+})
+
+test('replay map keeps enables and emulation state, drops disabled domains and one-shots', () => {
+  const replay = new Map()
+  rememberReplayable(replay, 'Page.enable')
+  rememberReplayable(replay, 'Network.enable')
+  rememberReplayable(replay, 'Emulation.setFocusEmulationEnabled', { enabled: true })
+  rememberReplayable(replay, 'Emulation.setFocusEmulationEnabled', { enabled: false })
+  rememberReplayable(replay, 'Page.navigate', { url: 'https://example.com' })
+  rememberReplayable(replay, 'Runtime.evaluate', { expression: '1' })
+  rememberReplayable(replay, 'Page.addScriptToEvaluateOnNewDocument', { source: 'a' })
+  rememberReplayable(replay, 'Page.addScriptToEvaluateOnNewDocument', { source: 'b' })
+  rememberReplayable(replay, 'Network.disable')
+  const replayed = [...replay.values()].map((c) => [c.method, c.params])
+  assert.deepEqual(replayed, [
+    ['Page.enable', undefined],
+    ['Emulation.setFocusEmulationEnabled', { enabled: false }],
+    ['Page.addScriptToEvaluateOnNewDocument', { source: 'a' }],
+    ['Page.addScriptToEvaluateOnNewDocument', { source: 'b' }],
+  ])
+})

--- a/extensions/ab-connect/manifest.json
+++ b/extensions/ab-connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "chrome-use",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "Let chrome-use drive your logged-in Chrome — install once, no token, no per-use confirmation.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6vQIyscGIPYPZdSpPwPL0+0gxUROyRgCpmvCSDoc8XUm4qm97VbKnD9Ijc1lV22lNWZtE78gaRjt6BeSfuMgnBymnhLKjN1gU6AI5QUU0mrJyeHdWKvrKQR5FmsM2A7Xr1ykE2SiiS8zNUS3Y/6O5l+Nva7wrVy6E4a2dkBVQkOsu+DV+nEZvhIyuDY5D5SPXqNwUTWTaglwj5mjvHz36xSwCWlPmrtJ+ED0AUyrb2z4GIOmvk4kqtBVrh/UD058klLo4CkYOnIybB5aV6WYuwarfPY4bF/dLggPem+ewLNTUNBuwrxj/A4nUv0LJTuRO8rR7f8WR9qnRCY0Ic5saQIDAQAB",
   "icons": {

--- a/extensions/ab-connect/options.html
+++ b/extensions/ab-connect/options.html
@@ -174,8 +174,19 @@
   <section class="card">
     <h2>The “started debugging this browser” bar</h2>
     <p class="lead">chrome-use drives Chrome via the DevTools protocol, so Chrome shows
-      that bar. It can’t be hidden at runtime — but a one-time restart with a startup
-      flag removes it (your tabs &amp; logins are restored automatically).</p>
+      that bar while an agent is driving a tab. The debugger is released automatically
+      once a tab has been idle for a while, so the bar disappears between tasks; a
+      one-time restart with a startup flag removes it entirely (your tabs &amp; logins
+      are restored automatically).</p>
+    <div class="row">
+      <div class="grow">
+        <div class="name">Release idle tabs after</div>
+        <div class="hint">Seconds without agent activity before the debugger detaches
+          from a tab (the bar goes away). The next command re-attaches automatically.
+          0 keeps tabs attached until the session ends.</div>
+      </div>
+      <input type="number" id="optIdleSecs" min="0" max="3600" step="5" style="width:5.5em" />
+    </div>
     <div class="cmd">
       <code id="silentCmd">chrome-use extension connect --silent</code>
       <button class="btn" id="copyCmd">Copy</button>

--- a/extensions/ab-connect/options.js
+++ b/extensions/ab-connect/options.js
@@ -4,13 +4,13 @@
 // Opens standalone (file://) too, with a friendly demo state, so the design is
 // viewable without the extension context.
 
-const DEFAULTS = { ab_notify: false, ab_cursor: false, ab_sites: [] }
+const DEFAULTS = { ab_notify: false, ab_cursor: false, ab_sites: [], ab_idle_detach_secs: 30 }
 const hasChrome = typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync
 
 // ---- elements ----
 const el = (id) => document.getElementById(id)
 const dot = el('dot'), statusLabel = el('statusLabel'), statusSub = el('statusSub'), tabPill = el('tabPill')
-const optNotify = el('optNotify'), optCursor = el('optCursor')
+const optNotify = el('optNotify'), optCursor = el('optCursor'), optIdleSecs = el('optIdleSecs')
 const sitesBox = el('sites'), siteInput = el('siteInput')
 const saved = el('saved')
 
@@ -91,12 +91,18 @@ el('ver').textContent = hasChrome ? 'v' + chrome.runtime.getManifest().version :
 loadSettings((s) => {
   optNotify.checked = !!s.ab_notify
   optCursor.checked = !!s.ab_cursor
+  optIdleSecs.value = Number.isFinite(Number(s.ab_idle_detach_secs)) ? Number(s.ab_idle_detach_secs) : 30
   sites = Array.isArray(s.ab_sites) ? s.ab_sites.slice() : []
   renderSites()
 })
 
 optNotify.addEventListener('change', () => save({ ab_notify: optNotify.checked }))
 optCursor.addEventListener('change', () => save({ ab_cursor: optCursor.checked }))
+optIdleSecs.addEventListener('change', () => {
+  const n = Math.max(0, Math.min(3600, Number(optIdleSecs.value) || 0))
+  optIdleSecs.value = n
+  save({ ab_idle_detach_secs: n })
+})
 el('addSite').addEventListener('click', addSite)
 siteInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') addSite() })
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -118,7 +118,9 @@ adopted, so
 concurrent agents share one real Chrome without cross-talk and never touch
 unadopted user tabs; an unset session auto-derives a stable per-agent name from supported
 runner IDs, including Codex's `CODEX_THREAD_ID`. Other runners can set
-`AGENT_BROWSER_SESSION_ID`. `adopt
+`AGENT_BROWSER_SESSION_ID`. The derived name is `cu-<repo>-<tag>`; a command run
+from another directory reuses the live daemon carrying the same agent tag, so
+tabs and refs survive `cd` (explicit `--session` still wins). `adopt
 <url|targetId>` drives a pre-existing tab on demand; OAuth/SSO popups and
 cross-process redirects are followed automatically.
 
@@ -247,6 +249,9 @@ chrome-use snapshot -i -c              # compact (no empty structural nodes)
 chrome-use snapshot -i -d 3            # cap depth at 3 levels
 chrome-use snapshot -s "#main"         # scope to a CSS selector
 chrome-use snapshot -i -f "SSH|端口|应用"  # keep only matching lines + ancestors (regex)
+chrome-use snapshot -i --dom           # list actionable elements from a DOM walk
+                                          # (open + closed shadow roots); automatic
+                                          # when the AX tree yields no refs at all
 chrome-use snapshot -i --json          # machine-readable output
 ```
 
@@ -345,6 +350,14 @@ pierces closed shadow roots** — a closed-shadow `<button>` / `[role=button]`
 shows up as a normal `@ref`. So shadow-rendered controls with a11y semantics are
 clickable the usual way; only a bare non-semantic clickable `<div>` inside a
 *closed* root can slip past both the AX tree and the cursor-element scan.
+If the AX tree comes back with **no refs at all** (web-component SPAs such as
+developer.apple.com/contact, whose whole page lives inside shadow roots),
+`snapshot` / `snapshot -i` automatically lists actionable elements from a
+`DOM.getDocument(pierce:true)` walk (open and closed shadow roots, same-process
+child documents) instead of printing "(no interactive elements)". Those
+`[ref=eN]` work with `click`/`type`/`fill` like normal refs; the JSON carries
+`source: "dom"` plus a `note`, and roles/names are derived from tags and
+attributes. `snapshot --dom` forces that path.
 
 **Canvas / WebGL UIs (game boards, voice-room mic seats, map tiles, design
 canvases).** These paint to a `<canvas>` — there is **no DOM node and no
@@ -369,8 +382,11 @@ chrome-use click @e1 --new-tab         # open link in new tab instead of navigat
 chrome-use dblclick @e1                # double-click
 chrome-use hover @e1                   # hover
 chrome-use focus @e1                   # focus (useful before keyboard input)
-chrome-use fill @e2 "hello"            # clear then type
-chrome-use type @e2 " world"           # type without clearing
+chrome-use fill @e2 "hello"            # clear then type (verified by read-back;
+                                          # a mismatch error quotes both values and
+                                          # says when the page filtered non-Latin input)
+chrome-use type @e2 " world"           # type without clearing (read back too: ⚠
+                                          # warning, exit 0, if the page rewrote it)
 chrome-use type @e5 "201-0001" --key-events  # real keystrokes (not insertText) —
                                           # use for autocomplete/combobox fields that
                                           # only react to key events (e.g. a postal box
@@ -385,6 +401,11 @@ chrome-use type @e6 "ChatGPT" --enter  # type (real keystrokes, implies --key-ev
 chrome-use press Enter                 # press a key at current focus (down+up).
                                           # The output names where it landed
                                           # ("Pressed Enter → textarea[name=q]").
+                                          # A prior `click <input>` focuses it, also
+                                          # over the relay. ⚠ warning (exit 0) when a
+                                          # JS-only key (Arrow/Escape/Enter on a bare
+                                          # input) finds no key listener on the page:
+                                          # it cannot react, click the option instead.
 chrome-use press Enter --selector @e2  # focus the target first (alias --on) —
                                           # each CLI call is its own process, so
                                           # don't assume focus stayed put
@@ -511,11 +532,22 @@ pages → `find role/text/label` when you'd rather skip the snapshot → raw CSS
 occluded clicks). Don't retry a flaky structured locator three times; drop to
 `eval` and act on the DOM directly.
 
+Selectors starting with `//`, `/`, `(`, `./` or `..` are XPath automatically (no
+`xpath=` prefix). `text()` only tests the FIRST direct text node, so a label
+split across nodes (React `{a} - {b}`) or nested in a child never matches; use
+`contains(normalize-space(.), '…')`, `find "<label>"`, `text=<label>` or a
+snapshot `@ref`. "Element not found" keeps the selector plus the resolver's
+diagnosis, and an XPath with `text()` that matched nothing explains this.
+
 `click` auto-scrolls into view and, if the coordinate click is occluded, falls
 back to a DOM `.click()`. If a click *reports success but nothing happened* —
 classic for an autocomplete/menu `<li>` that closes on the input's blur — retry
 that one with `AGENT_BROWSER_CLICK_MODE=dom chrome-use click ...`, or just
-`chrome-use eval "<select the item via JS>"`.
+`chrome-use eval "<select the item via JS>"`. A DOM-dispatched click (the relay's
+default for left clicks) moves focus like a real click: the clicked element, its
+nearest focusable ancestor, or a label's control gets focus unless the handler
+already moved it, so `click <input>` then `press Meta+a` lands on that input. A
+plain `<li>` has no focusable target, so the input keeps focus and still selects.
 
 Click a raw pixel point when the only handle you have is a coordinate (canvas,
 a marker from a screenshot, a target with no stable selector):
@@ -1172,6 +1204,14 @@ Destructive actions require `--fix`. Exit code is `0` if all checks pass
 **"Ref not found" / "Element not found: @eN"**
 Page changed since the snapshot. Run `chrome-use snapshot -i` again,
 then use the new refs.
+
+**"Unknown ref @eN"**
+The error names the session that answered and says whether it holds any refs.
+"no snapshot has run in this session" means the command reached a different
+session than the one you snapshotted (another directory or terminal): run
+`chrome-use session list` and pin with `--session <name>`. If it lists a ref
+range instead, the page changed; re-snapshot. Sessions are now reused across
+`cd` for the same agent tag, so this mostly shows up with a different terminal.
 
 **Element exists in the DOM but not in the snapshot**
 It's probably off-screen or not yet rendered. Try:

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -51,6 +51,7 @@ chrome-use snapshot -i         # Interactive elements only (recommended)
 chrome-use snapshot -c         # Compact output
 chrome-use snapshot -d 3       # Limit depth to 3
 chrome-use snapshot -s "#main" # Scope to CSS selector
+chrome-use snapshot -i --dom   # Actionable elements from a DOM walk (open + closed shadow roots); automatic when the AX tree has no refs
 chrome-use read <url>          # Fetch a URL as agent-readable markdown/text (prefers .md/llms.txt, HTML→markdown fallback)
 chrome-use read                # No URL: read the rendered DOM of the active tab
 chrome-use read <url> --outline        # Heading outline only
@@ -67,7 +68,7 @@ chrome-use dblclick @e1        # Double-click
 chrome-use focus @e1           # Focus element
 chrome-use fill @e2 "text"     # Clear and type
 chrome-use type @e2 "text"     # Type without clearing (add --clear to clear first, --delay <ms> for per-key delay)
-chrome-use press Enter         # Press key at current focus (alias: key); output names the target
+chrome-use press Enter         # Press key at current focus (alias: key); output names the target; ⚠ warns when the page has no listener for a JS-only key
 chrome-use press Enter --selector @e2  # Focus the target first (alias: --on)
 chrome-use press Control+a     # Key combination
 chrome-use keydown Shift       # Hold key down
@@ -82,6 +83,23 @@ chrome-use scrollintoview @e1  # Scroll element into view (alias: scrollinto)
 chrome-use drag @e1 @e2        # Drag and drop
 chrome-use upload @e1 file.pdf # Upload files
 ```
+
+`type` reads the field back and prints a ⚠ warning (exit 0, JSON `readBack`)
+when the page rewrote or filtered what was typed. `fill` verification errors
+quote both values (`read back "" after writing "狛江市"`) and say when every
+non-ASCII character vanished while ASCII survived (a Latin-only / masked
+field), so re-typing will not help. `press` warns (exit 0, JSON `keyListeners`)
+when a JavaScript-only key (Arrow/Home/End/PageUp/PageDown on a text field,
+Escape, Enter on a bare input outside a form) finds no keydown/keyup/keypress
+listener from the focused element up to window: the page cannot react, click
+the option instead. Chords, Tab, Backspace and printable keys are not probed.
+
+Selectors starting with `//`, `/`, `(`, `./` or `..` are XPath automatically
+(no `xpath=` prefix). `text()` only tests the FIRST direct text node, so text
+split across nodes (React `{a} - {b}`) or nested in a child never matches; use
+`contains(normalize-space(.), '…')`, `find "<label>"`, `text=<label>` or a
+snapshot `@ref`. "Element not found" keeps the selector and the resolver's
+diagnosis instead of always blaming a closed shadow root or cross-origin iframe.
 
 ## Get Information
 
@@ -619,9 +637,15 @@ click. If that fails (a floating layer fails the occlusion guard, or the point
 won't resolve) it falls back to a DOM-dispatched `.click()` on the intended
 element. If a click *reports success but the page didn't react* — common for
 autocomplete/menu `<li>` items that close on the input's blur — retry that one
-with `AGENT_BROWSER_CLICK_MODE=dom` (a DOM dispatch doesn't move focus the way a
-real pointer press does, so the item still selects). `=coord` disables the
+with `AGENT_BROWSER_CLICK_MODE=dom` (a plain `<li>` has no focusable target, so
+the input keeps focus and the item still selects). `=coord` disables the
 fallback when you specifically want a hard failure on occlusion.
+
+A DOM-dispatched click (the relay's default for left clicks) moves keyboard
+focus like a real click: the clicked element, its nearest focusable ancestor,
+or a label's control receives focus unless the click handler already moved it.
+So `click <input>` followed by `press Meta+a` lands on that input, not on the
+previously focused field.
 
 ### Stealth / anti-detection knobs (fork)
 

--- a/skill-data/core/references/session-management.md
+++ b/skill-data/core/references/session-management.md
@@ -148,6 +148,19 @@ chrome-use snapshot -i
 chrome-use close
 ```
 
+The derived name is `cu-<repo>-<tag>`: `<tag>` comes from the agent/terminal
+ID and `<repo>` is only the cwd basename. Running a command from another
+directory would mint a different name and hit a fresh daemon with no refs, so
+when a live daemon already carries the same agent tag under another prefix,
+that session is reused and your tabs and refs survive a `cd`. Explicit
+`--session <name>` / `AGENT_BROWSER_SESSION` still win.
+
+An "Unknown ref" error names the session that answered and says whether it
+holds any refs. "no snapshot has run in this session" means the command reached
+a different session than the one you snapshotted (another directory or
+terminal): run `chrome-use session list` and pin with `--session`. If it lists
+the ref range it does have, the page changed since the snapshot.
+
 ## Session Cleanup
 
 ```bash

--- a/skill-data/core/references/snapshot-refs.md
+++ b/skill-data/core/references/snapshot-refs.md
@@ -196,6 +196,24 @@ chrome-use click @e5
 - Empty iframes or iframes with no interactive content are omitted from the output
 - To scope a snapshot to a single iframe, use `frame @ref` then `snapshot -i`
 
+## Shadow-root pages (DOM walk fallback)
+
+Some web-component SPAs (developer.apple.com/contact, for example) render the
+whole page inside shadow roots and the accessibility tree comes back with no
+refs at all. Instead of printing "(no interactive elements)", `snapshot` and
+`snapshot -i` then list actionable elements from a `DOM.getDocument(pierce:true)`
+walk that covers open and closed shadow roots and same-process child documents.
+
+```bash
+chrome-use snapshot -i          # automatic fallback when the AX tree has no refs
+chrome-use snapshot -i --dom    # force the DOM walk
+```
+
+**Key details:**
+- Refs from the DOM listing (`[ref=eN]`) work with `click`, `type` and `fill` like normal refs
+- The JSON carries `source: "dom"` and a `note` saying the listing came from the DOM walk
+- Roles and names are derived from tags and attributes, so they are coarser than AX roles
+
 ## Troubleshooting
 
 ### "Ref not found" Error
@@ -204,6 +222,20 @@ chrome-use click @e5
 # Element may have been replaced or removed — re-snapshot
 chrome-use snapshot -i
 ```
+
+### "Unknown ref" Error
+
+The message names the session that answered and says whether it holds any refs.
+"no snapshot has run in this session" means the command reached a different
+session than the one you snapshotted (another directory or terminal):
+
+```bash
+chrome-use session list                 # find the session that has your refs
+chrome-use --session <name> click @e4   # pin it
+```
+
+If the error lists the ref range the session does have, the page changed since
+the snapshot; re-snapshot instead.
 
 ### Element Not Visible in Snapshot
 

--- a/skill-data/real-chrome/SKILL.md
+++ b/skill-data/real-chrome/SKILL.md
@@ -171,7 +171,14 @@ session and connected browser endpoint, so interrupted cleanup can resume safely
 > browser" bar never covers a page they're working in (it only appears on attached
 > tabs, and the agent's are background tabs). `adopt <url>` attaches that one tab
 > on demand (the bar then shows on *that* tab — it's the one you asked to drive).
-> No Chrome restart, fully seamless.
+> No Chrome restart, fully seamless. Since extension 0.5.19 the bar also goes
+> away by itself: after 30 s without agent activity on a tab the extension
+> releases the debugger from it, the tab stays known to the relay, and the next
+> command re-attaches transparently (enabled domains are replayed). The delay is
+> configurable on the extension options page ("Release idle tabs after", 0 =
+> never). Clicking Cancel on the bar is honoured until the agent's next command.
+> Trade-off: passive captures (network/console logging) miss events during a
+> released interval.
 
 > **Need to read a tab the user already has open?** Use `chrome-use adopt
 > <url-substring|targetId>` — it finds that pre-existing tab (the user's own, or


### PR DESCRIPTION
Batch fix for the six open issues, each verified live over the extension relay against a local repro page (developer.apple.com/contact itself needs a logged-in developer account, so #206 was exercised through the forced `--dom` path plus unit tests on a synthetic shadow-root DOM).

## Fixes

- **#204 press lands one step behind.** Over the relay a left click is DOM-dispatched (`el.click()`), which fires handlers but never moves keyboard focus, so `click <input>` + `press Meta+a` hit the previously focused field. The DOM click now focuses the clicked focusable element (or nearest focusable ancestor / a label's control) unless the handler already moved focus. Non-focusable targets leave focus alone, so the autocomplete `<li>` trick keeps working. Fixes #204.
- **#203 CJK "dropped".** CJK delivery over the relay is fine; the Apple form filters non-Latin input itself. `type` now reads the field back and prints a `⚠` warning (exit 0, `readBack` in JSON) when the field does not contain what was typed. `fill` verification errors quote both values and, when only ASCII survived, say the page filtered non-Latin text. Fixes #203.
- **#202 press "success" on keydown-less inputs / misleading not-found error.** `press` probes keydown/keyup/keypress listeners (element, ancestors, document, window via `DOMDebugger.getEventListeners`) for keys whose only effect depends on page JS (arrows/Home/End/Page on text fields, Escape, Enter on a bare input outside a form) and warns when none exist (`keyListeners` in JSON). Bare XPath (`//`, `/`, `(`, `./`, `..`) is auto-detected (it used to be fed to `querySelector`); an XPath with `text()` that misses gets the split-text-node hint. "Element not found" keeps the selector and the resolver's diagnosis instead of always blaming closed shadow roots / cross-origin iframes. Fixes #202.
- **#205 refs are cwd-scoped.** The derived name is `cu-<repo>-<tag>`; the repo prefix made a `cd` land on a fresh daemon. A live daemon carrying the same agent tag is now reused across directories (`doctor` reports the same name). "Unknown ref" names the session that answered and says whether it has any refs at all, with the `--session` / `session list` recovery. Fixes #205.
- **#206 empty snapshot on shadow-DOM pages.** When the AX tree yields no refs at all, `snapshot` falls back to a `DOM.getDocument(pierce:true)` walk (open and closed shadow roots, same-process child documents) and lists actionable elements with working refs (`dom_sourced` refs are DOM-verified instead of AX-verified). `snapshot --dom` forces it; the JSON carries `source: "dom"` and a `note`. Fixes #206.
- **#201 persistent debugger bar.** Extension 0.5.19: after 30 s without CDP traffic a tab's debugger is released (bar disappears) while the relay keeps the tab; the next command re-attaches and replays enabled domains / emulation state. Owned tabs are re-announced lazily after a worker restart (no eager attach), the alarm no longer re-attaches a tab the user cancelled, and `tabs.onUpdated` no longer attaches non-owned tabs. Delay configurable on the options page (0 = never). Addresses #201; the extension still needs the manual Web Store submission.

## Docs

Help text, README(s), core/real-chrome skills and the bilingual docs site updated alongside.

## Tests

- `cargo test --bin chrome-use`: new unit tests for xpath detection/hints, fill/type read-back wording, key-listener gating, session reuse, Unknown-ref wording, the DOM snapshot walker; one stale assertion updated (`test_to_ai_friendly_error_catches_no_element`).
- `node --test extensions/ab-connect/*.test.js`: new `idle-detach.test.js`. (`tab-duplicate.test.js` "native duplicate does not stall…" and `daemon::test_child_try_wait…` are timing-based and flake on a loaded machine on `main` too.)

https://claude.ai/code/session_01C8rTh5PfDZnBiHJzGBMrEQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `snapshot --dom` lists actionable elements through shadow roots and automatically falls back when the accessibility tree is empty.
  - XPath selectors are detected automatically from common XPath prefixes.
  - Sessions persist when changing directories.
  - Idle Chrome debugging connections release and reconnect automatically, with configurable timing.
  - DOM-dispatched clicks move focus like real mouse clicks.

- **Bug Fixes**
  - Improved feedback for rewritten or filtered input and key presses without listeners.
  - Element-not-found errors retain useful selector diagnostics.

- **Documentation**
  - Updated command references and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->