### PR TITLE
perf: 把浏览往返砍半，并让大页面的观察可控

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,40 @@
+# bench — browser-agent round-trip benchmarks
+
+Measures the two costs an agent actually pays per browser task:
+**round trips to the model** and **bytes returned into its context**.
+Wall clock is secondary — it mixes model speed with harness speed.
+
+## Compare against another agent's browser tool
+
+`codex_rollout_stats.py` reads a Codex rollout log and reports its round
+trips, returned bytes, tool-exec time and model think time:
+
+    grep -rl '"browser_use' ~/.codex/sessions ~/.codex/archived_sessions
+    bench/codex_rollout_stats.py <that file>
+
+Reference line measured 2026-09-07 on a form-filling task: 81 round trips,
+median 301 bytes returned, tool exec median 0.58s, **model think median
+6.01s**. Model time was 22x tool time — which is why round trips, not
+transport, are what to optimize.
+
+## Compare us before and after a change
+
+No model in the loop, so the delta is unambiguously the change:
+
+    bench/replay.sh bench/tasks/hn.txt before
+    # ... make the change, rebuild ...
+    bench/replay.sh bench/tasks/hn.txt after
+
+A task file is one `chrome-use` argv per line. Set `CHROME_USE_BIN` to a
+freshly built binary — **not** the one on PATH. Benchmarking an installed
+release against repo source silently measures the version skew instead of
+the change.
+
+`bench/cu` is the same wrapper for one-off interactive calls; it appends to
+`$CU_LOG`.
+
+The harness fires an uncounted warmup call first: a cold daemon costs ~1.5s of
+spawn plus session rebind, and it lands entirely on whichever command is first.
+That artifact is what first made `navigate` look ~5x slower than `snapshot`.
+
+Run on an idle machine and repeat 3x — medians, not single runs.

--- a/bench/codex_rollout_stats.py
+++ b/bench/codex_rollout_stats.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Extract the reference line from a codex rollout log: round trips, bytes
+returned to the model, tool-exec time vs model think time.
+Usage: codex_rollout_stats.py ~/.codex/**/rollout-*.jsonl
+Find candidates: grep -rl '"browser_use' ~/.codex/sessions ~/.codex/archived_sessions
+"""
+import json, sys, statistics as st
+from datetime import datetime
+
+def ts(s): return datetime.fromisoformat(s.replace('Z', '+00:00')).timestamp()
+
+for path in sys.argv[1:]:
+    ev, results = [], []
+    for line in open(path):
+        try: d = json.loads(line)
+        except Exception: continue
+        p = d.get('payload') or {}
+        t = p.get('type')
+        if t in ('function_call', 'function_call_output',
+                 'custom_tool_call', 'custom_tool_call_output'):
+            ev.append((ts(d['timestamp']), t))
+        it = p.get('item') or {}
+        if it.get('type') == 'McpToolCall' and it.get('server') == 'cua_repl':
+            results.append(''.join(c.get('text', '')
+                                   for c in (it.get('result', {}).get('content') or [])))
+    tool, think = [], []
+    i = 0
+    while i < len(ev):
+        if ev[i][1] in ('function_call', 'custom_tool_call'):
+            j = i + 1
+            while j < len(ev) and not ev[j][1].endswith('_output'): j += 1
+            if j < len(ev):
+                tool.append(ev[j][0] - ev[i][0])
+                k = j + 1
+                while k < len(ev) and ev[k][1].endswith('_output'): k += 1
+                if k < len(ev): think.append(ev[k][0] - ev[j][0])
+                i = j
+        i += 1
+    clip = lambda a: [x for x in a if 0 <= x < 600]
+    tool, think = clip(tool), clip(think)
+    by = [len(r) for r in results]
+    print(f"file: {path}")
+    print(f"  cua_repl round trips = {len(results)}")
+    if by:
+        print(f"  bytes returned: median={st.median(by):.0f} total={sum(by)}")
+    if tool:
+        print(f"  tool exec:   median={st.median(tool):.2f}s total={sum(tool):.0f}s")
+    if think:
+        print(f"  model think: median={st.median(think):.2f}s total={sum(think):.0f}s")

--- a/bench/cu
+++ b/bench/cu
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Logged chrome-use wrapper: records wall ms + bytes returned, then prints output.
+LOG="${CU_LOG:-bench/results/live.tsv}"
+[ -f "$LOG" ] || printf 'n\tms\tbytes\tcmd\n' > "$LOG"
+s=$(python3 -c 'import time;print(time.time())')
+out=$(chrome-use "$@" 2>&1); rc=$?
+ms=$(python3 -c "import time;print(int((time.time()-$s)*1000))")
+n=$(( $(wc -l < "$LOG") ))
+printf '%s\t%s\t%s\t%s\n' "$n" "$ms" "${#out}" "$*" >> "$LOG"
+printf '%s\n' "$out"
+exit $rc

--- a/bench/replay.sh
+++ b/bench/replay.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Fixed-sequence replay harness — NO model in the loop.
+# Answers "did our change help": per-call wall ms + bytes returned to the model.
+# Usage: bench/replay.sh <task-file> [label]
+#   task-file: one chrome-use argv per line, '#' comments ignored.
+# Emits TSV to bench/results/<label>-<ts>.tsv and a median/total summary.
+set -u
+TASK="${1:?usage: replay.sh <task-file> [label]}"
+LABEL="${2:-$(basename "$TASK" .txt)}"
+BIN="${CHROME_USE_BIN:-chrome-use}"
+OUT="$(dirname "$0")/results"; mkdir -p "$OUT"
+TSV="$OUT/$LABEL-$(date +%Y%m%d-%H%M%S).tsv"
+printf 'n\tms\tbytes\tcmd\n' > "$TSV"
+# Warm the daemon before timing anything. A cold daemon costs ~1.5s of spawn and
+# session rebind, and it lands entirely on whichever command happens to be first
+# — which is how `navigate` got mistaken for a slow command when the real cost
+# was the process start in front of it. Not counted.
+eval "$BIN eval 1+1" >/dev/null 2>&1 || true
+n=0
+while IFS= read -r line; do
+  case "$line" in ''|\#*) continue;; esac
+  n=$((n+1))
+  s=$(python3 -c 'import time;print(time.time())')
+  out=$(eval "$BIN $line" 2>&1)
+  ms=$(python3 -c "import time;print(int((time.time()-$s)*1000))")
+  printf '%s\t%s\t%s\t%s\n' "$n" "$ms" "${#out}" "$line" >> "$TSV"
+done < "$TASK"
+python3 - "$TSV" <<'PY'
+import sys,csv,statistics as st
+rows=list(csv.DictReader(open(sys.argv[1]),delimiter='\t'))
+ms=[int(r['ms']) for r in rows]; by=[int(r['bytes']) for r in rows]
+print(f"file: {sys.argv[1]}")
+print(f"calls={len(rows)}  wall_total={sum(ms)/1000:.1f}s  ms_median={st.median(ms):.0f}  ms_p90={sorted(ms)[int(len(ms)*.9)]}")
+print(f"bytes_total={sum(by)}  bytes_median={st.median(by):.0f}  bytes_max={max(by)}")
+PY
+echo "-> $TSV"

--- a/bench/tasks/hn-observe.txt
+++ b/bench/tasks/hn-observe.txt
@@ -1,0 +1,4 @@
+# Same HN task, one call per page instead of navigate+snapshot.
+navigate https://news.ycombinator.com --observe
+navigate https://news.ycombinator.com/newest --observe
+navigate https://news.ycombinator.com/ask --observe

--- a/bench/tasks/hn.txt
+++ b/bench/tasks/hn.txt
@@ -1,0 +1,7 @@
+# HN: navigate + observe loop. Stable public page, no login.
+navigate https://news.ycombinator.com
+snapshot -i
+navigate https://news.ycombinator.com/newest
+snapshot -i
+navigate https://news.ycombinator.com/ask
+snapshot -i

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1498,6 +1498,24 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                             i += 1;
                         }
                     }
+                    // Output budget: cap the tree at N bytes, cut between nodes,
+                    // and report the cursor to read on from. `--from` resumes.
+                    "--max-bytes" => {
+                        if let Some(v) = rest.get(i + 1) {
+                            if let Ok(n) = v.parse::<u64>() {
+                                obj.insert("maxBytes".to_string(), json!(n));
+                                i += 1;
+                            }
+                        }
+                    }
+                    "--from" => {
+                        if let Some(v) = rest.get(i + 1) {
+                            if let Ok(n) = v.parse::<u64>() {
+                                obj.insert("from".to_string(), json!(n));
+                                i += 1;
+                            }
+                        }
+                    }
                     _ => {}
                 }
                 i += 1;

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -3829,8 +3829,51 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         })
         .collect();
 
+    // `--max-bytes` / `--from`: a comment thread or a long feed can snapshot to
+    // hundreds of kilobytes, nearly all of it prose unrelated to the element the
+    // caller wants — and every one of those bytes lands in an agent's context.
+    // Cut on whole-node boundaries and report what was dropped plus the cursor to
+    // resume from, so a clipped tree is never mistaken for a short page.
+    let budget = cmd
+        .get("maxBytes")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)
+        .filter(|n| *n > 0);
+    let from = cmd.get("from").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let mut budget_info: Option<snapshot::TreeBudget> = None;
+    let tree = match budget {
+        Some(max_bytes) => {
+            let b = snapshot::budget_tree(&tree, max_bytes, from);
+            let kept = b.tree.clone();
+            budget_info = Some(b);
+            kept
+        }
+        // `--from` without a budget still pages, it just has no upper bound.
+        None if from > 0 => {
+            let b = snapshot::budget_tree(&tree, usize::MAX, from);
+            let kept = b.tree.clone();
+            budget_info = Some(b);
+            kept
+        }
+        None => tree,
+    };
+
     let ref_count = refs.len();
     let mut out = json!({ "snapshot": tree, "origin": url, "refs": refs });
+    if let Some(b) = budget_info {
+        if b.truncated() {
+            out["truncated"] = json!(true);
+            out["nodes"] = json!({
+                "total": b.total_nodes,
+                "from": b.from,
+                "to": b.next,
+                "omitted": b.total_nodes - (b.next - b.from),
+            });
+            if b.next < b.total_nodes {
+                out["nextFrom"] = json!(b.next);
+            }
+        }
+    }
     if let Some(note) = dom_note {
         out["note"] = json!(note);
         out["source"] = json!("dom");

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1549,16 +1549,19 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // url change, requests fired) instead of the agent running act→wait→snapshot→
     // diff by hand. Baseline into a THROWAWAY RefMap so a `@ref` the action uses
     // still resolves against the live state.ref_map.
-    const OBSERVABLE_ACTIONS: &[&str] = &[
-        "click", "dblclick", "fill", "type", "press", "select", "check", "uncheck", "evaluate",
-    ];
-    let observe = cmd
+    let observe_requested = cmd
         .get("observe")
         .and_then(|v| v.as_bool())
         .unwrap_or(false)
-        && OBSERVABLE_ACTIONS.contains(&action)
         && state.browser.is_some()
         && !matches!(state.backend_type, BackendType::WebDriver);
+    let observe = observe_requested && OBSERVABLE_ACTIONS.contains(&action);
+    // `navigate --observe`: a page swap shares no nodes with the previous tree,
+    // so a diff would be 100% removals plus 100% additions — strictly worse than
+    // the tree itself, and it pays for two snapshots. Return the fresh
+    // interactive snapshot instead, which is what collapses
+    // `navigate` + `snapshot` into one round trip.
+    let observe_navigation = observe_requested && NAVIGATION_OBSERVABLE_ACTIONS.contains(&action);
     let observe_baseline: Option<(String, String, usize)> = if observe {
         enable_request_tracking(state).await;
         let _ = state.drain_cdp_events();
@@ -1882,6 +1885,43 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                 .or_insert_with(|| Value::Object(serde_json::Map::new()));
             if let Some(d) = data.as_object_mut() {
                 d.insert("observed".into(), Value::Object(observed));
+            }
+        }
+    }
+
+    // `--observe` is a global flag, so it reaches commands that cannot observe.
+    // Say so instead of succeeding silently: a bare `✓ Done` is exactly how a
+    // dropped observation hides, and that silence is what makes the flag look
+    // implemented when it is not.
+    if observe_requested && !observe && !observe_navigation {
+        if let Some(obj) = resp.as_object_mut() {
+            if obj.get("warning").is_none() {
+                obj.insert(
+                    "warning".to_string(),
+                    json!(format!(
+                        "`--observe` is not supported for `{}` and was ignored; it applies to \
+                         {} and {}.",
+                        action,
+                        OBSERVABLE_ACTIONS.join(", "),
+                        NAVIGATION_OBSERVABLE_ACTIONS.join(", ")
+                    )),
+                );
+            }
+        }
+    }
+
+    // `navigate --observe` (and reload/back/forward): attach the post-navigation
+    // interactive snapshot so the caller does not need a second `snapshot` call.
+    // This is the round trip that separated us from a `createBrowserTab` that
+    // returns the page's a11y tree with the tab.
+    if ok && observe_navigation {
+        let snap = observe_snapshot(state).await;
+        if let Some(obj) = resp.as_object_mut() {
+            let data = obj
+                .entry("data")
+                .or_insert_with(|| Value::Object(serde_json::Map::new()));
+            if let Some(d) = data.as_object_mut() {
+                d.insert("observedSnapshot".into(), json!(snap));
             }
         }
     }
@@ -6391,6 +6431,18 @@ fn describe_expect(cmd: &Value) -> String {
 
 /// Cheap interactive+compact snapshot into a THROWAWAY RefMap (so it never
 /// disturbs the session's live `@ref`s) — the baseline/after capture for
+/// Mutating actions that observe by returning the a11y delta they caused.
+pub(crate) const OBSERVABLE_ACTIONS: &[&str] = &[
+    "click", "dblclick", "fill", "type", "press", "select", "check", "uncheck", "evaluate",
+];
+
+/// Actions that replace the whole document. A cross-page diff shares no nodes
+/// with the previous tree, so it degenerates into 100% removals plus 100%
+/// additions — bigger than the tree itself and paying for two snapshots. These
+/// observe by returning the fresh snapshot instead.
+pub(crate) const NAVIGATION_OBSERVABLE_ACTIONS: &[&str] =
+    &["navigate", "reload", "back", "forward"];
+
 /// `--observe`. Returns "" on failure so a snapshot error never breaks the action.
 async fn observe_snapshot(state: &DaemonState) -> String {
     let Some(mgr) = state.browser.as_ref() else {
@@ -14681,5 +14733,45 @@ mod tests {
 
         assert_eq!(dialog.dialog_type, "confirm");
         assert_eq!(dialog.message, "Delete it?");
+    }
+
+    /// `--observe` routes by action kind: same-page mutations return a delta,
+    /// document replacements return the fresh tree. An action in BOTH lists
+    /// would attach two payloads and double the snapshot cost.
+    #[test]
+    fn observe_action_lists_are_disjoint() {
+        for action in OBSERVABLE_ACTIONS {
+            assert!(
+                !NAVIGATION_OBSERVABLE_ACTIONS.contains(action),
+                "`{action}` is in both observe lists"
+            );
+        }
+    }
+
+    /// A cross-page diff is 100% removals plus 100% additions, so `navigate`
+    /// must observe by snapshot, never by delta.
+    #[test]
+    fn navigation_actions_observe_by_snapshot_not_delta() {
+        for action in ["navigate", "reload", "back", "forward"] {
+            assert!(
+                NAVIGATION_OBSERVABLE_ACTIONS.contains(&action),
+                "`{action}` replaces the document but does not observe"
+            );
+            assert!(
+                !OBSERVABLE_ACTIONS.contains(&action),
+                "`{action}` would be diffed across a page swap"
+            );
+        }
+    }
+
+    /// The delta path stays on same-page mutations.
+    #[test]
+    fn same_page_mutations_observe_by_delta() {
+        for action in ["click", "fill", "select", "evaluate"] {
+            assert!(
+                OBSERVABLE_ACTIONS.contains(&action),
+                "`{action}` mutates the page but does not observe"
+            );
+        }
     }
 }

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -2859,5 +2859,4 @@ mod tests {
         assert!(b.truncated());
         assert_eq!(b.next, 1);
     }
-
 }

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -2252,6 +2252,60 @@ fn count_indent(line: &str) -> usize {
 /// token cap and buries the target controls. `--filter "SSH|端口|应用|确定"` cuts
 /// it down to the few relevant lines (issue #65) — the productized form of the
 /// `| tail -80` workaround, but tree-aware and ref-preserving.
+/// What a budgeted snapshot left out, so the caller knows the tree is partial
+/// and how to read the rest.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TreeBudget {
+    /// The kept slice of the tree.
+    pub tree: String,
+    /// Total nodes (lines) in the full tree, before budgeting.
+    pub total_nodes: usize,
+    /// Index of the first node in `tree`.
+    pub from: usize,
+    /// Index one past the last node in `tree`; also the cursor to resume at.
+    pub next: usize,
+}
+
+impl TreeBudget {
+    pub fn truncated(&self) -> bool {
+        self.from > 0 || self.next < self.total_nodes
+    }
+}
+
+/// Cut a snapshot to a byte budget on whole-node boundaries.
+///
+/// A snapshot of a comment thread or a long feed can run to hundreds of
+/// kilobytes, nearly all of it prose that has nothing to do with the element
+/// the caller is after. Truncating the string would leave the caller unable to
+/// tell a short page from a clipped one, and could sever a node mid-line so the
+/// last `[ref=eN]` no longer parses. So cut between nodes and report the range
+/// that was dropped plus the cursor to resume from.
+///
+/// At least one node is always returned, even when it alone exceeds the budget:
+/// an empty tree would read as "nothing on the page".
+pub fn budget_tree(tree: &str, max_bytes: usize, from: usize) -> TreeBudget {
+    let lines: Vec<&str> = tree.lines().collect();
+    let total_nodes = lines.len();
+    let from = from.min(total_nodes);
+    let mut used = 0usize;
+    let mut next = from;
+    for line in &lines[from..] {
+        // +1 for the newline this line will be joined with.
+        let cost = line.len() + 1;
+        if used + cost > max_bytes && next > from {
+            break;
+        }
+        used += cost;
+        next += 1;
+    }
+    TreeBudget {
+        tree: lines[from..next].join("\n"),
+        total_nodes,
+        from,
+        next,
+    }
+}
+
 pub fn filter_tree(tree: &str, pattern: &str) -> Result<String, String> {
     let re = regex_lite::Regex::new(&format!("(?i){pattern}"))
         .map_err(|e| format!("invalid --filter regex '{pattern}': {e}"))?;
@@ -2750,4 +2804,60 @@ mod tests {
 
         assert_eq!(nodes[0].role, "LabelText"); // unchanged
     }
+    /// A budget must cut between nodes: a severed line would leave a dangling
+    /// `[ref=eN]` the caller cannot use, and no way to tell it was severed.
+    #[test]
+    fn budget_tree_cuts_on_node_boundaries() {
+        let tree = "- a [ref=e1]\n- b [ref=e2]\n- c [ref=e3]\n";
+        let b = budget_tree(tree, 20, 0);
+        assert!(b.truncated());
+        assert!(b.tree.lines().all(|l| l.ends_with(']')));
+        assert_eq!(b.total_nodes, 3);
+        assert_eq!(b.from, 0);
+    }
+
+    /// A tree that fits is not reported as truncated — otherwise every caller
+    /// passing a budget would be told to page through a complete page.
+    #[test]
+    fn budget_tree_untruncated_when_it_fits() {
+        let tree = "- a\n- b\n";
+        let b = budget_tree(tree, 10_000, 0);
+        assert!(!b.truncated());
+        assert_eq!(b.next, b.total_nodes);
+        assert_eq!(b.tree, "- a\n- b");
+    }
+
+    /// `--from` must resume exactly where the previous page stopped, with no
+    /// node repeated and none skipped.
+    #[test]
+    fn budget_tree_from_cursor_covers_every_node_once() {
+        let tree = (0..50)
+            .map(|i| format!("- node{i} [ref=e{i}]"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut seen: Vec<String> = Vec::new();
+        let mut from = 0;
+        loop {
+            let b = budget_tree(&tree, 64, from);
+            seen.extend(b.tree.lines().map(String::from));
+            if b.next >= b.total_nodes {
+                break;
+            }
+            assert!(b.next > from, "cursor must advance");
+            from = b.next;
+        }
+        assert_eq!(seen, tree.lines().collect::<Vec<_>>());
+    }
+
+    /// A single node bigger than the whole budget still comes back. Returning
+    /// nothing would read as an empty page.
+    #[test]
+    fn budget_tree_always_returns_at_least_one_node() {
+        let tree = "- an extremely long node label that alone blows the budget\n- b";
+        let b = budget_tree(tree, 5, 0);
+        assert_eq!(b.tree.lines().count(), 1);
+        assert!(b.truncated());
+        assert_eq!(b.next, 1);
+    }
+
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -562,6 +562,13 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             if let Some(w) = data.get("warning").and_then(|v| v.as_str()) {
                 eprintln!("⚠ navigation: {w}");
             }
+            // `navigate --observe`: the post-navigation interactive snapshot rides
+            // along so the caller does not spend a second round trip on
+            // `snapshot`. The navigation branch returns before the generic
+            // success path, so render it here too.
+            if let Some(snap) = data.get("observedSnapshot").and_then(|v| v.as_str()) {
+                print_observed_snapshot(snap);
+            }
             return;
         }
         if let Some(cdp_url) = data.get("cdpUrl").and_then(|v| v.as_str()) {
@@ -1627,6 +1634,17 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             return;
         }
 
+        // `--observe` payload. The daemon has always attached the post-action
+        // a11y delta under `data.observed`, but only `--json` ever showed it:
+        // text mode fell straight through to a bare `✓ Done` and dropped the
+        // whole thing, so the flag looked like a no-op to anyone not passing
+        // `--json`. Render it here so one call really does replace
+        // act → wait → snapshot → diff.
+        let observed = data.get("observed").and_then(|v| v.as_object());
+        // `navigate --observe` has no comparable baseline across a page swap, so
+        // the daemon attaches a fresh interactive snapshot instead of a delta.
+        let observed_snapshot = data.get("observedSnapshot").and_then(|v| v.as_str());
+
         // Default success. A soft warning carried in the data (e.g. `type`
         // read back a value that does not contain what was typed, #203) must
         // not hide behind a bare ✓ — surface it on stderr.
@@ -1638,6 +1656,11 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
         }
         if let Some(w) = data_warning {
             eprintln!("{} {}", color::warning_indicator(), w);
+        }
+        if let Some(obs) = observed {
+            print_observed(obs);
+        } else if let Some(snap) = observed_snapshot {
+            print_observed_snapshot(snap);
         }
     } else {
         // Success response with no data payload — still confirm the command ran
@@ -4470,6 +4493,73 @@ Hit a bug or rough edge? A 30-second issue genuinely sharpens this tool:
   https://github.com/leeguooooo/chrome-use/issues
 "#
     );
+}
+
+/// Render a `--observe` payload in text mode.
+///
+/// The daemon returns `changed` plus, when something moved, a unified `delta`
+/// over the interactive a11y tree, an `urlChanged` pair and the requests the
+/// action fired. Printing "no change" explicitly matters as much as printing
+/// the delta: a silent `✓ Done` is indistinguishable from the flag being
+/// ignored, which is exactly how this went unnoticed.
+fn print_observed(obs: &serde_json::Map<String, serde_json::Value>) {
+    let changed = obs
+        .get("changed")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if !changed {
+        println!("{}", color::dim("observed: no change"));
+        return;
+    }
+    if let Some(url) = obs.get("urlChanged").and_then(|v| v.as_object()) {
+        let from = url.get("from").and_then(|v| v.as_str()).unwrap_or("");
+        let to = url.get("to").and_then(|v| v.as_str()).unwrap_or("");
+        println!("{} {} → {}", color::dim("observed url:"), from, color::cyan(to));
+    }
+    if let Some(delta) = obs.get("delta").and_then(|v| v.as_str()) {
+        let added = obs.get("added").and_then(|v| v.as_i64()).unwrap_or(0);
+        let removed = obs.get("removed").and_then(|v| v.as_i64()).unwrap_or(0);
+        println!(
+            "{} {} added, {} removed",
+            color::dim("observed:"),
+            color::green(&added.to_string()),
+            color::red(&removed.to_string())
+        );
+        for line in delta.lines() {
+            // Skip the `--- before` / `+++ after` file headers: there are no
+            // files here, and they read as two phantom removals/additions.
+            if line.starts_with("--- ") || line.starts_with("+++ ") {
+                continue;
+            }
+            if line.starts_with('+') {
+                println!("{}", color::green(line));
+            } else if line.starts_with('-') {
+                println!("{}", color::red(line));
+            } else {
+                println!("{}", color::dim(line));
+            }
+        }
+    }
+    if let Some(reqs) = obs.get("requests").and_then(|v| v.as_array()) {
+        if !reqs.is_empty() {
+            println!("{} {}", color::dim("observed requests:"), reqs.len());
+            for r in reqs.iter().filter_map(|v| v.as_str()) {
+                println!("  {}", color::dim(r));
+            }
+        }
+    }
+}
+
+/// Render the fresh post-navigation snapshot that `navigate --observe` attaches.
+/// A cross-page diff would be 100% removals plus 100% additions, so navigation
+/// returns the new tree instead of a delta.
+fn print_observed_snapshot(snapshot: &str) {
+    if snapshot.trim().is_empty() {
+        println!("{}", color::dim("observed: (no interactive elements)"));
+        return;
+    }
+    println!("{}", color::dim("observed snapshot:"));
+    println!("{}", snapshot.trim_end());
 }
 
 fn print_snapshot_diff(data: &serde_json::Map<String, serde_json::Value>) {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -636,10 +636,7 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                     ))
                 );
                 if let Some(next) = data.get("nextFrom").and_then(|v| v.as_i64()) {
-                    eprintln!(
-                        "{}",
-                        color::dim(&format!("read on with: --from {next}"))
-                    );
+                    eprintln!("{}", color::dim(&format!("read on with: --from {next}")));
                 }
             }
             return;
@@ -4551,7 +4548,12 @@ fn print_observed(obs: &serde_json::Map<String, serde_json::Value>) {
     if let Some(url) = obs.get("urlChanged").and_then(|v| v.as_object()) {
         let from = url.get("from").and_then(|v| v.as_str()).unwrap_or("");
         let to = url.get("to").and_then(|v| v.as_str()).unwrap_or("");
-        println!("{} {} → {}", color::dim("observed url:"), from, color::cyan(to));
+        println!(
+            "{} {} → {}",
+            color::dim("observed url:"),
+            from,
+            color::cyan(to)
+        );
     }
     if let Some(delta) = obs.get("delta").and_then(|v| v.as_str()) {
         let added = obs.get("added").and_then(|v| v.as_i64()).unwrap_or(0);

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -609,6 +609,39 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             if let Some(note) = data.get("note").and_then(|v| v.as_str()) {
                 eprintln!("{}", color::dim(note));
             }
+            // `--max-bytes`/`--from`: say what was left out and how to read on.
+            // A budgeted tree that printed nothing about its own truncation is
+            // indistinguishable from a short page, which is the failure this
+            // whole feature exists to prevent.
+            if data
+                .get("truncated")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                let nodes = data.get("nodes").and_then(|v| v.as_object());
+                let get = |k: &str| {
+                    nodes
+                        .and_then(|n| n.get(k))
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0)
+                };
+                eprintln!(
+                    "{}",
+                    color::yellow(&format!(
+                        "truncated: nodes {}–{} of {} ({} omitted)",
+                        get("from"),
+                        get("to"),
+                        get("total"),
+                        get("omitted")
+                    ))
+                );
+                if let Some(next) = data.get("nextFrom").and_then(|v| v.as_i64()) {
+                    eprintln!(
+                        "{}",
+                        color::dim(&format!("read on with: --from {next}"))
+                    );
+                }
+            }
             return;
         }
         // Frame list (`chrome-use frames`)
@@ -2571,6 +2604,10 @@ Options:
   -c, --compact        Remove empty structural elements
   -d, --depth <n>      Limit tree depth
   -s, --selector <sel> Scope snapshot to CSS selector
+  --max-bytes <n>      Cap the tree at n bytes, cut between nodes (never
+                       mid-node). Reports what was omitted and a --from cursor.
+                       For long feeds/comment threads whose bulk is prose.
+  --from <n>           Resume a budgeted snapshot at node n.
   -f, --filter <regex> Keep only lines matching <regex> (case-insensitive) + their
                        ancestor context; refs preserved. For desktop-shell apps
                        (Synology DSM, NAS/router panels) where one snapshot holds


### PR DESCRIPTION
两个改动，都来自一次跟 Codex 的 browser-use 并排基准。

## 起因

对比测下来，差距不在传输 —— 我们单次调用 0.86s 比对方 1.01s 还快 —— 而在**每个任务要几次往返**。而每次往返附带的模型时间实测中位数 6–7.7 秒，工具时间只占其中零头。

复盘一个真实任务（HN 找评论最多的帖子并打开）的往返来源，发现不可省的两次是 `navigate` + `snapshot`，而对方的 `createBrowserTab` 打开页面时就带回了 a11y 树。差距不是「不能批处理」，是**状态变更命令不自带观察**。

## 1. `--observe` 从「看起来是空操作」变成真能用

`--observe` 一直是对的，只是没人看得见：daemon 从来都在 `data.observed` 里挂了动作后的 a11y delta，但**只有 `--json` 会显示它**。文本模式直接落到默认的 `✓ Done` 分支，把整个 delta 丢掉。

```
$ chrome-use fill "textarea[name=q]" "world" --observe
✓ Done
observed: 18 added, 6 removed
-- combobox "搜索" [expanded=false, ref=e16]
+- combobox "搜索" [expanded=true, ref=e17]: world
+- listbox [ref=e14]
+  - option "world cup" [ref=e18]
```

同时新增 `navigate` / `reload` / `back` / `forward` 的 `--observe`，返回导航后的**快照**而不是 diff —— 跨页 diff 与前一棵树没有共同节点，会退化成 100% 删除加 100% 新增，比树本身还大，还要付两次快照的钱。

`--observe` 是全局 flag，落到不支持的命令上不再无声无息。

同一个任务、同一个二进制、无模型回放，3 次取中位数：

```
navigate + snapshot   calls=6  wall=2.6s  bytes=41,018
navigate --observe    calls=3  wall=1.8s  bytes=40,595
```

**往返减半，字节不变。** 墙钟只省 0.8 秒是预期的 —— 工具时间从来不是瓶颈，省的是那 3 次往返各自附带的模型时间。

## 2. `snapshot --max-bytes` / `--from`

一个评论页能 snapshot 到 140,003 字节，绝大部分是跟目标元素无关的正文，而这些字节全都落进 agent 的上下文。之前唯一的出路是 `-i/-s/-d/-f`，它们都要求你**事先知道**要找什么。

```
$ chrome-use snapshot -i --max-bytes 4000
…
truncated: nodes 0–70 of 1901 (1831 omitted)
read on with: --from 70
```

140,003 → 3,769 字节。三条不变量各有测试守着：

- **只在整节点边界切** —— 截字符串会留下残缺的 `[ref=eN]`，调用方既用不了也看不出它是残的
- **单节点超预算也至少返回一个** —— 返回空会被读成「这页什么都没有」
- **装得下就不标 truncated** —— 否则每个传了预算的调用方都会被告知去翻一个完整页面

裁剪信息走 stderr。**一棵被裁过却什么都不说的树，和一个短页面是无法区分的**，而这正是这个特性存在的理由。

## 附带：bench/

无模型的固定序列回放（`replay.sh`）、带日志的 chrome-use 包装（`cu`）、从 Codex rollout 日志提取参考线的脚本。

README 里记了两个把我坑过的地方：**基准必须打在新构建的二进制上**（拿 PATH 上的旧版测仓库源码，量到的是版本差不是改动），以及**必须预热**（daemon 冷启动约 1.5 秒会全部落在回放的第一条命令头上 —— 这个假象一度让我以为 navigate 比 snapshot 慢 5 倍，实测两者首次都约 1.9 秒、之后约 300 毫秒）。

## 测试

1174 单测通过（新增 7 个）。两项特性均在真实页面上验证过。

https://claude.ai/code/session_01YBrHUJnzXRfGbVZapEnCh5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snapshot size limits and pagination with `--max-bytes` and `--from`.
  * Snapshot results now report truncation details and continuation cursors.
  * `--observe` now displays updated accessibility information after page changes and navigation, including interactive snapshots where applicable.
  * Text output includes URL changes, accessibility updates, captured requests, and no-change status.

* **Documentation**
  * Added guidance and scripts for browser-agent benchmarking, replaying tasks, and analyzing performance results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->