### PR TITLE
观察前自适应等待、select-text、paste --format、无名控件 @ref 恢复（#228 #227 #226 #224 #229 #231 #215）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,12 @@ one looked entirely reasonable on its own:
 
 `bench/` holds a no-model replay harness for before/after comparisons and a
 script that extracts a reference line from another agent's rollout log. See
-`bench/README.md`.
+`bench/README.md`. The harness records the facts these rules depend on rather
+than trusting you to remember them: which binary answered and its version,
+whether the daemon was warm, the machine's load, the exit code of every call,
+and whether the task reached the end state its `#! assert` line declares. A run
+that gave up halfway looks *cheaper* on round trips and bytes than one that
+finished, so a result without a verdict is not a result.
 
 ## Build and test
 

--- a/README.md
+++ b/README.md
@@ -538,6 +538,12 @@ Whichever takes longest wins, bounded by a 1 second ceiling. A static page
 costs about 100ms; a click that fires an XHR waits for the response instead of
 returning the pre-response tree as though it were the result.
 
+They differ in one way. A plain `snapshot` has no action to react to, so a still
+page is its answer. After a mutating action, `--observe` keeps watching for a
+first reaction for half the ceiling (500ms by default) before reporting
+`changed:false` — otherwise a control that renders on a 300ms timer reads as
+"nothing happened". Only actions that really change nothing pay that.
+
 When the ceiling expires with the page still moving, the reply says so rather
 than passing a mid-transition capture off as settled:
 
@@ -578,7 +584,7 @@ chrome-use select-text @e3 "confirm" --prefix "please "   # select one phrase
 chrome-use select-text @e3 "Hi Sam," --cursor-after       # place the caret
 chrome-use type @e3 " quick note:"                        # continues there
 
-chrome-use paste "line one\nline two" --selector "#notes"
+chrome-use paste $'line one\nline two' --selector "#notes"
 chrome-use paste "<b>bold</b> text" --format html --selector "#editor"
 ```
 

--- a/README.md
+++ b/README.md
@@ -551,6 +551,18 @@ chrome-use snapshot -i --settle-ms 3000   # raise the ceiling for a slow page
 chrome-use snapshot -i --no-settle        # capture now, mid-flight
 ```
 
+Because the wait already happened, the pixels can ride along with it:
+
+```bash
+chrome-use snapshot -i --with-screenshot ./page.png
+chrome-use click @e8 --observe --with-screenshot ./after.png
+```
+
+Both captures come from that one settled moment — two separately-waited
+captures would describe two different states, which is worse than not combining
+them. The tree still goes to stdout and the image to disk: a screenshot is an
+output here, for looking at or attaching, never the way an agent reads a page.
+
 `AGENT_BROWSER_SETTLE_MS` sets the ceiling for every command (0 disables the
 wait) and `AGENT_BROWSER_SETTLE_QUIET_MS` sets the quiet window. Waiting for
 something *specific* is still `wait`'s job: the settle knows the page stopped,

--- a/README.md
+++ b/README.md
@@ -523,6 +523,72 @@ diff and an unchanged page are indistinguishable.
 the string would leave a severed `[ref=eN]` you can neither use nor recognise as
 severed — and reports what it left out plus a cursor to resume from.
 
+## Waiting before a read
+
+An observation is only worth what the page was doing when it was taken.
+`snapshot` and `--observe` wait for the page to stop changing before they
+capture, so you do not have to guess a sleep:
+
+- the DOM has gone 100ms without a mutation,
+- no finite CSS transition or animation is still running (a spinner that loops
+  forever is ignored — it never ends),
+- and no request fired by the action you just ran is still in flight.
+
+Whichever takes longest wins, bounded by a 1 second ceiling. A static page
+costs about 100ms; a click that fires an XHR waits for the response instead of
+returning the pre-response tree as though it were the result.
+
+When the ceiling expires with the page still moving, the reply says so rather
+than passing a mid-transition capture off as settled:
+
+```
+⚠ Page had not settled after 1000ms (request in flight still active) — this
+  capture may be mid-transition.
+```
+
+```bash
+chrome-use snapshot -i --settle-ms 3000   # raise the ceiling for a slow page
+chrome-use snapshot -i --no-settle        # capture now, mid-flight
+```
+
+`AGENT_BROWSER_SETTLE_MS` sets the ceiling for every command (0 disables the
+wait) and `AGENT_BROWSER_SETTLE_QUIET_MS` sets the quiet window. Waiting for
+something *specific* is still `wait`'s job: the settle knows the page stopped,
+not that what you wanted appeared.
+
+## Editing inside a field, and pasting with a MIME type
+
+`fill` replaces a whole value and `type` appends. Two things that needs but
+neither does:
+
+```bash
+chrome-use select-text @e3 "confirm" --prefix "please "   # select one phrase
+chrome-use select-text @e3 "Hi Sam," --cursor-after       # place the caret
+chrome-use type @e3 " quick note:"                        # continues there
+
+chrome-use paste "line one\nline two" --selector "#notes"
+chrome-use paste "<b>bold</b> text" --format html --selector "#editor"
+```
+
+`select-text` works on `<input>`, `<textarea>` and contenteditable. The prefix
+and suffix are context, not part of the selection: with `--prefix "please "` the
+selected text is `confirm`. A phrase that appears more than once is refused with
+the count rather than resolved to the first one, and "not found", "found but not
+with that context" and "too many matches" are three different messages, because
+they have three different fixes. Monaco and CodeMirror keep their own selection
+model and are refused by name — a DOM selection there looks applied and does
+nothing.
+
+`paste` matters wherever typing and pasting produce different documents:
+`type "<b>bold</b>"` gives you those eleven characters, `paste --format html`
+gives you bold text, and a newline stays a newline instead of becoming Enter.
+`--format md` inserts Markdown source as plain text. **The user's real clipboard
+is never touched** — the content rides on a synthetic ClipboardEvent, with no
+`navigator.clipboard` call and no Ctrl+V. Such an event is untrusted and so has
+no default action: an editor that listens gets it through its own handler, and
+one that ignores it gets a real insert instead. The reply names which path ran,
+and a paste that produced nothing is an error rather than a ✓.
+
 ## Actions beyond a click
 
 Some controls do more than click: a disclosure expands, a menu button opens a

--- a/README.zh.md
+++ b/README.zh.md
@@ -214,6 +214,61 @@ chrome-use snapshot -i --max-bytes 4000 --from 70   # 从上次停下的地方�
 **不需要事先知道要找什么**。它只在完整节点边界切开（截字符串会留下残缺的
 `[ref=eN]`，既用不了也看不出是残的），并告诉你漏了哪些、从哪继续。
 
+## 读之前的等待
+
+一次观察值多少，取决于它拍下的那一刻页面在做什么。`snapshot` 和 `--observe`
+会先等页面不再变化再采集，你不需要自己猜一个 sleep：
+
+- DOM 连续 100ms 没有变更，
+- 没有还在跑的有限时长过渡/动画（无限循环的 loading 转圈会被忽略 —— 它永远不结束），
+- 你刚触发的动作发出的请求都已经回来。
+
+以最慢的那个为准，上限 1 秒。静态页面大约只花 100ms；而一次触发 XHR 的点击会等到
+响应回来，而不是把「响应前的树」当成结果返回。
+
+上限到点而页面仍在动时，它会**说出来**，不会把中间态冒充成最终态：
+
+```
+⚠ Page had not settled after 1000ms (request in flight still active) — this
+  capture may be mid-transition.
+```
+
+```bash
+chrome-use snapshot -i --settle-ms 3000   # 慢页面：把上限调高
+chrome-use snapshot -i --no-settle        # 就要中间态：不等，立刻采
+```
+
+`AGENT_BROWSER_SETTLE_MS` 全局设置上限（设 0 关闭等待），
+`AGENT_BROWSER_SETTLE_QUIET_MS` 设置静默窗口。等**某个具体条件**仍然是 `wait`
+的活：settle 只知道页面停了，不知道你要的东西出现了没有。
+
+## 在字段内部编辑，以及带格式粘贴
+
+`fill` 是整体替换，`type` 是追加。有两件事它们都做不到：
+
+```bash
+chrome-use select-text @e3 "确认" --prefix "请"      # 选中其中一段
+chrome-use select-text @e3 "Hi Sam," --cursor-after  # 只放光标
+chrome-use type @e3 " 顺便说一句："                    # 从光标处继续
+
+chrome-use paste "第一行\n第二行" --selector "#notes"
+chrome-use paste "<b>粗体</b>文字" --format html --selector "#editor"
+```
+
+`select-text` 支持 `<input>`、`<textarea>` 和 contenteditable。prefix / suffix
+是**消歧用的上下文，不属于被选中的内容**：`--prefix "请"` 选中的是「确认」。
+出现多次而没有消歧信息时它**报错并说清有几处**，不会替你挑第一个；而且
+「找不到」「找到了但上下文对不上」「有多处」是三条不同的提示 —— 它们的解法本来就不同。
+Monaco 和 CodeMirror 有自己的选区模型，会被点名拒绝：在那上面做 DOM 选区，
+看起来成功、实际什么也没发生。
+
+`paste` 用在「敲字和粘贴结果不一样」的地方：`type "<b>粗体</b>"` 得到的是这几个字符，
+`paste --format html` 得到的才是粗体；换行也保持换行，而不是变成 Enter。
+`--format md` 把 Markdown 源码作为纯文本插入。**全程不碰用户的真实剪贴板** ——
+内容走的是合成 ClipboardEvent，不调用 `navigator.clipboard`，也不模拟 Ctrl+V。
+这种事件是 untrusted 的、没有默认行为：监听 paste 的编辑器从自己的 handler 里拿到内容，
+不监听的则走一次真实插入。回复里会写明走的是哪条路径；两条都没生效时它**报错**，不会打 ✓。
+
 ## 点击之外的动作
 
 有些控件不止能点：折叠块要展开，菜单按钮要弹出，数字框和滑块要按范围步进。

--- a/README.zh.md
+++ b/README.zh.md
@@ -238,6 +238,16 @@ chrome-use snapshot -i --settle-ms 3000   # 慢页面：把上限调高
 chrome-use snapshot -i --no-settle        # 就要中间态：不等，立刻采
 ```
 
+既然已经等过一次，像素就可以搭这趟车：
+
+```bash
+chrome-use snapshot -i --with-screenshot ./page.png
+chrome-use click @e8 --observe --with-screenshot ./after.png
+```
+
+两份采集来自**同一个稳定时刻** —— 各等各的会得到两个时刻的快照，那比不合并还糟。
+结构照旧走 stdout，图片落盘：截图在这里是**输出**，用于看和附上，不是 agent 读页面的方式。
+
 `AGENT_BROWSER_SETTLE_MS` 全局设置上限（设 0 关闭等待），
 `AGENT_BROWSER_SETTLE_QUIET_MS` 设置静默窗口。等**某个具体条件**仍然是 `wait`
 的活：settle 只知道页面停了，不知道你要的东西出现了没有。

--- a/README.zh.md
+++ b/README.zh.md
@@ -226,6 +226,11 @@ chrome-use snapshot -i --max-bytes 4000 --from 70   # 从上次停下的地方�
 以最慢的那个为准，上限 1 秒。静态页面大约只花 100ms；而一次触发 XHR 的点击会等到
 响应回来，而不是把「响应前的树」当成结果返回。
 
+两者有一处不同：单独的 `snapshot` 没有动作要反应，页面静止就是答案；而动作之后的
+`--observe` 会先花上限的一半（默认 500ms）盯着「有没有第一个反应」，才肯报
+`changed:false` —— 否则一个 300ms 后才渲染的控件会被读成「什么都没发生」。
+这份代价只由真的什么都没做的动作承担。
+
 上限到点而页面仍在动时，它会**说出来**，不会把中间态冒充成最终态：
 
 ```
@@ -261,7 +266,7 @@ chrome-use select-text @e3 "确认" --prefix "请"      # 选中其中一段
 chrome-use select-text @e3 "Hi Sam," --cursor-after  # 只放光标
 chrome-use type @e3 " 顺便说一句："                    # 从光标处继续
 
-chrome-use paste "第一行\n第二行" --selector "#notes"
+chrome-use paste $'第一行\n第二行' --selector "#notes"
 chrome-use paste "<b>粗体</b>文字" --format html --selector "#editor"
 ```
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -40,5 +40,43 @@ the change.
 The harness fires an uncounted warmup call first: a cold daemon costs ~1.5s of
 spawn plus session rebind, and it lands entirely on whichever command is first.
 That artifact is what first made `navigate` look ~5x slower than `snapshot`.
+Set `BENCH_WARMUP=0` to measure a cold daemon deliberately — the result file
+records which of the two you did.
 
 Run on an idle machine and repeat 3x — medians, not single runs.
+
+## What a result file records, and why
+
+Round trips and bytes alone rank a run that gave up halfway **above** one that
+finished: fewer calls, fewer bytes. So every run also records whether the task
+actually reached its end state, and under what conditions the numbers were
+taken (issue #231).
+
+A task file declares its end state with `#! assert <expect-args>`, run after the
+sequence through `chrome-use expect`:
+
+    #! assert url contains news.ycombinator.com/ask
+    #! assert text body contains "Ask HN"
+    navigate https://news.ycombinator.com
+    snapshot -i
+
+The TSV then carries, above the per-call rows:
+
+    # binary    /path/to/the/binary/that/answered
+    # version   chrome-use 1.5.105
+    # warm      true
+    # loadavg   0.31 0.28 0.24
+
+and below them one `# assert` line per check plus a `# verdict`. The summary
+prints `PASS`, `FAIL`, or `none` — a task with no assertion is never counted as
+a pass, because "we did not check" and "it worked" must not look the same.
+
+Per-call rows carry the exit code, and the summary counts failed calls
+separately from the total. A failure and the recovery after it are part of what
+a task really costs; folding them into one number is how 17 calls containing 6
+failures read as a cheaper run than 12 clean ones.
+
+Three wrong conclusions in the first pass — "wall clock halved", "navigate is
+5x slower", "the repo source is slower than the release" — each looked entirely
+reasonable in isolation and came from not recording these facts. A README
+warning did not prevent them; the harness recording the facts does.

--- a/bench/cu
+++ b/bench/cu
@@ -6,11 +6,15 @@ LOG="${CU_LOG:-bench/results/live.tsv}"
 # daemon — a version-mismatch restart on every call, and results from the old
 # binary. Same trap the README warns about; the harness itself fell into it.
 BIN="${CHROME_USE_BIN:-chrome-use}"
-[ -f "$LOG" ] || printf 'n\tms\tbytes\tcmd\n' > "$LOG"
+# The exit code is logged alongside the size (issue #231): a call that failed
+# and one that succeeded cost the same round trip, but only one of them did any
+# work, and a log that cannot tell them apart makes a run that fell over look
+# cheap.
+[ -f "$LOG" ] || printf 'n\tms\tbytes\trc\tcmd\n' > "$LOG"
 s=$(python3 -c 'import time;print(time.time())')
 out=$("$BIN" "$@" 2>&1); rc=$?
 ms=$(python3 -c "import time;print(int((time.time()-$s)*1000))")
 n=$(( $(wc -l < "$LOG") ))
-printf '%s\t%s\t%s\t%s\n' "$n" "$ms" "${#out}" "$*" >> "$LOG"
+printf '%s\t%s\t%s\t%s\t%s\n' "$n" "$ms" "${#out}" "$rc" "$*" >> "$LOG"
 printf '%s\n' "$out"
 exit $rc

--- a/bench/replay.sh
+++ b/bench/replay.sh
@@ -1,36 +1,147 @@
 #!/usr/bin/env bash
 # Fixed-sequence replay harness — NO model in the loop.
-# Answers "did our change help": per-call wall ms + bytes returned to the model.
+# Answers "did our change help": per-call wall ms + bytes returned to the model,
+# plus whether the task actually finished and under which conditions it ran.
+#
 # Usage: bench/replay.sh <task-file> [label]
 #   task-file: one chrome-use argv per line, '#' comments ignored.
-# Emits TSV to bench/results/<label>-<ts>.tsv and a median/total summary.
+#              `#! assert <expect-args>` lines are the task's end-state check,
+#              run after the sequence (see bench/README.md).
+#
+# Env:
+#   CHROME_USE_BIN   binary under test (default: chrome-use on PATH — but see
+#                    the README: benchmarking the installed release against repo
+#                    source measures the version skew, not the change)
+#   BENCH_WARMUP=0   skip the warmup call, i.e. measure a COLD daemon on purpose
+#
+# Emits TSV to bench/results/<label>-<ts>.tsv and a summary.
+#
+# Why the extra columns (issue #231): a run that gave up halfway used to look
+# BETTER than one that finished, because it made fewer calls and returned fewer
+# bytes. And three wrong conclusions in the first pass came from not recording
+# whether the daemon was warm or which binary answered. Numbers without those
+# facts are not comparable across runs, so the harness records them rather than
+# the README warning about them.
 set -u
 TASK="${1:?usage: replay.sh <task-file> [label]}"
 LABEL="${2:-$(basename "$TASK" .txt)}"
 BIN="${CHROME_USE_BIN:-chrome-use}"
 OUT="$(dirname "$0")/results"; mkdir -p "$OUT"
 TSV="$OUT/$LABEL-$(date +%Y%m%d-%H%M%S).tsv"
-printf 'n\tms\tbytes\tcmd\n' > "$TSV"
+
+BIN_PATH=$(command -v "$BIN" 2>/dev/null || printf '%s' "$BIN")
+BIN_VERSION=$(eval "$BIN --version" 2>/dev/null | head -1)
+LOADAVG=$(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null \
+  || uptime | sed 's/.*load averages*: //' 2>/dev/null || echo unknown)
+
 # Warm the daemon before timing anything. A cold daemon costs ~1.5s of spawn and
 # session rebind, and it lands entirely on whichever command happens to be first
 # — which is how `navigate` got mistaken for a slow command when the real cost
-# was the process start in front of it. Not counted.
-eval "$BIN eval 1+1" >/dev/null 2>&1 || true
+# was the process start in front of it. Not counted, and recorded either way:
+# a cold run is a legitimate thing to measure, but only if you can tell later
+# that that is what you measured.
+WARM=true
+if [ "${BENCH_WARMUP:-1}" = "0" ]; then
+  WARM=false
+else
+  eval "$BIN eval 1+1" >/dev/null 2>&1 || true
+fi
+
+{
+  printf '# task\t%s\n' "$TASK"
+  printf '# label\t%s\n' "$LABEL"
+  printf '# started\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '# binary\t%s\n' "$BIN_PATH"
+  printf '# version\t%s\n' "${BIN_VERSION:-unknown}"
+  printf '# warm\t%s\n' "$WARM"
+  printf '# loadavg\t%s\n' "$LOADAVG"
+} > "$TSV"
+printf 'n\tms\tbytes\trc\tcmd\n' >> "$TSV"
+
+ASSERTIONS=()
 n=0
 while IFS= read -r line; do
-  case "$line" in ''|\#*) continue;; esac
+  case "$line" in
+    '#!'*)
+      directive="${line#\#!}"
+      directive="${directive# }"
+      case "$directive" in
+        assert\ *) ASSERTIONS+=("${directive#assert }");;
+        *) printf 'unknown directive: %s\n' "$directive" >&2;;
+      esac
+      continue
+      ;;
+    ''|\#*) continue;;
+  esac
   n=$((n+1))
   s=$(python3 -c 'import time;print(time.time())')
-  out=$(eval "$BIN $line" 2>&1)
+  out=$(eval "$BIN $line" 2>&1); rc=$?
   ms=$(python3 -c "import time;print(int((time.time()-$s)*1000))")
-  printf '%s\t%s\t%s\t%s\n' "$n" "$ms" "${#out}" "$line" >> "$TSV"
+  printf '%s\t%s\t%s\t%s\t%s\n' "$n" "$ms" "${#out}" "$rc" "$line" >> "$TSV"
 done < "$TASK"
+
+# The end-state check. A task with no assertion is recorded as `none` rather
+# than as a pass: "we never checked" and "it worked" must not look the same in
+# the results file, which is the whole point of this column.
+verdict=none
+if [ ${#ASSERTIONS[@]} -gt 0 ]; then
+  verdict=pass
+  for a in "${ASSERTIONS[@]}"; do
+    if eval "$BIN expect $a" >/dev/null 2>&1; then
+      printf '# assert\tpass\t%s\n' "$a" >> "$TSV"
+    else
+      printf '# assert\tFAIL\t%s\n' "$a" >> "$TSV"
+      verdict=FAIL
+    fi
+  done
+fi
+printf '# verdict\t%s\n' "$verdict" >> "$TSV"
+
 python3 - "$TSV" <<'PY'
-import sys,csv,statistics as st
-rows=list(csv.DictReader(open(sys.argv[1]),delimiter='\t'))
-ms=[int(r['ms']) for r in rows]; by=[int(r['bytes']) for r in rows]
-print(f"file: {sys.argv[1]}")
-print(f"calls={len(rows)}  wall_total={sum(ms)/1000:.1f}s  ms_median={st.median(ms):.0f}  ms_p90={sorted(ms)[int(len(ms)*.9)]}")
+import sys, statistics as st
+
+path = sys.argv[1]
+meta, rows = {}, []
+for raw in open(path):
+    line = raw.rstrip('\n')
+    if line.startswith('#'):
+        parts = line.lstrip('#').strip().split('\t')
+        if parts and parts[0] not in ('assert',):
+            meta[parts[0]] = '\t'.join(parts[1:])
+        continue
+    parts = line.split('\t')
+    if not parts or parts[0] == 'n':
+        continue
+    rows.append(parts)
+
+ms = [int(r[1]) for r in rows]
+by = [int(r[2]) for r in rows]
+rcs = [int(r[3]) for r in rows]
+failed = [i for i, rc in enumerate(rcs) if rc != 0]
+
+print(f"file: {path}")
+print(f"binary: {meta.get('binary','?')}  version: {meta.get('version','?')}  "
+      f"warm: {meta.get('warm','?')}  loadavg: {meta.get('loadavg','?')}")
+if not rows:
+    print("no calls recorded")
+    raise SystemExit(0)
+print(f"calls={len(rows)}  wall_total={sum(ms)/1000:.1f}s  "
+      f"ms_median={st.median(ms):.0f}  ms_p90={sorted(ms)[int(len(ms)*.9)]}")
 print(f"bytes_total={sum(by)}  bytes_median={st.median(by):.0f}  bytes_max={max(by)}")
+# Failed calls are counted apart from the total, never folded into it: the cost
+# of a failure and its recovery is part of what a task really costs, and hiding
+# it makes a run that gave up look cheap (issue #231).
+ok = len(rows) - len(failed)
+print(f"succeeded={ok}  failed={len(failed)}" +
+      (f"  (calls {', '.join(str(i+1) for i in failed)})" if failed else ""))
+verdict = meta.get('verdict', 'none')
+if verdict == 'pass':
+    print("verdict: PASS — the task reached its asserted end state")
+elif verdict == 'FAIL':
+    print("verdict: FAIL — the sequence ran but the end state is wrong; "
+          "these numbers are not comparable with a passing run")
+else:
+    print("verdict: none — this task has no `#! assert` line, so nothing "
+          "checked that it actually finished")
 PY
 echo "-> $TSV"

--- a/bench/replay.sh
+++ b/bench/replay.sh
@@ -29,8 +29,24 @@ BIN="${CHROME_USE_BIN:-chrome-use}"
 OUT="$(dirname "$0")/results"; mkdir -p "$OUT"
 TSV="$OUT/$LABEL-$(date +%Y%m%d-%H%M%S).tsv"
 
-BIN_PATH=$(command -v "$BIN" 2>/dev/null || printf '%s' "$BIN")
-BIN_VERSION=$(eval "$BIN --version" 2>/dev/null | head -1)
+# Split once, with shell quoting rules but WITHOUT shell evaluation: task files
+# and CHROME_USE_BIN are ordinary text, and running them through `eval` would let
+# a stray `;` or `$(...)` in either execute as a command. python3 is already a
+# dependency of this script, so shlex does the splitting.
+# Sets ARGV to the split result (a global, not a nameref: macOS still ships
+# bash 3.2, where `local -n` does not exist).
+split_into_argv() {
+  ARGV=()
+  local part
+  while IFS= read -r -d '' part; do
+    ARGV[${#ARGV[@]}]="$part"
+  done < <(python3 -c 'import shlex,sys;print("\0".join(shlex.split(sys.argv[1])),end="")' "$1"; printf '\0')
+}
+
+split_into_argv "$BIN"
+BIN_ARGV=("${ARGV[@]}")
+BIN_PATH=$(command -v "${BIN_ARGV[0]}" 2>/dev/null || printf '%s' "${BIN_ARGV[0]}")
+BIN_VERSION=$("${BIN_ARGV[@]}" --version 2>/dev/null | head -1)
 LOADAVG=$(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null \
   || uptime | sed 's/.*load averages*: //' 2>/dev/null || echo unknown)
 
@@ -44,7 +60,7 @@ WARM=true
 if [ "${BENCH_WARMUP:-1}" = "0" ]; then
   WARM=false
 else
-  eval "$BIN eval 1+1" >/dev/null 2>&1 || true
+  "${BIN_ARGV[@]}" eval 1+1 >/dev/null 2>&1 || true
 fi
 
 {
@@ -60,6 +76,9 @@ printf 'n\tms\tbytes\trc\tcmd\n' >> "$TSV"
 
 ASSERTIONS=()
 n=0
+# `set -u` plus an empty array is an error on bash 3.2, and a task line that
+# splits to nothing (only quotes, say) would trip it.
+
 while IFS= read -r line; do
   case "$line" in
     '#!'*)
@@ -74,8 +93,11 @@ while IFS= read -r line; do
     ''|\#*) continue;;
   esac
   n=$((n+1))
+  split_into_argv "$line"
+  if [ ${#ARGV[@]} -eq 0 ]; then continue; fi
+  CALL_ARGV=("${ARGV[@]}")
   s=$(python3 -c 'import time;print(time.time())')
-  out=$(eval "$BIN $line" 2>&1); rc=$?
+  out=$("${BIN_ARGV[@]}" "${CALL_ARGV[@]}" 2>&1); rc=$?
   ms=$(python3 -c "import time;print(int((time.time()-$s)*1000))")
   printf '%s\t%s\t%s\t%s\t%s\n' "$n" "$ms" "${#out}" "$rc" "$line" >> "$TSV"
 done < "$TASK"
@@ -87,7 +109,8 @@ verdict=none
 if [ ${#ASSERTIONS[@]} -gt 0 ]; then
   verdict=pass
   for a in "${ASSERTIONS[@]}"; do
-    if eval "$BIN expect $a" >/dev/null 2>&1; then
+    split_into_argv "$a"
+    if "${BIN_ARGV[@]}" expect "${ARGV[@]}" >/dev/null 2>&1; then
       printf '# assert\tpass\t%s\n' "$a" >> "$TSV"
     else
       printf '# assert\tFAIL\t%s\n' "$a" >> "$TSV"
@@ -98,7 +121,7 @@ fi
 printf '# verdict\t%s\n' "$verdict" >> "$TSV"
 
 python3 - "$TSV" <<'PY'
-import sys, statistics as st
+import math, sys, statistics as st
 
 path = sys.argv[1]
 meta, rows = {}, []
@@ -125,8 +148,11 @@ print(f"binary: {meta.get('binary','?')}  version: {meta.get('version','?')}  "
 if not rows:
     print("no calls recorded")
     raise SystemExit(0)
+# Nearest-rank p90: `int(len * .9)` picks the maximum for 10 calls (index 9),
+# which is a different statistic than the one the label promises.
+p90 = sorted(ms)[math.ceil(len(ms) * 0.9) - 1]
 print(f"calls={len(rows)}  wall_total={sum(ms)/1000:.1f}s  "
-      f"ms_median={st.median(ms):.0f}  ms_p90={sorted(ms)[int(len(ms)*.9)]}")
+      f"ms_median={st.median(ms):.0f}  ms_p90={p90}")
 print(f"bytes_total={sum(by)}  bytes_median={st.median(by):.0f}  bytes_max={max(by)}")
 # Failed calls are counted apart from the total, never folded into it: the cost
 # of a failure and its recovery is part of what a task really costs, and hiding

--- a/bench/tasks/hn-observe.txt
+++ b/bench/tasks/hn-observe.txt
@@ -1,4 +1,6 @@
 # Same HN task, one call per page instead of navigate+snapshot.
+#! assert url contains news.ycombinator.com/ask
+#! assert text body contains "Ask HN"
 navigate https://news.ycombinator.com --observe
 navigate https://news.ycombinator.com/newest --observe
 navigate https://news.ycombinator.com/ask --observe

--- a/bench/tasks/hn.txt
+++ b/bench/tasks/hn.txt
@@ -1,4 +1,6 @@
 # HN: navigate + observe loop. Stable public page, no login.
+#! assert url contains news.ycombinator.com/ask
+#! assert text body contains "Ask HN"
 navigate https://news.ycombinator.com
 snapshot -i
 navigate https://news.ycombinator.com/newest

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -445,6 +445,15 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
             obj.insert("settleMs".to_string(), json!(ms));
         }
     }
+    // `--with-screenshot <path>` (issue #229): structure and pixels from one
+    // call, and — because both are taken after the same settle — from one
+    // moment. Two separately-waited captures would describe two different
+    // states, which is worse than not combining them at all.
+    if let Some(ref path) = flags.with_screenshot {
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("withScreenshot".to_string(), json!(path));
+        }
+    }
 
     Ok(result)
 }
@@ -4808,6 +4817,7 @@ mod tests {
             if_present: false,
             observe: false,
             settle_ms: None,
+            with_screenshot: None,
             profile: None,
             state: None,
             proxy: None,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1539,7 +1539,20 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     "--cursor-after" => {
                         obj.insert("selectionType".to_string(), json!("cursor_after"));
                     }
-                    _ => {}
+                    // The text is ONE argument. An unquoted phrase arrives as
+                    // several, and dropping the tail would select a shorter run
+                    // than asked for while reporting success — say so instead.
+                    extra => {
+                        return Err(ParseError::InvalidValue {
+                            message: format!(
+                                "unexpected argument '{extra}' — select-text takes the text as a \
+                                 single argument, so quote it: select-text {sel} \"{text} \
+                                 {extra}\""
+                            ),
+                            usage: "select-text <@ref|selector> <text> [--prefix <s>] \
+                                    [--suffix <s>] [--cursor-before|--cursor-after]",
+                        });
+                    }
                 }
                 i += 1;
             }
@@ -6581,6 +6594,18 @@ mod tests {
         assert_eq!(cmd["prefix"], "please");
         assert_eq!(cmd["suffix"], ".");
         assert!(cmd.get("selectionType").is_none());
+    }
+
+    /// The text is one argument. An unquoted phrase arrives as several, and
+    /// silently keeping only the first word would select a shorter run than
+    /// asked for — with a ✓ on it.
+    #[test]
+    fn select_text_refuses_an_unquoted_multi_word_phrase() {
+        let err = parse_command(&args("select-text @e3 confirm order"), &default_flags())
+            .expect_err("an extra positional token must not be dropped");
+        let rendered = format!("{err:?}");
+        assert!(rendered.contains("order"), "{rendered}");
+        assert!(rendered.contains("quote"), "{rendered}");
     }
 
     #[test]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -59,6 +59,8 @@ const KNOWN_COMMANDS: &[&str] = &[
     "scroll",
     "hover",
     "select",
+    "select-text",
+    "paste",
     "check",
     "uncheck",
     "tab",
@@ -432,6 +434,15 @@ pub fn parse_command(args: &[String], flags: &Flags) -> Result<Value, ParseError
     if flags.observe {
         if let Some(obj) = result.as_object_mut() {
             obj.insert("observe".to_string(), json!(true));
+        }
+    }
+    // `--settle-ms` / `--no-settle` (issue #228): ceiling on the adaptive wait
+    // an observation makes before capturing. Stamped rather than read from the
+    // environment in the daemon so a per-command override actually reaches it —
+    // the daemon is a long-lived process that does not see this run's flags.
+    if let Some(ms) = flags.settle_ms {
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("settleMs".to_string(), json!(ms));
         }
     }
 
@@ -1476,6 +1487,90 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                 usage: "do <@ref> <action>   (run `actions <@ref>` to list them)",
             })?;
             Ok(json!({ "id": id, "action": "do", "selector": sel, "actionName": act }))
+        }
+
+        // Select a run of text inside an editable element, or place the caret
+        // next to it (issue #226). `fill` replaces everything and `type`
+        // appends; neither can touch one phrase inside a long field.
+        "select-text" => {
+            let sel = rest.first().ok_or(ParseError::MissingArguments {
+                context: "select-text".to_string(),
+                usage: "select-text <@ref|selector> <text> [--prefix <s>] [--suffix <s>] \
+                        [--cursor-before|--cursor-after]",
+            })?;
+            let text = rest.get(1).ok_or(ParseError::MissingArguments {
+                context: "select-text".to_string(),
+                usage: "select-text <@ref|selector> <text>   (the text to select inside it)",
+            })?;
+            let mut cmd = json!({
+                "id": id,
+                "action": "select_text",
+                "selector": sel,
+                "text": text,
+            });
+            let obj = cmd.as_object_mut().unwrap();
+            let mut i = 2;
+            while i < rest.len() {
+                match rest[i] {
+                    "--prefix" => {
+                        if let Some(v) = rest.get(i + 1) {
+                            obj.insert("prefix".to_string(), json!(v));
+                            i += 1;
+                        }
+                    }
+                    "--suffix" => {
+                        if let Some(v) = rest.get(i + 1) {
+                            obj.insert("suffix".to_string(), json!(v));
+                            i += 1;
+                        }
+                    }
+                    "--cursor-before" => {
+                        obj.insert("selectionType".to_string(), json!("cursor_before"));
+                    }
+                    "--cursor-after" => {
+                        obj.insert("selectionType".to_string(), json!("cursor_after"));
+                    }
+                    _ => {}
+                }
+                i += 1;
+            }
+            Ok(cmd)
+        }
+
+        // Paste content with a MIME type instead of typing it (issue #227).
+        // Never touches the user's real clipboard — the payload rides on a
+        // synthetic ClipboardEvent.
+        "paste" => {
+            let mut text_parts: Vec<&str> = Vec::new();
+            let mut cmd = json!({ "id": id, "action": "paste" });
+            let obj = cmd.as_object_mut().unwrap();
+            let mut i = 0;
+            while i < rest.len() {
+                match rest[i] {
+                    "--format" | "-f" => {
+                        if let Some(v) = rest.get(i + 1) {
+                            obj.insert("format".to_string(), json!(v));
+                            i += 1;
+                        }
+                    }
+                    "--selector" | "--on" => {
+                        if let Some(v) = rest.get(i + 1) {
+                            obj.insert("selector".to_string(), json!(v));
+                            i += 1;
+                        }
+                    }
+                    other => text_parts.push(other),
+                }
+                i += 1;
+            }
+            if text_parts.is_empty() {
+                return Err(ParseError::MissingArguments {
+                    context: "paste".to_string(),
+                    usage: "paste <text> [--format text|md|html] [--selector <sel>]",
+                });
+            }
+            obj.insert("text".to_string(), json!(text_parts.join(" ")));
+            Ok(cmd)
         }
 
         // === Snapshot ===
@@ -4712,6 +4807,7 @@ mod tests {
             browser: None,
             if_present: false,
             observe: false,
+            settle_ms: None,
             profile: None,
             state: None,
             proxy: None,
@@ -6457,6 +6553,69 @@ mod tests {
         assert_eq!(cmd["action"], "clipboard");
         assert_eq!(cmd["operation"], "write");
         assert_eq!(cmd["text"], "hello world");
+    }
+
+    /// `select-text`'s prefix/suffix are context for finding the match, so they
+    /// must survive parsing separately from the text — folding either into the
+    /// text would select the wrong span (issue #226).
+    #[test]
+    fn select_text_keeps_context_separate_from_the_target_text() {
+        let cmd = parse_command(
+            &args("select-text @e3 confirm --prefix please --suffix ."),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "select_text");
+        assert_eq!(cmd["selector"], "@e3");
+        assert_eq!(cmd["text"], "confirm");
+        assert_eq!(cmd["prefix"], "please");
+        assert_eq!(cmd["suffix"], ".");
+        assert!(cmd.get("selectionType").is_none());
+    }
+
+    #[test]
+    fn select_text_cursor_modes_are_distinct() {
+        let before = parse_command(
+            &args("select-text @e3 hi --cursor-before"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(before["selectionType"], "cursor_before");
+        let after =
+            parse_command(&args("select-text @e3 hi --cursor-after"), &default_flags()).unwrap();
+        assert_eq!(after["selectionType"], "cursor_after");
+    }
+
+    #[test]
+    fn select_text_without_text_is_an_error_naming_what_is_missing() {
+        let err = parse_command(&args("select-text @e3"), &default_flags()).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("select-text"),
+            "the usage line must name the command: {err:?}"
+        );
+    }
+
+    /// `paste` takes its content as free text, so flags must not be swallowed
+    /// into it and multi-word content must not be truncated (issue #227).
+    #[test]
+    fn paste_separates_its_flags_from_its_content() {
+        let cmd = parse_command(
+            &args("paste hello there --format html --selector #editor"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["action"], "paste");
+        assert_eq!(cmd["text"], "hello there");
+        assert_eq!(cmd["format"], "html");
+        assert_eq!(cmd["selector"], "#editor");
+    }
+
+    #[test]
+    fn paste_defaults_to_plain_text_and_the_focused_element() {
+        let cmd = parse_command(&args("paste hello"), &default_flags()).unwrap();
+        assert_eq!(cmd["text"], "hello");
+        assert!(cmd.get("format").is_none());
+        assert!(cmd.get("selector").is_none());
     }
 
     #[test]

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -33,6 +33,10 @@ pub(crate) const GLOBAL_BOOL_FLAGS: &[&str] = &[
     "--if-present",
     "--optional",
     "--observe",
+    // Adaptive wait before an observation (issue #228). Stripped here for the
+    // same reason: they are global, and a command's positional parsing must not
+    // see them.
+    "--no-settle",
     "--as-strict",
     "-v",
     "--verbose",
@@ -74,6 +78,7 @@ pub(crate) const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
     "--confirm-actions",
     "--config",
     "--engine",
+    "--settle-ms",
     "--screenshot-dir",
     "--screenshot-quality",
     "--screenshot-format",
@@ -335,6 +340,7 @@ fn extract_config_path(args: &[String]) -> Option<Option<String>> {
         "--model",
         "--humanize",
         "--window",
+        "--settle-ms",
     ];
     let mut i = 0;
     while i < args.len() {
@@ -446,6 +452,11 @@ pub struct Flags {
     /// `--if-present`/`--optional`: skip a selector action (success {skipped})
     /// instead of erroring when the target element is absent (issue #65 followup).
     pub if_present: bool,
+    /// `--settle-ms <ms>`: ceiling on the adaptive wait an observation makes
+    /// before capturing (issue #228). `--no-settle` stamps `Some(0)`, which
+    /// skips the wait entirely. `None` means "use AGENT_BROWSER_SETTLE_MS, or
+    /// the default" — it is deliberately distinct from `Some(0)`.
+    pub settle_ms: Option<u64>,
     /// `--observe`: after a mutating action, return only what changed on the page
     /// (a11y delta + url + requests) instead of the agent re-snapshotting.
     pub observe: bool,
@@ -901,6 +912,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
             || config.no_auto_dialog.unwrap_or(false),
         if_present: false,
         observe: false,
+        settle_ms: None,
         model: env::var("AI_GATEWAY_MODEL").ok().or(config.model),
         verbose: false,
         quiet: false,
@@ -1294,6 +1306,17 @@ pub fn parse_flags(args: &[String]) -> Flags {
             }
             "--observe" => {
                 flags.observe = true;
+            }
+            "--no-settle" => {
+                flags.settle_ms = Some(0);
+            }
+            "--settle-ms" => {
+                if let Some(s) = args.get(i + 1) {
+                    if let Ok(n) = s.parse::<u64>() {
+                        flags.settle_ms = Some(n);
+                    }
+                    i += 1;
+                }
             }
             "--model" => {
                 if let Some(s) = args.get(i + 1) {

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -79,6 +79,7 @@ pub(crate) const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
     "--config",
     "--engine",
     "--settle-ms",
+    "--with-screenshot",
     "--screenshot-dir",
     "--screenshot-quality",
     "--screenshot-format",
@@ -341,6 +342,7 @@ fn extract_config_path(args: &[String]) -> Option<Option<String>> {
         "--humanize",
         "--window",
         "--settle-ms",
+        "--with-screenshot",
     ];
     let mut i = 0;
     while i < args.len() {
@@ -457,6 +459,11 @@ pub struct Flags {
     /// skips the wait entirely. `None` means "use AGENT_BROWSER_SETTLE_MS, or
     /// the default" — it is deliberately distinct from `Some(0)`.
     pub settle_ms: Option<u64>,
+    /// `--with-screenshot <path>`: save the pixels alongside a structural
+    /// observation, captured from the same settled state (issue #229). The
+    /// image is an output — something to look at or attach — not an input for
+    /// the agent to read the page from.
+    pub with_screenshot: Option<String>,
     /// `--observe`: after a mutating action, return only what changed on the page
     /// (a11y delta + url + requests) instead of the agent re-snapshotting.
     pub observe: bool,
@@ -913,6 +920,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
         if_present: false,
         observe: false,
         settle_ms: None,
+        with_screenshot: None,
         model: env::var("AI_GATEWAY_MODEL").ok().or(config.model),
         verbose: false,
         quiet: false,
@@ -1315,6 +1323,12 @@ pub fn parse_flags(args: &[String]) -> Flags {
                     if let Ok(n) = s.parse::<u64>() {
                         flags.settle_ms = Some(n);
                     }
+                    i += 1;
+                }
+            }
+            "--with-screenshot" => {
+                if let Some(s) = args.get(i + 1) {
+                    flags.with_screenshot = Some(s.clone());
                     i += 1;
                 }
             }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2031,6 +2031,31 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
         }
     }
 
+    // `--with-screenshot <path>` on an observed action (issue #229): the pixels
+    // for the delta just reported, from the same settled moment. Only for an
+    // observation that actually happened — attaching an image to a command that
+    // observed nothing would be a picture of an unrelated instant.
+    if ok && (observe || observe_navigation) {
+        if let Some(path) = cmd.get("withScreenshot").and_then(|v| v.as_str()) {
+            let shot = companion_screenshot(path, state).await;
+            if let Some(obj) = resp.as_object_mut() {
+                let data = obj
+                    .entry("data")
+                    .or_insert_with(|| Value::Object(serde_json::Map::new()));
+                if let Some(d) = data.as_object_mut() {
+                    match shot {
+                        Ok(saved) => {
+                            d.insert("screenshot".into(), json!(saved));
+                        }
+                        Err(e) => {
+                            d.insert("screenshotError".into(), json!(e));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Auto-report pending JavaScript dialog so agents know why commands may hang
     if action != "dialog" {
         if let Some(ref dialog) = state.pending_dialog {
@@ -4292,7 +4317,40 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
         }
     }
 
+    // `--with-screenshot <path>` (issue #229): the pixels for the tree above,
+    // taken from the state the settle already waited for rather than after a
+    // second wait of its own — two waits would describe two moments, which is
+    // worse than not combining them. Structure still goes to stdout; the image
+    // is written to disk and only its path is reported, because a screenshot is
+    // an output here, never the agent's way of reading the page.
+    if let Some(path) = cmd.get("withScreenshot").and_then(|v| v.as_str()) {
+        match companion_screenshot(path, state).await {
+            Ok(saved) => {
+                out["screenshot"] = json!(saved);
+            }
+            Err(e) => {
+                out["screenshotError"] = json!(e);
+            }
+        }
+    }
+
     Ok(out)
+}
+
+/// Take the screenshot that rides along with a structural observation
+/// (`--with-screenshot`, issue #229).
+///
+/// Delegates to the `screenshot` handler rather than reimplementing the
+/// capture: that path carries the target-drift and blank-image guards a
+/// screenshot needs, and a companion shot deserves them just as much as a
+/// standalone one.
+async fn companion_screenshot(path: &str, state: &mut DaemonState) -> Result<String, String> {
+    let resp = handle_screenshot(&json!({ "path": path }), state).await?;
+    Ok(resp
+        .get("path")
+        .and_then(|v| v.as_str())
+        .unwrap_or(path)
+        .to_string())
 }
 
 /// Resolve a (possibly relative) saved-file path to an absolute one so the CLI

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -853,12 +853,15 @@ impl DaemonState {
                         Some(iframe_sid.as_str()),
                     )
                     .await;
-                if self.har_recording || self.request_tracking {
-                    let _ = mgr
-                        .client
-                        .send_command_no_params("Network.enable", Some(iframe_sid.as_str()))
-                        .await;
-                }
+                // Unconditional, like the page session's own `Network.enable`:
+                // the adaptive settle (#228) counts in-flight requests, and an
+                // iframe whose Network domain was never enabled emits none — so
+                // a fetch driving an iframe's render would look like silence and
+                // the settle would call the page quiet before it was.
+                let _ = mgr
+                    .client
+                    .send_command_no_params("Network.enable", Some(iframe_sid.as_str()))
+                    .await;
                 // Hide automation markers in this cross-origin iframe session too.
                 apply_stealth_via_mgr(mgr, iframe_sid.as_str()).await;
             }
@@ -1032,10 +1035,13 @@ impl DaemonState {
                         false
                     };
 
-                    // Allow Network events from cross-origin iframe sessions
-                    // when HAR recording or request tracking is active.
+                    // Allow Network events from cross-origin iframe sessions. Not
+                    // gated on HAR/request tracking: the in-flight bookkeeping
+                    // below feeds the adaptive settle (#228), which must see an
+                    // iframe's requests whether or not anyone asked to record
+                    // them. The HAR and `network requests` arms stay gated
+                    // individually, so nothing else changes.
                     let iframe_network_event = !session_matches
-                        && (self.har_recording || self.request_tracking)
                         && event.method.starts_with("Network.")
                         && event
                             .session_id
@@ -1942,6 +1948,12 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             })
             .unwrap_or_default();
         let mut observed = serde_json::Map::new();
+        // The diff is the authority on whether the action changed anything: a
+        // mutation made synchronously during dispatch happens before the wait's
+        // observer exists, so `sawChange` alone would report `false` next to a
+        // delta that plainly shows a change.
+        let mut settled = settled;
+        settled.mark_changed(d.changed || url0 != url1);
         observed.insert("settle".into(), settled.to_json());
         observed.insert("changed".into(), json!(d.changed || url0 != url1));
         if d.changed {

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4301,18 +4301,23 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     // (dogfood: the Dead Cell game). When the tree is sparse but a canvas
     // dominates the viewport, tell them to switch to the screenshot-driven path.
     if ref_count < 3 {
-        let canvas_js =
-            "(() => { const c = document.querySelector('canvas'); if (!c) return false; \
-                         const r = c.getBoundingClientRect(); \
-                         return r.width * r.height > innerWidth * innerHeight * 0.5; })()";
-        if let Ok(v) = mgr.evaluate(canvas_js, None).await {
-            if v.as_bool() == Some(true) {
-                out["note"] = json!(
-                    "This page renders to a <canvas> (game / WebGL / editor) and exposes almost no \
-                     accessibility tree — refs won't help. Use `screenshot` to see it, coordinate \
-                     `click <x> <y>` to interact, and `keydown`/`keyup`/`press` for keyboard \
-                     (hold-to-move: `keydown d` … `keyup d`)."
-                );
+        // One probe, two answers. The second is `document.visibilityState`
+        // (issue #215): a tab we drive in the background really is hidden —
+        // focus emulation does not change that — and a page that gates its UI
+        // on visibility renders its "background" branch, which reaches the
+        // agent as a page that is simply empty. Nothing in the tree says why,
+        // so an agent burns turns looking for controls that the page has
+        // deliberately not drawn.
+        let probe_js =
+            "(() => { const c = document.querySelector('canvas'); \
+                         const r = c && c.getBoundingClientRect(); \
+                         return { canvas: !!r && r.width * r.height > innerWidth * innerHeight * 0.5, \
+                                  hidden: document.visibilityState === 'hidden' }; })()";
+        if let Ok(v) = mgr.evaluate(probe_js, None).await {
+            let canvas = v.get("canvas").and_then(|c| c.as_bool()).unwrap_or(false);
+            let hidden = v.get("hidden").and_then(|h| h.as_bool()).unwrap_or(false);
+            if let Some(note) = sparse_tree_note(canvas, hidden) {
+                out["note"] = json!(note);
             }
         }
     }
@@ -4335,6 +4340,41 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     }
 
     Ok(out)
+}
+
+/// Why a snapshot came back with almost nothing in it, when the page itself can
+/// say. Pure so the wording is testable without a browser.
+///
+/// Two causes look identical in the output — an empty tree — and neither is
+/// something the tree itself can express:
+///
+/// - the page paints to a `<canvas>` (game / WebGL / editor), so there is
+///   nothing to put in an accessibility tree in the first place;
+/// - the tab is **hidden**, and the page gates its UI on
+///   `document.visibilityState` (issue #215). We drive tabs in the background
+///   on purpose, and focus emulation does not make a background tab visible —
+///   so a page that does nothing while hidden is doing exactly what it was
+///   written to do, and the agent needs to be told that rather than left
+///   hunting for controls that were never drawn.
+fn sparse_tree_note(canvas: bool, hidden: bool) -> Option<String> {
+    match (canvas, hidden) {
+        (true, _) => Some(
+            "This page renders to a <canvas> (game / WebGL / editor) and exposes almost no \
+             accessibility tree — refs won't help. Use `screenshot` to see it, coordinate \
+             `click <x> <y>` to interact, and `keydown`/`keyup`/`press` for keyboard \
+             (hold-to-move: `keydown d` … `keyup d`)."
+                .to_string(),
+        ),
+        (false, true) => Some(
+            "This tab is hidden (document.visibilityState === 'hidden') — tabs are driven in the \
+             background, and focus emulation does not change that. A page that gates its UI on \
+             visibility will have rendered its background branch, which is why the tree looks \
+             empty. If this page needs to be visible, surface it with `chrome-use bringToFront` \
+             and read it again."
+                .to_string(),
+        ),
+        _ => None,
+    }
 }
 
 /// Take the screenshot that rides along with a structural observation
@@ -13876,6 +13916,28 @@ fn error_response(id: &str, error: &str) -> Value {
 
 #[cfg(test)]
 mod tests {
+    /// An empty tree has two very different causes, and the output cannot tell
+    /// them apart on its own (issues #206 and #215). Canvas wins when both
+    /// hold: a canvas app has no tree to render whether or not anyone is
+    /// looking at it, so "make it visible" would be the wrong advice.
+    #[test]
+    fn a_sparse_tree_says_which_of_the_two_reasons_it_is() {
+        let canvas = sparse_tree_note(true, false).expect("canvas gets a note");
+        assert!(canvas.contains("<canvas>"), "{canvas}");
+        assert!(canvas.contains("screenshot"), "{canvas}");
+
+        let hidden = sparse_tree_note(false, true).expect("a hidden tab gets a note");
+        assert!(hidden.contains("visibilityState"), "{hidden}");
+        // The advice has to be a command that exists and actually surfaces it.
+        assert!(hidden.contains("bringToFront"), "{hidden}");
+        // And it must not repeat the claim that #215 was filed against.
+        assert!(!hidden.contains("'visible'"), "{hidden}");
+
+        assert!(sparse_tree_note(true, true).unwrap().contains("<canvas>"));
+        // An ordinary page that is simply short gets no note at all.
+        assert!(sparse_tree_note(false, false).is_none());
+    }
+
     use super::is_blank_capture_target;
 
     // issue #184: a screenshot must not report ✓ when its capture session is on a

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -383,6 +383,13 @@ pub struct DaemonState {
     pub routes: Arc<RwLock<Vec<RouteEntry>>>,
     pub tracked_requests: Vec<TrackedRequest>,
     pub request_tracking: bool,
+    /// Requests seen going out and not yet finished, as (requestId, start).
+    /// Feeds the adaptive settle (#228): a click that fires an XHR leaves the
+    /// DOM quiet for the whole round trip, so DOM stillness alone would report
+    /// the pre-response tree as the result. Tracked unconditionally — gating it
+    /// on `request_tracking` would make the wait blind unless someone happened
+    /// to ask for `network requests`.
+    pub in_flight_requests: Vec<(String, std::time::Instant)>,
     pub active_frame_id: Option<String>,
     /// Last `snapshot` this session produced, as (url, options fingerprint, tree).
     /// `snapshot --diff` compares against it so a re-read of a mostly-unchanged
@@ -459,6 +466,7 @@ impl DaemonState {
             routes: Arc::new(RwLock::new(Vec::new())),
             tracked_requests: Vec::new(),
             request_tracking: false,
+            in_flight_requests: Vec::new(),
             active_frame_id: None,
             last_snapshot: None,
             iframe_sessions: HashMap::new(),
@@ -499,6 +507,14 @@ impl DaemonState {
 
     fn reset_input_state(&mut self) {
         self.mouse_state = MouseState::default();
+    }
+
+    /// Requests still in flight that started at or after `since` — the network
+    /// half of the adaptive settle (#228). See `settle::pending_requests` for
+    /// why age matters: a stream never finishes, and waiting on one would hold
+    /// every observation to its ceiling.
+    pub fn pending_request_count(&self, since: std::time::Instant) -> usize {
+        super::settle::pending_requests(&self.in_flight_requests, since)
     }
 
     /// Create state with an optional stream client slot and server instance
@@ -1028,6 +1044,39 @@ impl DaemonState {
 
                     if !session_matches && !iframe_network_event {
                         continue;
+                    }
+
+                    // In-flight bookkeeping for the adaptive settle (#228),
+                    // separate from the tracking below because it must run
+                    // whether or not anyone asked for HAR or `network requests`.
+                    match event.method.as_str() {
+                        "Network.requestWillBeSent" => {
+                            if let Some(rid) =
+                                event.params.get("requestId").and_then(|v| v.as_str())
+                            {
+                                let now = std::time::Instant::now();
+                                // A redirect reuses the requestId; keep the
+                                // original start so the chain ages out together.
+                                if !self.in_flight_requests.iter().any(|(id, _)| id == rid) {
+                                    self.in_flight_requests.push((rid.to_string(), now));
+                                }
+                            }
+                            // Bounded: a page that streams forever would
+                            // otherwise grow this list for the session's life.
+                            if self.in_flight_requests.len() > 256 {
+                                let cutoff = std::time::Duration::from_secs(30);
+                                self.in_flight_requests
+                                    .retain(|(_, t)| t.elapsed() < cutoff);
+                            }
+                        }
+                        "Network.loadingFinished" | "Network.loadingFailed" => {
+                            if let Some(rid) =
+                                event.params.get("requestId").and_then(|v| v.as_str())
+                            {
+                                self.in_flight_requests.retain(|(id, _)| id != rid);
+                            }
+                        }
+                        _ => {}
                     }
 
                     match event.method.as_str() {
@@ -1580,6 +1629,10 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     } else {
         None
     };
+    // Marks the point the settle's network signal cares about: a request fired
+    // BY the action starts before the settle does, so anchoring on "now" here
+    // is what lets the wait see it (#228).
+    let action_started_at = std::time::Instant::now();
 
     // On the relay, a cross-process navigation (an OAuth/SSO redirect) can swap the
     // renderer and rotate the CDP sessionId out from under a non-navigate read or
@@ -1610,6 +1663,8 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             "keep" => handle_keep(state).await,
             "stealth_status" => handle_stealth_status(state).await,
             "snapshot" => handle_snapshot(cmd, state).await,
+            "select_text" => handle_select_text(cmd, state).await,
+            "paste" => handle_paste(cmd, state).await,
             "actions" => handle_actions(cmd, state).await,
             "do" => handle_do_action(cmd, state).await,
             "screenshot" => handle_screenshot(cmd, state).await,
@@ -1850,7 +1905,17 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // and attach ONLY the delta vs the baseline (added/removed lines, url change,
     // requests fired). Collapses act→wait→snapshot→diff into one reply.
     if let (true, Some((url0, snap0, req_mark))) = (ok, observe_baseline) {
-        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        // Wait on signals, not on a number (#228). The 250ms this replaces was
+        // wrong in both directions: too short on a slow page, where the delta
+        // described a tree that no longer existed by the time the agent read
+        // it, and pure overhead on a static one.
+        let settled = super::settle::settle(
+            state,
+            super::settle::max_ms_for(cmd),
+            action_started_at,
+            true,
+        )
+        .await;
         let _ = state.drain_cdp_events();
         // Registering: the delta the caller reads names refs it will act on next.
         let snap1 = observe_snapshot_registering(state).await;
@@ -1877,6 +1942,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             })
             .unwrap_or_default();
         let mut observed = serde_json::Map::new();
+        observed.insert("settle".into(), settled.to_json());
         observed.insert("changed".into(), json!(d.changed || url0 != url1));
         if d.changed {
             observed.insert("delta".into(), json!(d.diff));
@@ -1895,6 +1961,13 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                 .or_insert_with(|| Value::Object(serde_json::Map::new()));
             if let Some(d) = data.as_object_mut() {
                 d.insert("observed".into(), Value::Object(observed));
+            }
+            // A delta captured off a page that never went quiet is a guess. Say
+            // so rather than letting it read like the settled result.
+            if let Some(w) = settled.warning() {
+                if obj.get("warning").is_none() {
+                    obj.insert("warning".to_string(), json!(w));
+                }
             }
         }
     }
@@ -1925,6 +1998,22 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
     // This is the round trip that separated us from a `createBrowserTab` that
     // returns the page's a11y tree with the tab.
     if ok && observe_navigation {
+        // `navigate` returns at its load state, which is before client-side
+        // routing, hydration and the first data fetch have finished. Settle on
+        // the page's own signals so the attached tree is the one the agent will
+        // act on, not the shell it briefly was (#228).
+        //
+        // No reaction window here, unlike a same-page action: the change a
+        // navigation makes has already happened, and what comes after it (an
+        // SPA's first data fetch) announces itself on the network signal. A
+        // fully static page would otherwise pay that window for nothing.
+        let settled = super::settle::settle(
+            state,
+            super::settle::max_ms_for(cmd),
+            action_started_at,
+            false,
+        )
+        .await;
         let snap = observe_snapshot_registering(state).await;
         if let Some(obj) = resp.as_object_mut() {
             let data = obj
@@ -1932,6 +2021,12 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                 .or_insert_with(|| Value::Object(serde_json::Map::new()));
             if let Some(d) = data.as_object_mut() {
                 d.insert("observedSnapshot".into(), json!(snap));
+                d.insert("settle".into(), settled.to_json());
+            }
+            if let Some(w) = settled.warning() {
+                if obj.get("warning").is_none() {
+                    obj.insert("warning".to_string(), json!(w));
+                }
             }
         }
     }
@@ -3945,6 +4040,22 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
     if let Some(mgr) = state.browser.as_mut() {
         mgr.resync_targets().await.ok();
     }
+
+    // Wait for the page to stop changing before reading it (#228). `snapshot`
+    // used to capture the instant it was called, which on anything doing
+    // client-side rendering meant the caller read a shell, acted on refs that
+    // were about to be replaced, and blamed the refs. The wait is bounded and
+    // says so when it expires — see `settle`.
+    let settled = super::settle::settle(
+        state,
+        super::settle::max_ms_for(cmd),
+        super::settle::lookback(),
+        // No action of ours to react to: on a plain read, a still page is the
+        // answer, not a reason to keep waiting.
+        false,
+    )
+    .await;
+
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 
@@ -4121,6 +4232,12 @@ async fn handle_snapshot(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
 
     let ref_count = refs.len();
     let mut out = json!({ "snapshot": tree, "origin": url, "refs": refs });
+    out["settle"] = settled.to_json();
+    // A tree read off a page that was still moving is not the page's answer.
+    // Print that rather than let a mid-transition capture pass for a settled one.
+    if let Some(w) = settled.warning() {
+        out["settleWarning"] = json!(w);
+    }
     if want_diff {
         out["diffMode"] = json!(diff_note.is_none());
         if let Some(n) = diff_note {
@@ -4885,6 +5002,101 @@ async fn handle_fill(cmd: &Value, state: &mut DaemonState) -> Result<Value, Stri
     // Echo the input path used (input/contenteditable/codemirror5/monaco/select)
     // so the agent can confirm a rich editor was handled, not silently no-op'd (#41).
     Ok(json!({ "filled": selector, "engine": engine }))
+}
+
+/// `select-text` (issue #226): select one run of text inside an editable
+/// element, or place the caret before/after it.
+///
+/// The gap this closes: `fill` replaces the whole value and `type` appends, so
+/// changing one word in a written paragraph — or putting the cursor somewhere
+/// specific and carrying on — had no route but hand-written `eval`. Needing
+/// `eval` for something this ordinary is the signal that a feature is missing.
+async fn handle_select_text(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let selector = cmd
+        .get("selector")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'selector' parameter")?;
+    let text = cmd
+        .get("text")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'text' parameter")?;
+    let prefix = cmd.get("prefix").and_then(|v| v.as_str()).unwrap_or("");
+    let suffix = cmd.get("suffix").and_then(|v| v.as_str()).unwrap_or("");
+    let mode = interaction::SelectTextMode::parse(
+        cmd.get("selectionType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("text"),
+    )?;
+
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+
+    let result = interaction::select_text(
+        &mgr.client,
+        &session_id,
+        &state.ref_map,
+        selector,
+        text,
+        prefix,
+        suffix,
+        mode,
+        &state.iframe_sessions,
+    )
+    .await?;
+
+    Ok(json!({
+        "selector": selector,
+        "engine": result.get("engine").cloned().unwrap_or(Value::Null),
+        "selected": result.get("selected").cloned().unwrap_or(Value::Null),
+        "start": result.get("start").cloned().unwrap_or(Value::Null),
+        "end": result.get("end").cloned().unwrap_or(Value::Null),
+        "selectionType": cmd
+            .get("selectionType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("text"),
+    }))
+}
+
+/// `paste` (issue #227): put content into the page with a MIME type, without
+/// touching the user's real clipboard.
+///
+/// `type` and `paste` are not interchangeable in a rich-text editor: typing
+/// `<b>bold</b>` gives you those characters, pasting `text/html` gives you bold
+/// text. Newlines differ too — `type` sends Enter, which submits or splits a
+/// block in most editors, while a paste inserts the break.
+async fn handle_paste(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let text = cmd
+        .get("text")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'text' parameter")?;
+    let format = interaction::PasteFormat::parse(
+        cmd.get("format").and_then(|v| v.as_str()).unwrap_or("text"),
+    )?;
+    let selector = cmd.get("selector").and_then(|v| v.as_str());
+
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let session_id = mgr.active_session_id()?.to_string();
+
+    let result = interaction::paste_content(
+        &mgr.client,
+        &session_id,
+        &state.ref_map,
+        selector,
+        text,
+        format,
+        &state.iframe_sessions,
+    )
+    .await?;
+
+    Ok(json!({
+        "pasted": result.get("chars").cloned().unwrap_or(Value::Null),
+        "format": result.get("format").cloned().unwrap_or(Value::Null),
+        // Which path took the content: the page's own paste handler, or our
+        // insert after nobody listened. An agent debugging a rich editor needs
+        // to know which one it got.
+        "engine": result.get("engine").cloned().unwrap_or(Value::Null),
+        "target": selector.map(Value::from).unwrap_or(Value::Null),
+    }))
 }
 
 async fn handle_type(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -8921,3 +8921,278 @@ async fn e2e_paste_html_arrives_as_rich_content() {
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     server.abort();
 }
+
+// ---------------------------------------------------------------------------
+// Nameless controls: a @ref that role + name cannot tell apart (#224)
+// ---------------------------------------------------------------------------
+
+/// A bare `<select>` has no accessible name, so role + name — the signal a
+/// stale ref re-anchors on — matches every `<select>` on the page. The value it
+/// was showing is the one thing that still identifies it, and that is what this
+/// exercises: the node is replaced (stale backendNodeId) and a second nameless
+/// combobox appears, which is exactly the shape that used to be unrecoverable.
+#[tokio::test]
+#[ignore]
+async fn e2e_nameless_ref_recovers_by_the_value_it_was_showing() {
+    let page = r##"<!doctype html><meta charset="utf-8"><title>nameless select</title>
+<div id="host">
+  <select id="sort">
+    <option>Name (A to Z)</option>
+    <option>Price (low to high)</option>
+  </select>
+</div>"##
+        .to_string();
+    let (port, server) = spawn_html_server(page).await;
+    let mut state = DaemonState::new();
+    launch_on(port, &mut state).await;
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let tree = get_data(&resp)["snapshot"].as_str().unwrap_or_default();
+    let line = tree
+        .lines()
+        .find(|l| l.contains("combobox"))
+        .unwrap_or_else(|| panic!("no combobox in snapshot:\n{tree}"));
+    assert!(
+        line.contains("Name (A to Z)"),
+        "the value is the only identity a nameless control has: {line}"
+    );
+    let start = line.find("ref=").expect("line has a ref") + 4;
+    let rest = &line[start..];
+    let end = rest
+        .find(|c: char| !c.is_alphanumeric())
+        .unwrap_or(rest.len());
+    let sort_ref = format!("@{}", &rest[..end]);
+
+    // Replace the node (stale backendNodeId) and add a second nameless
+    // combobox, so role + name now matches two elements and the ref carries no
+    // ordinal to choose with.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "(() => { const el = document.getElementById('sort'); \
+                       el.replaceWith(el.cloneNode(true)); \
+                       const extra = document.createElement('select'); \
+                       extra.innerHTML = '<option>Alpha</option><option>Beta</option>'; \
+                       document.getElementById('host').prepend(extra); \
+                       return true; })()"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "select",
+            "selector": sort_ref,
+            "value": "Price (low to high)"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "evaluate",
+            "script": "document.getElementById('sort').value"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        json!("Price (low to high)"),
+        "the recovery must land on the control the ref named, not the new one"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+/// When the last signal cannot separate them either, the refusal stands — but
+/// it has to say that several elements are indistinguishable, not that the
+/// element is gone. The two have different fixes, and the old wording only
+/// described the one that had not happened.
+#[tokio::test]
+#[ignore]
+async fn e2e_nameless_ref_refusal_says_indistinguishable_not_missing() {
+    let page = r##"<!doctype html><meta charset="utf-8"><title>twin selects</title>
+<div id="host">
+  <select id="sort">
+    <option>Name (A to Z)</option>
+    <option>Price (low to high)</option>
+  </select>
+</div>"##
+        .to_string();
+    let (port, server) = spawn_html_server(page).await;
+    let mut state = DaemonState::new();
+    launch_on(port, &mut state).await;
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let tree = get_data(&resp)["snapshot"].as_str().unwrap_or_default();
+    let line = tree
+        .lines()
+        .find(|l| l.contains("combobox"))
+        .unwrap_or_else(|| panic!("no combobox in snapshot:\n{tree}"));
+    let start = line.find("ref=").expect("line has a ref") + 4;
+    let rest = &line[start..];
+    let end = rest
+        .find(|c: char| !c.is_alphanumeric())
+        .unwrap_or(rest.len());
+    let sort_ref = format!("@{}", &rest[..end]);
+
+    // Two twins now, same role, same (absent) name, same value — and the
+    // original node replaced so the cached id is stale.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "(() => { const el = document.getElementById('sort'); \
+                       const twin = el.cloneNode(true); twin.removeAttribute('id'); \
+                       el.replaceWith(el.cloneNode(true)); \
+                       document.getElementById('host').prepend(twin); \
+                       return true; })()"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "select",
+            "selector": sort_ref,
+            "value": "Price (low to high)"
+        }),
+        &mut state,
+    )
+    .await;
+    let err = resp["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("cannot be told apart"),
+        "the refusal must name the real problem: {err}"
+    );
+    assert!(
+        !err.contains("no element with that role and name"),
+        "and must not claim the element disappeared: {err}"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+// ---------------------------------------------------------------------------
+// Structure and pixels from one call, at one moment (#229)
+// ---------------------------------------------------------------------------
+
+/// `--with-screenshot` exists to save a round trip, but its real constraint is
+/// that both captures describe the *same* state: they ride on the single
+/// settle the observation already performed (#228), instead of each waiting on
+/// its own and describing two different moments.
+#[tokio::test]
+#[ignore]
+async fn e2e_with_screenshot_saves_pixels_alongside_the_tree() {
+    let page = r##"<!doctype html><meta charset="utf-8"><title>with screenshot</title>
+<button id="go">Go</button>
+<div id="out"></div>
+<script>
+document.getElementById('go').addEventListener('click', () => {
+  document.getElementById('out').innerHTML = '<button>Appeared</button>';
+});
+</script>"##
+        .to_string();
+    let (port, server) = spawn_html_server(page).await;
+    let dir = std::env::temp_dir().join(format!(
+        "chrome-use-e2e-shot-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&dir).expect("temp dir should be creatable");
+    let snap_shot = dir.join("snapshot.png");
+    let observe_shot = dir.join("observe.png");
+
+    let mut state = DaemonState::new();
+    launch_on(port, &mut state).await;
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "snapshot",
+            "interactive": true,
+            "withScreenshot": snap_shot.to_string_lossy()
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert!(
+        data["snapshot"].as_str().unwrap_or_default().contains("Go"),
+        "the tree is still the thing you read: {data}"
+    );
+    assert!(
+        data.get("screenshotError").is_none(),
+        "a companion capture that failed must say so, not be dropped: {data}"
+    );
+    let saved = data["screenshot"]
+        .as_str()
+        .expect("the saved path must be reported");
+    assert!(
+        std::fs::metadata(saved)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false),
+        "the reported path must hold a real image: {saved}"
+    );
+
+    // The same on an observed action: the delta and the pixels for it.
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "click",
+            "selector": "#go",
+            "observe": true,
+            "withScreenshot": observe_shot.to_string_lossy()
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert!(
+        data["observed"]["delta"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Appeared"),
+        "the delta must be the post-action one: {data}"
+    );
+    let saved = data["screenshot"]
+        .as_str()
+        .expect("the saved path must be reported");
+    assert!(
+        std::fs::metadata(saved)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false),
+        "the reported path must hold a real image: {saved}"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -8138,3 +8138,786 @@ async fn e2e_a11y_preserves_sibling_frame_dom_order() {
     let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
     server.abort();
 }
+
+// ---------------------------------------------------------------------------
+// Adaptive settle before an observation (#228)
+// ---------------------------------------------------------------------------
+
+/// HTTP server for the settle tests: `/slow` answers after `delay_ms`,
+/// everything else serves `html` immediately. The delayed route is the whole
+/// point — a fetch in flight leaves the DOM perfectly quiet, so it is the case
+/// a page-side "has the DOM stopped" wait cannot see on its own.
+async fn spawn_slow_fetch_server(
+    html: String,
+    delay_ms: u64,
+) -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("HTTP listener should bind");
+    let port = listener
+        .local_addr()
+        .expect("HTTP listener should have an address")
+        .port();
+    let task = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let html = html.clone();
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 4096];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                let slow = request.starts_with("GET /slow");
+                if slow {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
+                let (ctype, body) = if slow {
+                    ("text/plain; charset=utf-8", "late payload".to_string())
+                } else {
+                    ("text/html; charset=utf-8", html)
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    ctype,
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+    (port, task)
+}
+
+/// A click whose result renders 450ms later. The old fixed 250ms sleep captured
+/// the page before the button existed and reported that tree as the result —
+/// the silent wrong answer #228 exists to remove.
+///
+/// The control half matters as much as the assertion: with the wait switched
+/// off (`--no-settle`) the same click observes nothing, which is what proves
+/// the delta came from waiting rather than from the action being slow enough
+/// by luck.
+#[tokio::test]
+#[ignore]
+async fn e2e_settle_waits_for_a_late_render() {
+    let page = r##"<!doctype html><meta charset="utf-8"><title>late render</title>
+<button id="go">Go</button>
+<script>
+document.getElementById('go').addEventListener('click', () => {
+  setTimeout(() => {
+    const b = document.createElement('button');
+    b.textContent = 'Confirmed';
+    document.body.appendChild(b);
+  }, 450);
+});
+</script>"##
+        .to_string();
+    let (port, server) = spawn_html_server(page).await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": format!("http://127.0.0.1:{port}/") }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // Control: no wait, no observation. This is the old behaviour.
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "click",
+            "selector": "#go",
+            "observe": true,
+            "settleMs": 0
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let observed = &get_data(&resp)["observed"];
+    assert_eq!(
+        observed["changed"],
+        json!(false),
+        "with the wait off, the late render must not be visible yet: {observed}"
+    );
+
+    let resp = execute_command(&json!({ "id": "4", "action": "reload" }), &mut state).await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "click",
+            "selector": "#go",
+            "observe": true,
+            "settleMs": 3000
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let observed = &get_data(&resp)["observed"];
+    assert_eq!(observed["settle"]["quiet"], json!(true), "{observed}");
+    // The wait clearly outlasted its quiet window; the exact figure is the
+    // render's remaining time, which depends on how long the click dispatch
+    // itself took, so the delta below is the real assertion.
+    assert!(
+        observed["settle"]["waitedMs"].as_u64().unwrap_or(0) >= 200,
+        "the wait must have covered the late render: {observed}"
+    );
+    assert!(
+        observed["delta"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Confirmed"),
+        "the observed delta must carry the late-rendered button: {observed}"
+    );
+    assert!(
+        resp.get("warning").is_none(),
+        "a page that settled must not be flagged as mid-transition: {resp}"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+/// The signal a page-side wait cannot see: the click fires a fetch, the DOM
+/// stays perfectly still for its whole round trip, and only the response
+/// renders anything. DOM quiet alone would report the pre-response tree.
+#[tokio::test]
+#[ignore]
+async fn e2e_settle_waits_for_an_in_flight_request() {
+    let page = r##"<!doctype html><meta charset="utf-8"><title>slow fetch</title>
+<button id="go">Go</button>
+<script>
+document.getElementById('go').addEventListener('click', async () => {
+  const r = await fetch('/slow');
+  const t = await r.text();
+  const b = document.createElement('button');
+  b.textContent = t;
+  document.body.appendChild(b);
+});
+</script>"##
+        .to_string();
+    let (port, server) = spawn_slow_fetch_server(page, 500).await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": format!("http://127.0.0.1:{port}/") }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "click",
+            "selector": "#go",
+            "observe": true,
+            "settleMs": 4000
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let observed = &get_data(&resp)["observed"];
+    assert_eq!(observed["settle"]["quiet"], json!(true), "{observed}");
+    assert!(
+        observed["delta"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("late payload"),
+        "the wait must outlast the request that renders the result: {observed}"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+/// A static page must not pay for the wait. The old `--observe` slept 250ms
+/// whatever the page was doing; the signal-based wait returns as soon as the
+/// quiet window passes.
+#[tokio::test]
+#[ignore]
+async fn e2e_settle_is_cheap_on_a_static_page() {
+    let page = r##"<!doctype html><meta charset="utf-8"><title>static</title>
+<button>Only button</button>"##
+        .to_string();
+    let (port, server) = spawn_html_server(page).await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": format!("http://127.0.0.1:{port}/") }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "snapshot", "interactive": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["settle"]["quiet"], json!(true), "{data}");
+    let waited = data["settle"]["waitedMs"].as_u64().unwrap_or(u64::MAX);
+    assert!(
+        waited < 400,
+        "a static page must settle on its quiet window, not on the ceiling (waited {waited}ms)"
+    );
+    assert!(
+        data.get("settleWarning").is_none(),
+        "a settled page must not carry a mid-transition warning: {data}"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+/// A page that never stops mutating must still return — and must say that what
+/// it returned may be mid-transition. A ceiling that expires quietly is the
+/// same silent success in a new place.
+#[tokio::test]
+#[ignore]
+async fn e2e_settle_reports_its_ceiling_instead_of_hiding_it() {
+    let page = r##"<!doctype html><meta charset="utf-8"><title>never quiet</title>
+<button>Only button</button>
+<div id="churn"></div>
+<script>
+setInterval(() => {
+  const d = document.getElementById('churn');
+  d.textContent = String(Date.now());
+}, 10);
+</script>"##
+        .to_string();
+    let (port, server) = spawn_html_server(page).await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": format!("http://127.0.0.1:{port}/") }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "snapshot",
+            "interactive": true,
+            "settleMs": 300
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let data = get_data(&resp);
+    assert_eq!(data["settle"]["quiet"], json!(false), "{data}");
+    assert!(
+        data["settle"]["pending"]
+            .as_array()
+            .map(|a| a.iter().any(|v| v == "dom"))
+            .unwrap_or(false),
+        "the DOM was the thing still moving: {data}"
+    );
+    let warning = data["settleWarning"].as_str().unwrap_or_default();
+    assert!(
+        warning.contains("mid-transition"),
+        "an expired ceiling must name what it means: {warning}"
+    );
+    // The tree still comes back — the wait is bounded, not blocking.
+    assert!(
+        data["snapshot"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Only button"),
+        "a page that never settles must still be readable: {data}"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+// ---------------------------------------------------------------------------
+// select-text: select a run of text inside an editable element (#226)
+// ---------------------------------------------------------------------------
+
+/// The page every `select-text` test drives: one field of each family, each
+/// carrying a deliberately repeated phrase so the disambiguation path is
+/// exercised rather than assumed.
+fn select_text_fixture() -> String {
+    r##"<!doctype html><meta charset="utf-8"><title>select text</title>
+<textarea id="ta" rows="4" cols="60">Hi Sam, please confirm the meeting. Please confirm again.</textarea>
+<input id="in" value="one two three two">
+<div id="ce" contenteditable="true">Alpha beta gamma beta delta</div>
+<input id="mail" type="email" value="a@b.com">"##
+        .to_string()
+}
+
+async fn launch_on(port: u16, state: &mut DaemonState) {
+    let resp = execute_command(
+        &json!({
+            "id": "1",
+            "action": "launch",
+            "headless": true,
+            "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+        }),
+        state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": format!("http://127.0.0.1:{port}/") }),
+        state,
+    )
+    .await;
+    assert_success(&resp);
+}
+
+/// `<textarea>`, `<input>` and contenteditable are three different selection
+/// APIs, and the command is only useful if all three land — so all three are
+/// verified from the page's own state, not from the command's own report.
+#[tokio::test]
+#[ignore]
+async fn e2e_select_text_selects_in_each_editable_family() {
+    let (port, server) = spawn_html_server(select_text_fixture()).await;
+    let mut state = DaemonState::new();
+    launch_on(port, &mut state).await;
+
+    // Textarea, disambiguated by prefix: "confirm" appears twice, and the
+    // prefix picks the first without becoming part of the selection.
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "select_text",
+            "selector": "#ta",
+            "text": "confirm",
+            "prefix": "please "
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["selected"], json!("confirm"));
+    assert_eq!(get_data(&resp)["engine"], json!("input"));
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "(() => { const t = document.getElementById('ta'); \
+                       return t.value.slice(t.selectionStart, t.selectionEnd); })()"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        json!("confirm"),
+        "the page's own selection must be the phrase, not the prefix plus it"
+    );
+
+    // Input, disambiguated by prefix: "two" appears twice.
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "select_text",
+            "selector": "#in",
+            "text": "two",
+            "prefix": "three "
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["start"], json!(14));
+
+    // Contenteditable goes through Range/Selection instead.
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "select_text",
+            "selector": "#ce",
+            "text": "gamma"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["engine"], json!("contenteditable"));
+    let resp = execute_command(
+        &json!({
+            "id": "7",
+            "action": "evaluate",
+            "script": "window.getSelection().toString()"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], json!("gamma"));
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+/// "Not found" and "matches too many places" are different problems with
+/// different fixes. Reporting the second as the first sends the agent hunting
+/// for a typo that is not there — the exact confusion #224 records — so each
+/// has to say which it is.
+#[tokio::test]
+#[ignore]
+async fn e2e_select_text_separates_missing_from_ambiguous() {
+    let (port, server) = spawn_html_server(select_text_fixture()).await;
+    let mut state = DaemonState::new();
+    launch_on(port, &mut state).await;
+
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "select_text", "selector": "#in", "text": "two" }),
+        &mut state,
+    )
+    .await;
+    let err = resp["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("matches 2 places") && err.contains("--prefix"),
+        "an ambiguous match must say so and name the way out: {err}"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "select_text", "selector": "#in", "text": "zebra" }),
+        &mut state,
+    )
+    .await;
+    let err = resp["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("No text matching"),
+        "a missing phrase must not read like an ambiguous one: {err}"
+    );
+
+    // Present, but not with that context: a third, distinct answer.
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "select_text",
+            "selector": "#in",
+            "text": "two",
+            "prefix": "nine "
+        }),
+        &mut state,
+    )
+    .await;
+    let err = resp["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("never with the prefix/suffix"),
+        "a context mismatch must not read as a missing phrase: {err}"
+    );
+
+    // A field that cannot hold a selection at all is refused with that reason,
+    // rather than reported as a selection that silently did nothing.
+    let resp = execute_command(
+        &json!({ "id": "6", "action": "select_text", "selector": "#mail", "text": "a@b" }),
+        &mut state,
+    )
+    .await;
+    let err = resp["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("does not support text selection"),
+        "an unselectable input must say why: {err}"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+/// The cursor modes exist so the next `type` lands in the right place. Assert
+/// exactly that, end to end, rather than the offsets the command reports.
+#[tokio::test]
+#[ignore]
+async fn e2e_select_text_cursor_modes_place_the_next_type() {
+    let (port, server) = spawn_html_server(select_text_fixture()).await;
+    let mut state = DaemonState::new();
+    launch_on(port, &mut state).await;
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "select_text",
+            "selector": "#ta",
+            "text": "Hi Sam,",
+            "selectionType": "cursor_after"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["start"], json!(7));
+    assert_eq!(get_data(&resp)["end"], json!(7));
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "type", "selector": "#ta", "text": " quick note:" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "evaluate",
+            "script": "document.getElementById('ta').value"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(
+        get_data(&resp)["result"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with("Hi Sam, quick note: please confirm"),
+        "typing after `--cursor-after` must land at the caret, not at the end: {}",
+        get_data(&resp)["result"]
+    );
+
+    // Selecting text and typing replaces exactly that run — the "change one
+    // phrase in a long field" case that `fill` cannot express.
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "select_text",
+            "selector": "#ce",
+            "text": "gamma"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({ "id": "7", "action": "type", "selector": "#ce", "text": "GAMMA" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let resp = execute_command(
+        &json!({
+            "id": "8",
+            "action": "evaluate",
+            "script": "document.getElementById('ce').textContent"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        json!("Alpha beta GAMMA beta delta"),
+        "the rest of the field must survive"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+// ---------------------------------------------------------------------------
+// paste: content with a MIME type, without the user's clipboard (#227)
+// ---------------------------------------------------------------------------
+
+/// One field with no paste handler at all (the fallback path), one editor that
+/// handles `paste` itself and records what it was given (the event path), and a
+/// clipboard whose methods count their calls — because "we never touch the real
+/// clipboard" is a promise, and a promise nothing checks is a comment.
+fn paste_fixture() -> String {
+    r##"<!doctype html><meta charset="utf-8"><title>paste</title>
+<textarea id="notes" rows="4" cols="60"></textarea>
+<div id="plain" contenteditable="true"></div>
+<div id="editor" contenteditable="true"></div>
+<script>
+window.__clipboardCalls = 0;
+try {
+  navigator.clipboard.writeText = () => { window.__clipboardCalls++; return Promise.resolve(); };
+  navigator.clipboard.readText = () => { window.__clipboardCalls++; return Promise.resolve(''); };
+} catch (e) {}
+window.__seenHtml = null;
+document.getElementById('editor').addEventListener('paste', (e) => {
+  e.preventDefault();
+  window.__seenHtml = e.clipboardData.getData('text/html');
+  document.getElementById('editor').innerHTML = window.__seenHtml || e.clipboardData.getData('text/plain');
+});
+</script>"##
+        .to_string()
+}
+
+/// Multi-line text is one of the two reasons this command exists: `type` turns
+/// a newline into Enter, which submits or splits a block; a paste inserts the
+/// break. And the whole operation must leave the user's clipboard alone.
+#[tokio::test]
+#[ignore]
+async fn e2e_paste_inserts_multiline_without_touching_the_clipboard() {
+    let (port, server) = spawn_html_server(paste_fixture()).await;
+    let mut state = DaemonState::new();
+    launch_on(port, &mut state).await;
+
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "paste",
+            "selector": "#notes",
+            "text": "line one\nline two"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["format"], json!("text"));
+
+    let resp = execute_command(
+        &json!({
+            "id": "4",
+            "action": "evaluate",
+            "script": "document.getElementById('notes').value"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        json!("line one\nline two"),
+        "the newline must survive as a newline"
+    );
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "evaluate", "script": "window.__clipboardCalls" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"],
+        json!(0),
+        "we drive the user's real Chrome: their clipboard must be untouched"
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
+/// `--format html` has to reach an editor as `text/html` — that is the whole
+/// difference from `type`. Verified from the editor's own handler (what it was
+/// handed) and from the resulting markup.
+#[tokio::test]
+#[ignore]
+async fn e2e_paste_html_arrives_as_rich_content() {
+    let (port, server) = spawn_html_server(paste_fixture()).await;
+    let mut state = DaemonState::new();
+    launch_on(port, &mut state).await;
+
+    // An editor that listens: the paste event carries the html to its handler.
+    let resp = execute_command(
+        &json!({
+            "id": "3",
+            "action": "paste",
+            "selector": "#editor",
+            "text": "<b>bold</b> text",
+            "format": "html"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["engine"],
+        json!("paste-event"),
+        "an editor that handles paste must be reached through its handler"
+    );
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "window.__seenHtml" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["result"], json!("<b>bold</b> text"));
+
+    // A contenteditable with no handler: nothing listened, so the content is
+    // inserted for real — and still as markup, not as eleven characters.
+    let resp = execute_command(
+        &json!({
+            "id": "5",
+            "action": "paste",
+            "selector": "#plain",
+            "text": "<b>bold</b> text",
+            "format": "html"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["engine"], json!("insert-html"));
+    let resp = execute_command(
+        &json!({
+            "id": "6",
+            "action": "evaluate",
+            "script": "document.getElementById('plain').innerHTML"
+        }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert!(
+        get_data(&resp)["result"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("<b>bold</b>"),
+        "html must land as markup: {}",
+        get_data(&resp)["result"]
+    );
+
+    let _ = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    server.abort();
+}

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -8411,6 +8411,11 @@ async fn e2e_settle_is_cheap_on_a_static_page() {
 /// A page that never stops mutating must still return — and must say that what
 /// it returned may be mid-transition. A ceiling that expires quietly is the
 /// same silent success in a new place.
+///
+/// The 300ms ceiling here also pins the wait's own arithmetic: the last slice of
+/// the budget is too short to run a real quiet check, and a zero-length quiet
+/// window is satisfied the moment it is tested. That path once turned this exact
+/// page into a confident `quiet: true`.
 #[tokio::test]
 #[ignore]
 async fn e2e_settle_reports_its_ceiling_instead_of_hiding_it() {

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -496,6 +496,17 @@ fn identity_probe_budget() -> std::time::Duration {
     }
 }
 
+/// What re-anchoring found, so the caller can tell "it is gone" from "there are
+/// several and they are indistinguishable" — two situations with two different
+/// fixes, which the old wording collapsed into "no element with that role and
+/// name is on the page now" (issue #224).
+struct Reanchor {
+    /// The node to act on, when exactly one could be identified.
+    target: Option<i64>,
+    /// How many nodes carry the ref's role + name right now.
+    candidates: usize,
+}
+
 /// Read the full accessibility tree and return the node the ref names.
 ///
 /// Prefers `cached` when that node still carries the ref's role + name — the
@@ -503,14 +514,23 @@ fn identity_probe_budget() -> std::time::Duration {
 /// even though nothing changed, and re-anchoring a still-correct ref onto a
 /// different same-labelled element would trade one mis-target for another.
 /// Otherwise falls back to the ref's `nth` match, the same rule the snapshot
-/// used to number duplicates. `None` when nothing carries that identity.
+/// used to number duplicates.
+///
+/// For a control with **no accessible name** — a bare `<select>`, an icon
+/// button — role + name matches every one of its kind on the page, so this
+/// second step has nothing to discriminate with, and a nameless ref whose node
+/// was replaced had no recovery path at all (issue #224). Those get one more
+/// signal before being given up on: the value the snapshot recorded. It is only
+/// ever used to narrow to exactly one candidate; narrowing to none, or still to
+/// several, keeps the refusal — the point is to recover the right element, not
+/// to relax the guard that stops us acting on the wrong one (#162).
 async fn reanchor_ref(
     client: &CdpClient,
     session_id: &str,
     entry: &RefEntry,
     cached: i64,
     iframe_sessions: &HashMap<String, String>,
-) -> Option<i64> {
+) -> Option<Reanchor> {
     let (ax_params, effective_session_id) =
         resolve_ax_session(entry.frame_id.as_deref(), session_id, iframe_sessions);
     let tree: GetFullAXTreeResult = client
@@ -522,17 +542,66 @@ async fn reanchor_ref(
         .await
         .ok()?;
 
-    let matches: Vec<i64> = tree
+    let live: Vec<(i64, String)> = tree
         .nodes
         .iter()
         .filter(|n| !n.ignored.unwrap_or(false))
         .filter(|n| {
             extract_ax_string(&n.role) == entry.role && extract_ax_string(&n.name) == entry.name
         })
-        .filter_map(|n| n.backend_d_o_m_node_id)
+        .filter_map(|n| {
+            n.backend_d_o_m_node_id
+                .map(|id| (id, extract_ax_string(&n.value)))
+        })
         .collect();
 
-    pick_reanchor_target(&matches, cached, entry.nth)
+    let matches: Vec<i64> = live.iter().map(|(id, _)| *id).collect();
+    if let Some(id) = pick_reanchor_target(&matches, cached, entry.nth) {
+        return Some(Reanchor {
+            target: Some(id),
+            candidates: matches.len(),
+        });
+    }
+
+    let by_value = entry
+        .name
+        .is_empty()
+        .then(|| fingerprint_value(entry))
+        .flatten()
+        .and_then(|want| pick_by_value(&live, &want));
+
+    Some(Reanchor {
+        target: by_value,
+        candidates: matches.len(),
+    })
+}
+
+/// The value the snapshot recorded for a ref, if any — a nameless `<select>`
+/// showing "Name (A to Z)" carries its identity there and nowhere else.
+fn fingerprint_value(entry: &RefEntry) -> Option<String> {
+    entry
+        .fingerprint
+        .as_ref()
+        .and_then(|f| f.attrs.get("value"))
+        .filter(|v| !v.is_empty())
+        .cloned()
+}
+
+/// The one candidate carrying `want` as its value, or `None` when none or
+/// several do. Never "the first one": a value shared by two controls has told
+/// us nothing, and guessing is the mis-target the identity guard exists to
+/// prevent (#162).
+fn pick_by_value(live: &[(i64, String)], want: &str) -> Option<i64> {
+    let mut hit = None;
+    for (id, value) in live {
+        if value == want {
+            if hit.is_some() {
+                return None;
+            }
+            hit = Some(*id);
+        }
+    }
+    hit
 }
 
 /// Selection rule for [`reanchor_ref`], split out so it can be tested directly.
@@ -613,12 +682,14 @@ async fn confirmed_backend_node_id(
     // tree also re-confirms the cached node itself, so a probe that merely ran
     // out of budget on a busy page doesn't push a still-correct ref onto a
     // different element.
-    if let Ok(Some(id)) = tokio::time::timeout(
+    let reanchor = tokio::time::timeout(
         recovery_budget,
         reanchor_ref(client, session_id, entry, backend_node_id, iframe_sessions),
     )
     .await
-    {
+    .ok()
+    .flatten();
+    if let Some(id) = reanchor.as_ref().and_then(|r| r.target) {
         if id != backend_node_id {
             eprintln!(
                 "[ref] {ref_id} re-anchored to backendNodeId {id} ({} \"{}\")",
@@ -635,8 +706,46 @@ async fn confirmed_backend_node_id(
     .await
     {
         Ok(Some(id)) => Ok(id),
-        _ => Err(err),
+        // Nothing recovered it. Say which of the two situations this is: the
+        // element is gone, or several indistinguishable ones are on the page.
+        // "No element with that role and name" reads like the first even when
+        // it is the second, which sends the agent looking for something that
+        // has not happened (#224).
+        _ => Err(match reanchor.map(|r| r.candidates) {
+            Some(n) if n > 1 => indistinguishable_ref_error(ref_id, entry, n),
+            _ => err,
+        }),
     }
+}
+
+/// Error for a ref whose identity several live elements share — the nameless
+/// case, where role + name matches every control of its kind.
+///
+/// Refusing here is right (#162: acting on the wrong node is worse than
+/// failing), but the message has to name the real problem and a way out that
+/// works. A fresh `snapshot` does help: it numbers duplicates, so the new ref
+/// carries the ordinal this one lacked.
+fn indistinguishable_ref_error(ref_id: &str, entry: &RefEntry, candidates: usize) -> String {
+    let identity = if entry.name.is_empty() {
+        format!("{} with no accessible name", entry.role)
+    } else {
+        format!("{} \"{}\"", entry.role, entry.name)
+    };
+    let value_hint = match fingerprint_value(entry) {
+        Some(v) => format!(
+            " Its value was \"{v}\" at snapshot time; no live candidate has that value now, so \
+             that could not tell them apart either."
+        ),
+        None => String::new(),
+    };
+    format!(
+        "Ref {ref_id} could not be confirmed, and {candidates} elements on the page are \
+         [{identity}] — they cannot be told apart, so re-anchoring would be a guess rather than \
+         a recovery.{value_hint}\n\
+         Fix: take a fresh `snapshot` (it numbers duplicates, so the new ref carries the ordinal \
+         this one lacks), or address the element directly by CSS selector — `find` prints \
+         `id` / `data-testid` / class anchors for exactly this case."
+    )
 }
 
 /// Resolve a `@ref` or CSS selector to a click point. Returns
@@ -2628,6 +2737,60 @@ mod tests {
         assert!(err.contains("我的 agent"));
         assert!(err.contains("timed out"));
         assert!(err.contains("fresh `snapshot`"));
+    }
+
+    /// A nameless control's identity lives in its value, and that is the only
+    /// signal left once role + name has matched every `<select>` on the page
+    /// (issue #224). It may only ever narrow to exactly one.
+    #[test]
+    fn a_nameless_ref_is_recovered_by_the_value_the_snapshot_recorded() {
+        let live = vec![
+            (11, "Name (A to Z)".to_string()),
+            (12, "Price (low to high)".to_string()),
+        ];
+        assert_eq!(pick_by_value(&live, "Price (low to high)"), Some(12));
+        // Nothing carries it any more: that is not a licence to pick one.
+        assert_eq!(pick_by_value(&live, "Name (Z to A)"), None);
+        // Shared by two: the signal has told us nothing.
+        let dupes = vec![(11, "same".to_string()), (12, "same".to_string())];
+        assert_eq!(pick_by_value(&dupes, "same"), None);
+    }
+
+    /// The failure this issue is about is not "the element vanished" but "there
+    /// are several and nothing tells them apart". Reporting the second as the
+    /// first sends the agent hunting for a disappearance that never happened.
+    #[test]
+    fn an_indistinguishable_ref_says_so_instead_of_reporting_it_missing() {
+        let entry = RefEntry {
+            backend_node_id: Some(7),
+            role: "combobox".to_string(),
+            name: String::new(),
+            nth: None,
+            selector: None,
+            frame_id: None,
+            fingerprint: Some(ElementFingerprint {
+                tag: "combobox".to_string(),
+                attrs: [("value".to_string(), "Name (A to Z)".to_string())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            }),
+            dom_sourced: false,
+        };
+        let err = indistinguishable_ref_error("e7", &entry, 3);
+        assert!(err.contains("e7"), "{err}");
+        assert!(err.contains("3 elements"), "{err}");
+        assert!(err.contains("no accessible name"), "{err}");
+        assert!(err.contains("cannot be told apart"), "{err}");
+        // The old wording claimed the element was gone. It must not come back.
+        assert!(!err.contains("no element with that role and name"), "{err}");
+        // The value it had is worth saying: it is why the last signal failed.
+        assert!(err.contains("Name (A to Z)"), "{err}");
+        // And the way out has to be one that actually works for this case.
+        assert!(
+            err.contains("fresh `snapshot`") && err.contains("CSS selector"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/cli/src/native/element.rs
+++ b/cli/src/native/element.rs
@@ -733,8 +733,8 @@ fn indistinguishable_ref_error(ref_id: &str, entry: &RefEntry, candidates: usize
     };
     let value_hint = match fingerprint_value(entry) {
         Some(v) => format!(
-            " Its value was \"{v}\" at snapshot time; no live candidate has that value now, so \
-             that could not tell them apart either."
+            " Its value was \"{v}\" at snapshot time, which did not single one of them out \
+             either — no live candidate carries it, or more than one does."
         ),
         None => String::new(),
     };

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -3146,6 +3146,553 @@ fn named_key_info(key: &str) -> (String, String, i32) {
     }
 }
 
+/// Where to leave the caret once the match is found (issue #226).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectTextMode {
+    /// Select the matched text itself.
+    Text,
+    /// Collapse to just before the match — a cursor, not a selection.
+    CursorBefore,
+    /// Collapse to just after the match, so a following `type` appends there.
+    CursorAfter,
+}
+
+impl SelectTextMode {
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "text" => Ok(Self::Text),
+            "cursor_before" | "cursor-before" => Ok(Self::CursorBefore),
+            "cursor_after" | "cursor-after" => Ok(Self::CursorAfter),
+            other => Err(format!(
+                "Unknown selection type '{other}'. Use text, cursor-before or cursor-after."
+            )),
+        }
+    }
+
+    fn as_js(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::CursorBefore => "cursor_before",
+            Self::CursorAfter => "cursor_after",
+        }
+    }
+}
+
+/// Turn the page-side refusal into the sentence the agent needs (issue #226).
+///
+/// "Not found" and "too many candidates" are different problems with different
+/// fixes, and this codebase has already paid for conflating them (#224): an
+/// ambiguous match reported as "no match" sends the agent looking for a typo
+/// that is not there. So each reason gets its own wording, and the ambiguous
+/// one names the disambiguators.
+fn select_text_error(result: &Value, selector: &str, text: &str) -> String {
+    let reason = result
+        .get("reason")
+        .and_then(|v| v.as_str())
+        .unwrap_or("failed");
+    let occurrences = result
+        .get("textOccurrences")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let matches = result.get("matches").and_then(|v| v.as_u64()).unwrap_or(0);
+    let detail = result.get("detail").and_then(|v| v.as_str()).unwrap_or("");
+    match reason {
+        "not-found" => format!(
+            "No text matching \"{text}\" in {selector}. The field holds {} characters; \
+             read it with `get value {selector}` to see what is actually there.",
+            result.get("length").and_then(|v| v.as_u64()).unwrap_or(0)
+        ),
+        "context-mismatch" => format!(
+            "\"{text}\" appears {occurrences} time(s) in {selector}, but never with the \
+             prefix/suffix given. The prefix and suffix must sit immediately before and after \
+             the text, and they are not part of what gets selected."
+        ),
+        "ambiguous" => format!(
+            "\"{text}\" matches {matches} places in {selector} — refusing to guess which. \
+             Disambiguate with --prefix / --suffix (the text immediately before or after the \
+             one you mean)."
+        ),
+        "not-editable" => format!(
+            "select-text needs an <input>, <textarea> or contenteditable element; {selector} \
+             is {detail}."
+        ),
+        "unsupported-editor" => format!(
+            "select-text cannot address {detail} — it keeps its own selection model, and a DOM \
+             selection there would look applied while doing nothing. Use `fill` to replace the \
+             whole value."
+        ),
+        "selection-unsupported" => format!(
+            "{selector} is {detail}, which does not support text selection at all \
+             (`setSelectionRange` throws on it). Use `fill` to replace the value."
+        ),
+        "not-applied" => format!(
+            "The selection did not take on {selector} — the element may have re-rendered \
+             between the match and the selection. Re-read the page and try again."
+        ),
+        other => format!("select-text failed on {selector}: {other}"),
+    }
+}
+
+/// Select a run of text inside an editable element, or place the caret next to
+/// it (issue #226).
+///
+/// `prefix`/`suffix` disambiguate a repeated phrase; they are context, not part
+/// of the selection: `select_text(el, "确认", prefix = "请")` selects `确认`,
+/// not `请确认`. A match that is missing, or present more than once with no way
+/// to tell which was meant, is an error naming which of the two it was — never
+/// a silent pick of the first one.
+#[allow(clippy::too_many_arguments)]
+pub async fn select_text(
+    client: &CdpClient,
+    session_id: &str,
+    ref_map: &RefMap,
+    selector_or_ref: &str,
+    text: &str,
+    prefix: &str,
+    suffix: &str,
+    mode: SelectTextMode,
+    iframe_sessions: &HashMap<String, String>,
+) -> Result<Value, String> {
+    if text.is_empty() {
+        return Err("select-text needs the text to select (it cannot be empty).".to_string());
+    }
+    let (object_id, effective_session_id) = resolve_element_object_id(
+        client,
+        session_id,
+        ref_map,
+        selector_or_ref,
+        iframe_sessions,
+    )
+    .await?;
+
+    // Two different selection APIs, because the two element families have
+    // nothing in common: `<input>`/`<textarea>` own a flat string and take
+    // `setSelectionRange`; contenteditable content lives in text nodes, so the
+    // offsets have to be mapped back onto them and applied through a Range.
+    let js = format!(
+        r#"function() {{
+            const TEXT = {text};
+            const PREFIX = {prefix};
+            const SUFFIX = {suffix};
+            const MODE = {mode};
+            let el = this;
+            if (el.shadowRoot) {{
+                const inner = el.shadowRoot.querySelector('input, textarea, [contenteditable]');
+                if (inner) el = inner;
+            }}
+            const editorRoot = el.closest && (el.closest('.monaco-editor') || el.closest('.CodeMirror') || el.closest('.cm-editor'));
+            if (editorRoot) {{
+                const kind = editorRoot.classList.contains('monaco-editor') ? 'a Monaco editor'
+                    : (editorRoot.classList.contains('CodeMirror') ? 'a CodeMirror 5 editor' : 'a CodeMirror 6 editor');
+                return {{ ok: false, reason: 'unsupported-editor', detail: kind }};
+            }}
+            const tag = el.tagName;
+            const isField = tag === 'INPUT' || tag === 'TEXTAREA';
+            if (!isField && !el.isContentEditable) {{
+                return {{ ok: false, reason: 'not-editable', detail: 'a <' + tag.toLowerCase() + '>' }};
+            }}
+
+            // Offsets are computed over the raw text: the field's value, or the
+            // concatenated text nodes for contenteditable (which is what a Range
+            // addresses).
+            let nodes = [];
+            let hay;
+            if (isField) {{
+                hay = el.value;
+            }} else {{
+                const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+                let acc = 0;
+                hay = '';
+                while (walker.nextNode()) {{
+                    const n = walker.currentNode;
+                    nodes.push([acc, n]);
+                    hay += n.data;
+                    acc += n.data.length;
+                }}
+            }}
+
+            const countOf = (needle) => {{
+                if (!needle) return 0;
+                let n = 0, at = hay.indexOf(needle);
+                while (at !== -1) {{ n++; at = hay.indexOf(needle, at + 1); }}
+                return n;
+            }};
+            const needle = PREFIX + TEXT + SUFFIX;
+            const hits = [];
+            let at = hay.indexOf(needle);
+            while (at !== -1) {{ hits.push(at); at = hay.indexOf(needle, at + 1); }}
+            const bare = countOf(TEXT);
+            if (hits.length === 0) {{
+                return {{
+                    ok: false,
+                    reason: bare > 0 ? 'context-mismatch' : 'not-found',
+                    textOccurrences: bare,
+                    length: hay.length
+                }};
+            }}
+            if (hits.length > 1) {{
+                return {{ ok: false, reason: 'ambiguous', matches: hits.length, textOccurrences: bare }};
+            }}
+            const start = hits[0] + PREFIX.length;
+            const end = start + TEXT.length;
+            const from = MODE === 'cursor_after' ? end : start;
+            const to = MODE === 'text' ? end : from;
+
+            try {{ el.focus({{ preventScroll: true }}); }} catch (e) {{}}
+
+            if (isField) {{
+                try {{
+                    el.setSelectionRange(from, to);
+                }} catch (e) {{
+                    return {{
+                        ok: false,
+                        reason: 'selection-unsupported',
+                        detail: 'an <' + tag.toLowerCase() + (el.type ? ' type=' + el.type : '') + '>'
+                    }};
+                }}
+                // Verify the effect, not the call: a field can refuse the range
+                // (or be re-rendered under us) and report nothing.
+                const okSel = el.selectionStart === from && el.selectionEnd === to;
+                return {{
+                    ok: okSel,
+                    reason: okSel ? null : 'not-applied',
+                    engine: 'input',
+                    start: from,
+                    end: to,
+                    selected: el.value.slice(from, to)
+                }};
+            }}
+
+            const locate = (off) => {{
+                for (let k = nodes.length - 1; k >= 0; k--) {{
+                    if (off >= nodes[k][0]) return [nodes[k][1], off - nodes[k][0]];
+                }}
+                return [el, 0];
+            }};
+            const range = document.createRange();
+            const [sn, so] = locate(from);
+            const [en, eo] = locate(to);
+            try {{
+                range.setStart(sn, so);
+                range.setEnd(en, eo);
+            }} catch (e) {{
+                return {{ ok: false, reason: 'not-applied' }};
+            }}
+            const view = el.ownerDocument.defaultView || window;
+            const sel = view.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+            const got = sel.toString();
+            const okSel = MODE === 'text' ? got === TEXT : sel.isCollapsed;
+            return {{
+                ok: okSel,
+                reason: okSel ? null : 'not-applied',
+                engine: 'contenteditable',
+                start: from,
+                end: to,
+                selected: MODE === 'text' ? got : ''
+            }};
+        }}"#,
+        text = serde_json::to_string(text).unwrap_or_default(),
+        prefix = serde_json::to_string(prefix).unwrap_or_default(),
+        suffix = serde_json::to_string(suffix).unwrap_or_default(),
+        mode = serde_json::to_string(mode.as_js()).unwrap_or_default(),
+    );
+
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: js,
+                object_id: Some(object_id),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(&effective_session_id),
+        )
+        .await?;
+
+    if let Some(ex) = result.exception_details {
+        return Err(format!("select-text failed: {}", ex.text));
+    }
+    let value = result.result.value.unwrap_or(Value::Null);
+    if value.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        return Err(select_text_error(&value, selector_or_ref, text));
+    }
+    Ok(value)
+}
+
+/// What `paste` put on the synthetic clipboard (issue #227).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PasteFormat {
+    /// Plain text.
+    Text,
+    /// Markdown *source*, inserted as plain text — the same thing the other
+    /// tool does. Rendering it to HTML first would make the result depend on a
+    /// renderer the caller cannot see; inserting the source is predictable.
+    Markdown,
+    /// Rich text: the payload rides as `text/html`, with the same string as the
+    /// `text/plain` fallback for editors that only read plain text.
+    Html,
+}
+
+impl PasteFormat {
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "text" | "plain" => Ok(Self::Text),
+            "md" | "markdown" => Ok(Self::Markdown),
+            "html" => Ok(Self::Html),
+            other => Err(format!(
+                "Unknown paste format '{other}'. Use text, md or html."
+            )),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Markdown => "md",
+            Self::Html => "html",
+        }
+    }
+}
+
+/// Paste content into the page without going anywhere near the user's real
+/// clipboard (issue #227).
+///
+/// Why this exists: in a rich-text editor, pasting `text/html` and typing the
+/// same characters produce different documents — `type` of `<b>bold</b>` gives
+/// you those eleven characters, a paste gives you bold text. Multi-line text is
+/// the same story: `type` turns a newline into Enter, which in most editors
+/// submits or starts a new block, while a paste inserts the line break.
+///
+/// The clipboard is deliberately untouched. We drive the user's real Chrome, so
+/// overwriting what they had copied is not an acceptable side effect — the
+/// payload is carried by a `DataTransfer` on a synthetic `ClipboardEvent`
+/// instead, and no `navigator.clipboard` call and no Ctrl+V is involved.
+///
+/// A synthetic paste event is untrusted, so it has no default action: an editor
+/// that listens for `paste` handles it, and a plain field ignores it. That is
+/// why the effect is read back, and why an unhandled paste falls through to a
+/// real insert rather than reporting a success nothing produced.
+pub async fn paste_content(
+    client: &CdpClient,
+    session_id: &str,
+    ref_map: &RefMap,
+    selector_or_ref: Option<&str>,
+    text: &str,
+    format: PasteFormat,
+    iframe_sessions: &HashMap<String, String>,
+) -> Result<Value, String> {
+    let want_html = matches!(format, PasteFormat::Html);
+    let probe = format!(
+        r#"function() {{
+            const TEXT = {text};
+            const WANT_HTML = {want_html};
+            let el = this;
+            if (!el || el.nodeType !== 1) {{
+                return {{ ok: false, reason: 'no-target' }};
+            }}
+            if (el.shadowRoot) {{
+                const inner = el.shadowRoot.querySelector('input, textarea, [contenteditable]');
+                if (inner) el = inner;
+            }}
+            const isField = el.tagName === 'INPUT' || el.tagName === 'TEXTAREA';
+            const read = () => (isField ? el.value : (el.isContentEditable ? el.innerHTML : el.textContent));
+            const before = read();
+            try {{ el.focus({{ preventScroll: true }}); }} catch (e) {{}}
+            let handled = false;
+            try {{
+                const dt = new DataTransfer();
+                dt.setData('text/plain', TEXT);
+                if (WANT_HTML) dt.setData('text/html', TEXT);
+                const ev = new ClipboardEvent('paste', {{
+                    clipboardData: dt,
+                    bubbles: true,
+                    cancelable: true
+                }});
+                handled = el.dispatchEvent(ev) === false;
+            }} catch (e) {{
+                return {{ ok: false, reason: 'dispatch-failed', detail: String(e && e.message || e) }};
+            }}
+            return {{
+                ok: true,
+                handled,
+                before,
+                changed: read() !== before,
+                isField,
+                contentEditable: !!el.isContentEditable
+            }};
+        }}"#,
+        text = serde_json::to_string(text).unwrap_or_default(),
+        want_html = want_html,
+    );
+
+    let (object_id, effective_session_id) = match selector_or_ref {
+        Some(sel) => {
+            resolve_element_object_id(client, session_id, ref_map, sel, iframe_sessions).await?
+        }
+        None => (
+            active_element_object_id(client, session_id).await?,
+            session_id.to_string(),
+        ),
+    };
+
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: probe,
+                object_id: Some(object_id.clone()),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(&effective_session_id),
+        )
+        .await?;
+    if let Some(ex) = result.exception_details {
+        return Err(format!("paste failed: {}", ex.text));
+    }
+    let probe_result = result.result.value.unwrap_or(Value::Null);
+    if probe_result.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        let reason = probe_result
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("failed");
+        return Err(match reason {
+            "no-target" => {
+                "paste needs an element: pass a selector/@ref, or focus a field first.".to_string()
+            }
+            other => format!("paste failed: {other}"),
+        });
+    }
+
+    let changed = probe_result
+        .get("changed")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let content_editable = probe_result
+        .get("contentEditable")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if changed {
+        return Ok(json!({
+            "engine": "paste-event",
+            "format": format.as_str(),
+            "chars": text.chars().count(),
+        }));
+    }
+
+    // Nothing listened. Insert for real, matching what the format promised:
+    // rich content through `insertHTML` (contenteditable only — a `<textarea>`
+    // holds a string, so its "html" is that string), everything else through a
+    // TRUSTED `Input.insertText`, which respects the current selection and puts
+    // newlines in as newlines instead of Enter.
+    let engine = if want_html && content_editable {
+        let insert = format!(
+            r#"function() {{
+                try {{
+                    this.focus({{ preventScroll: true }});
+                    return document.execCommand('insertHTML', false, {html});
+                }} catch (e) {{ return false; }}
+            }}"#,
+            html = serde_json::to_string(text).unwrap_or_default(),
+        );
+        let _: EvaluateResult = client
+            .send_command_typed(
+                "Runtime.callFunctionOn",
+                &CallFunctionOnParams {
+                    function_declaration: insert,
+                    object_id: Some(object_id.clone()),
+                    arguments: None,
+                    return_by_value: Some(true),
+                    await_promise: Some(false),
+                },
+                Some(&effective_session_id),
+            )
+            .await?;
+        "insert-html"
+    } else {
+        client
+            .send_command_typed::<_, Value>(
+                "Input.insertText",
+                &InsertTextParams {
+                    text: text.to_string(),
+                },
+                Some(&effective_session_id),
+            )
+            .await?;
+        "insert-text"
+    };
+
+    // Verify the effect, not the call. An editor that swallowed the paste event
+    // AND ignored the insert must not come back as a success — that is exactly
+    // the silent no-op this codebase keeps paying for.
+    let verify: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: r#"function() {
+                    const isField = this.tagName === 'INPUT' || this.tagName === 'TEXTAREA';
+                    return isField ? this.value : (this.isContentEditable ? this.innerHTML : this.textContent);
+                }"#
+                .to_string(),
+                object_id: Some(object_id),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(&effective_session_id),
+        )
+        .await?;
+    let after = verify
+        .result
+        .value
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_default();
+    let before = probe_result
+        .get("before")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if after == before && !after.contains(text) {
+        return Err(
+            "The paste did not take: the target neither handled the paste event nor accepted an \
+             insert. Its content is unchanged. For Monaco or a similar editor with its own model, \
+             use `fill`."
+                .to_string(),
+        );
+    }
+
+    Ok(json!({
+        "engine": engine,
+        "format": format.as_str(),
+        "chars": text.chars().count(),
+    }))
+}
+
+/// The object id of `document.activeElement`, for a `paste` with no selector.
+async fn active_element_object_id(client: &CdpClient, session_id: &str) -> Result<String, String> {
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.evaluate",
+            &EvaluateParams {
+                expression: "(() => { let a = document.activeElement; \
+                             while (a && a.shadowRoot && a.shadowRoot.activeElement) \
+                             a = a.shadowRoot.activeElement; return a; })()"
+                    .to_string(),
+                return_by_value: Some(false),
+                await_promise: Some(false),
+            },
+            Some(session_id),
+        )
+        .await?;
+    result.result.object_id.ok_or_else(|| {
+        "paste needs a target: pass a selector/@ref, or focus a field first.".to_string()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -3656,7 +3656,11 @@ pub async fn paste_content(
         .get("before")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-    if after == before && !after.contains(text) {
+    // Unchanged content is the failure, full stop. The earlier form let a
+    // target that ALREADY held the payload pass verification — `after` contains
+    // the text, but so did `before`, so the paste demonstrably did nothing and
+    // still reported ✓.
+    if after == before {
         return Err(
             "The paste did not take: the target neither handled the paste event nor accepted an \
              insert. Its content is unchanged. For Monaco or a similar editor with its own model, \

--- a/cli/src/native/mod.rs
+++ b/cli/src/native/mod.rs
@@ -45,6 +45,8 @@ pub mod script;
 
 pub mod script_js;
 #[allow(dead_code)]
+pub mod settle;
+#[allow(dead_code)]
 pub mod slider;
 #[allow(dead_code)]
 pub mod snapshot;

--- a/cli/src/native/parity_tests.rs
+++ b/cli/src/native/parity_tests.rs
@@ -61,6 +61,8 @@ const DOCUMENTED_ACTIONS: &[&str] = &[
     "hover",
     "scroll",
     "select",
+    "select_text",
+    "paste",
     "check",
     "uncheck",
     "wait",

--- a/cli/src/native/settle.rs
+++ b/cli/src/native/settle.rs
@@ -1,0 +1,525 @@
+//! Adaptive wait before an observation (issue #228).
+//!
+//! Observing a page is only meaningful once the page has stopped changing, and
+//! "how long is that" is not a constant. The two call sites this module
+//! replaces both guessed:
+//!
+//! - `--observe` slept a hard-coded 250ms after the action and captured
+//!   whatever was there. When 250ms was not enough it returned a
+//!   mid-transition tree **as though it were the result** — a silent wrong
+//!   answer, which is worse than being slow.
+//! - `snapshot` did not wait at all.
+//!
+//! The fix is to wait on signals instead of on a number, and to **say so** when
+//! the signals never went quiet:
+//!
+//! - **DOM quiet** — a `MutationObserver` reports no mutation for
+//!   [`DEFAULT_QUIET_MS`].
+//! - **Animations** — no finite CSS transition/animation still running.
+//!   Infinitely-repeating ones (spinners) are ignored on purpose: a spinner
+//!   never ends, so waiting for it means always paying the ceiling.
+//! - **Network** — no request in flight that started after the action did.
+//!   This is the signal a page-side wait cannot see: an XHR fired by the click
+//!   leaves the DOM quiet for its whole round trip, and that quiet is exactly
+//!   the mid-transition tree the old 250ms returned.
+//!
+//! Everything is bounded by a ceiling ([`DEFAULT_MAX_MS`]). Hitting it is not
+//! silently swallowed: the outcome carries what was still busy, and the callers
+//! print it.
+//!
+//! Waiting is the observer's job, not the caller's. An agent asked to guess a
+//! sleep duration guesses conservatively, and that guess is paid on every call.
+
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+
+use super::actions::DaemonState;
+
+/// How long the page must go without a DOM mutation (or a running animation)
+/// before we call it settled.
+pub const DEFAULT_QUIET_MS: u64 = 100;
+
+/// Upper bound on a single settle. On expiry we capture anyway and report that
+/// the capture may be mid-transition.
+pub const DEFAULT_MAX_MS: u64 = 1000;
+
+/// How often the network signal is re-checked while the page itself is quiet.
+const NETWORK_POLL_MS: u64 = 25;
+
+/// A request that has been in flight this long stops counting as a settle
+/// blocker. Server-sent events, long-polls and streaming responses never
+/// "finish"; without this they would hold every observation to the ceiling.
+const NETWORK_STALE_MS: u64 = 10_000;
+
+/// Env override for the ceiling, in milliseconds. `0` disables waiting.
+pub const ENV_MAX_MS: &str = "AGENT_BROWSER_SETTLE_MS";
+/// Env override for the quiet window, in milliseconds.
+pub const ENV_QUIET_MS: &str = "AGENT_BROWSER_SETTLE_QUIET_MS";
+
+/// What a settle waited for and whether it got there.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SettleOutcome {
+    /// Wall time actually spent waiting.
+    pub waited_ms: u64,
+    /// True when every signal went quiet within the ceiling.
+    pub quiet: bool,
+    /// Whether anything moved at all while waiting — a mutation, a request, an
+    /// animation. `quiet` with `saw_change: false` after an action is the
+    /// honest form of "that did nothing": the wait watched for a reaction and
+    /// none came, rather than never having looked.
+    pub saw_change: bool,
+    /// Signals still busy when the ceiling hit: `dom`, `animation`, `network`.
+    /// Empty when `quiet`.
+    pub pending: Vec<String>,
+}
+
+impl SettleOutcome {
+    /// A settle that was switched off (`--no-settle`, ceiling 0). Reports as
+    /// quiet because nothing was asked for — a skipped wait is not a timeout.
+    pub fn skipped() -> Self {
+        Self {
+            waited_ms: 0,
+            quiet: true,
+            saw_change: false,
+            pending: Vec::new(),
+        }
+    }
+
+    /// The warning to print when the page never went quiet, or `None`.
+    ///
+    /// This is the whole point of the ceiling being visible: a tree captured
+    /// mid-transition looks exactly like a settled one, so the only thing that
+    /// separates them is this line.
+    pub fn warning(&self) -> Option<String> {
+        if self.quiet {
+            return None;
+        }
+        Some(format!(
+            "Page had not settled after {}ms ({} still active) — this capture may be \
+             mid-transition. Re-read to confirm, or raise the ceiling with {}.",
+            self.waited_ms,
+            describe_pending(&self.pending),
+            ENV_MAX_MS,
+        ))
+    }
+
+    /// JSON shape attached to `--json` output.
+    pub fn to_json(&self) -> serde_json::Value {
+        json!({
+            "waitedMs": self.waited_ms,
+            "quiet": self.quiet,
+            "sawChange": self.saw_change,
+            "pending": self.pending,
+        })
+    }
+}
+
+/// Human-readable list of the signals that were still busy.
+pub fn describe_pending(pending: &[String]) -> String {
+    if pending.is_empty() {
+        return "nothing".to_string();
+    }
+    pending
+        .iter()
+        .map(|p| match p.as_str() {
+            "dom" => "DOM still mutating",
+            "animation" => "animation running",
+            "network" => "request in flight",
+            other => other,
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Read a positive-integer millisecond budget from the environment, falling
+/// back to `default` when unset or unparseable. `0` is meaningful (disable), so
+/// it is preserved rather than treated as "unset".
+pub fn env_ms(var: &str, default: u64) -> u64 {
+    match std::env::var(var) {
+        Ok(s) => s.trim().parse::<u64>().unwrap_or(default),
+        Err(_) => default,
+    }
+}
+
+/// Resolve the ceiling for one command: an explicit per-command value
+/// (`--settle-ms`, `--no-settle` → 0) wins over the env override, which wins
+/// over [`DEFAULT_MAX_MS`].
+pub fn resolve_max_ms(explicit: Option<u64>) -> u64 {
+    explicit.unwrap_or_else(|| env_ms(ENV_MAX_MS, DEFAULT_MAX_MS))
+}
+
+/// The ceiling a command asked for, read off the action JSON that the CLI
+/// stamps `--settle-ms` / `--no-settle` onto.
+pub fn max_ms_for(cmd: &serde_json::Value) -> u64 {
+    resolve_max_ms(cmd.get("settleMs").and_then(|v| v.as_u64()))
+}
+
+/// Fraction of the ceiling spent watching for a *first* change after an action.
+///
+/// A `setTimeout` that will render in 300ms emits no signal at all until it
+/// fires: the DOM is still, nothing is animating, nothing is in flight. A wait
+/// that accepts stillness immediately therefore reports "nothing changed" for
+/// every control that reacts on a timer — the same silent wrong answer, just
+/// faster. So after an action the wait keeps watching for the first sign of a
+/// reaction for half the ceiling before it is willing to call the page
+/// unchanged, and it scales with the ceiling so `--settle-ms` is the one knob:
+/// raise it for a slow page and the reaction window grows with it.
+///
+/// The cost is paid only by actions that really change nothing (they wait half
+/// the ceiling and then report `changed: false`). Anything that does react —
+/// a mutation, a request, an animation — ends the window the moment it starts.
+pub const REACTION_FRACTION: u64 = 2;
+
+/// How long to keep watching for a first reaction, given the ceiling.
+pub fn reaction_window_ms(max_ms: u64, quiet_ms: u64) -> u64 {
+    (max_ms / REACTION_FRACTION).clamp(quiet_ms.min(max_ms), max_ms)
+}
+
+/// Wait until the page stops changing, or the ceiling expires.
+///
+/// `since` marks the point the caller cares about — for `--observe` that is the
+/// instant *before* the action was dispatched, so a request the action fired is
+/// counted even though it started before this call. Requests already in flight
+/// beforehand (a streaming response, a long-poll) are not this observation's
+/// business and are ignored.
+///
+/// `expect_change` is for an observation that follows an action of ours: it
+/// turns on the reaction window described at [`REACTION_FRACTION`]. A plain
+/// `snapshot` passes `false` — there is no action to react to, so stillness is
+/// the answer, not a signal to keep waiting.
+pub async fn settle(
+    state: &mut DaemonState,
+    max_ms: u64,
+    since: Instant,
+    expect_change: bool,
+) -> SettleOutcome {
+    if max_ms == 0 {
+        return SettleOutcome::skipped();
+    }
+    let quiet_ms = env_ms(ENV_QUIET_MS, DEFAULT_QUIET_MS).min(max_ms);
+    let start = Instant::now();
+    let deadline = start + Duration::from_millis(max_ms);
+    let reaction_deadline = start
+        + Duration::from_millis(if expect_change {
+            reaction_window_ms(max_ms, quiet_ms)
+        } else {
+            0
+        });
+    let mut last_pending: Vec<String> = Vec::new();
+    let mut saw_change = false;
+
+    loop {
+        state.drain_cdp_events_background().await;
+        let now = Instant::now();
+        if now >= deadline {
+            break;
+        }
+        let remaining = (deadline - now).as_millis() as u64;
+        // Time left in which a first reaction is still expected. A request the
+        // action fired counts as that reaction, so once anything has happened
+        // this drops to zero and the wait is a plain quiet check again.
+        let reaction_left = if saw_change || now >= reaction_deadline {
+            0
+        } else {
+            (reaction_deadline - now).as_millis() as u64
+        };
+
+        // Network first: it costs no round trip, and while a request the action
+        // fired is outstanding the DOM being quiet means nothing.
+        if state.pending_request_count(since) > 0 {
+            saw_change = true;
+            last_pending = vec!["network".to_string()];
+            tokio::time::sleep(Duration::from_millis(NETWORK_POLL_MS.min(remaining))).await;
+            continue;
+        }
+
+        match page_quiet(state, quiet_ms.min(remaining), remaining, reaction_left).await {
+            Ok(page) if page.pending.is_empty() => {
+                saw_change |= page.saw_change;
+                // The page went quiet; re-check the network, because it may have
+                // started fetching while we were waiting on the DOM.
+                state.drain_cdp_events_background().await;
+                if state.pending_request_count(since) == 0 {
+                    return SettleOutcome {
+                        waited_ms: start.elapsed().as_millis() as u64,
+                        quiet: true,
+                        saw_change,
+                        pending: Vec::new(),
+                    };
+                }
+                saw_change = true;
+                last_pending = vec!["network".to_string()];
+            }
+            Ok(page) => {
+                saw_change |= page.saw_change;
+                last_pending = page.pending;
+            }
+            Err(_) => {
+                // The execution context went away mid-wait — a navigation, or a
+                // renderer that is busy enough not to answer. Neither is a
+                // settled page, so keep waiting rather than reporting quiet.
+                last_pending = vec!["dom".to_string()];
+                tokio::time::sleep(Duration::from_millis(NETWORK_POLL_MS.min(remaining))).await;
+            }
+        }
+    }
+
+    if last_pending.is_empty() {
+        last_pending.push("dom".to_string());
+    }
+    SettleOutcome {
+        waited_ms: start.elapsed().as_millis() as u64,
+        quiet: false,
+        saw_change,
+        pending: last_pending,
+    }
+}
+
+/// What one page-side wait reported.
+struct PageQuiet {
+    /// Signals still busy when it gave up. Empty means the page is still.
+    pending: Vec<String>,
+    /// Whether anything mutated while it was watching.
+    saw_change: bool,
+}
+
+/// Page-side half of the wait: resolves when the DOM has been still for
+/// `quiet_ms` and no finite animation is running, or when `budget_ms` expires.
+/// While `reaction_ms` has not elapsed it will not call an untouched page
+/// settled — that window is what catches a render scheduled on a timer.
+async fn page_quiet(
+    state: &DaemonState,
+    quiet_ms: u64,
+    budget_ms: u64,
+    reaction_ms: u64,
+) -> Result<PageQuiet, String> {
+    let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+    let script = page_quiet_script(quiet_ms, budget_ms, reaction_ms);
+    // The page-side wait resolves on its own budget; the outer timeout only
+    // guards against a renderer that never answers at all.
+    let value = tokio::time::timeout(
+        Duration::from_millis(budget_ms + 500),
+        mgr.evaluate(&script, None),
+    )
+    .await
+    .map_err(|_| "settle wait timed out".to_string())??;
+
+    let pending = value
+        .get("pending")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str())
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+    let saw_change = value
+        .get("sawChange")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    Ok(PageQuiet {
+        pending,
+        saw_change,
+    })
+}
+
+/// The injected wait. Kept as a builder (rather than a format! at the call
+/// site) so the JS can be unit-tested for the substitutions it depends on.
+///
+/// Note the animation filter: only animations with a finite duration and finite
+/// iteration count count as "still running". A spinner declared
+/// `animation: spin 1s infinite` is the normal state of a loading page, not a
+/// transition that will end, and waiting on it would spend the whole ceiling on
+/// every observation of every page that has one.
+///
+/// `reaction_ms` is the window in which stillness alone is not an answer: until
+/// it elapses (or something mutates) the wait keeps going, which is what makes a
+/// render scheduled on a timer visible instead of reported as "no change".
+pub fn page_quiet_script(quiet_ms: u64, budget_ms: u64, reaction_ms: u64) -> String {
+    format!(
+        r#"(() => new Promise((resolve) => {{
+  const QUIET = {quiet_ms};
+  const REACTION = {reaction_ms};
+  const t0 = performance.now();
+  const deadline = t0 + {budget_ms};
+  let lastChange = t0;
+  let sawChange = false;
+  let observer = null;
+  try {{
+    observer = new MutationObserver(() => {{ lastChange = performance.now(); sawChange = true; }});
+    observer.observe(document, {{ subtree: true, childList: true, attributes: true, characterData: true }});
+  }} catch (e) {{}}
+  const animating = () => {{
+    try {{
+      if (typeof document.getAnimations !== 'function') return false;
+      return document.getAnimations().some((a) => {{
+        if (a.playState !== 'running') return false;
+        const t = a.effect && a.effect.getComputedTiming ? a.effect.getComputedTiming() : null;
+        if (!t) return false;
+        if (t.iterations === Infinity || t.duration === Infinity) return false;
+        return true;
+      }});
+    }} catch (e) {{ return false; }}
+  }};
+  const finish = (pending) => {{
+    try {{ if (observer) observer.disconnect(); }} catch (e) {{}}
+    resolve({{ pending, sawChange, waitedMs: Math.round(performance.now() - t0) }});
+  }};
+  const tick = () => {{
+    const now = performance.now();
+    const domQuiet = now - lastChange >= QUIET;
+    const anim = animating();
+    // Stillness is only an answer once a reaction has been seen, or once the
+    // window in which one was expected has passed.
+    const answered = sawChange || now - t0 >= REACTION;
+    if (domQuiet && !anim && answered) return finish([]);
+    if (now >= deadline) {{
+      const pending = [];
+      if (!domQuiet) pending.push('dom');
+      if (anim) pending.push('animation');
+      return finish(pending);
+    }}
+    setTimeout(tick, 16);
+  }};
+  tick();
+}}))()"#
+    )
+}
+
+/// How far back a standalone observation looks for in-flight requests.
+///
+/// `snapshot` has no action to anchor to, so it uses a short window instead: a
+/// request that started a moment ago is the page still loading and worth
+/// waiting for; one that started a minute ago is somebody's stream and is not.
+pub const LOOKBACK_MS: u64 = 2000;
+
+/// The `since` anchor for an observation that follows no action of ours.
+pub fn lookback() -> Instant {
+    let now = Instant::now();
+    now.checked_sub(Duration::from_millis(LOOKBACK_MS))
+        .unwrap_or(now)
+}
+
+/// Requests that started at or after `since` and have not finished, ignoring
+/// ones old enough to be a stream rather than a page load.
+pub fn pending_requests(in_flight: &[(String, Instant)], since: Instant) -> usize {
+    let stale = Duration::from_millis(NETWORK_STALE_MS);
+    in_flight
+        .iter()
+        .filter(|(_, started)| *started >= since && started.elapsed() < stale)
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skipped_settle_is_quiet_and_warns_nothing() {
+        let s = SettleOutcome::skipped();
+        assert!(s.quiet);
+        assert_eq!(s.waited_ms, 0);
+        assert!(s.warning().is_none());
+    }
+
+    /// The ceiling exists to bound the wait, not to hide it: a capture taken
+    /// after the ceiling expired must carry a line saying so, naming what was
+    /// still moving. This is the "never ship a silent success" rule applied to
+    /// waiting.
+    #[test]
+    fn timed_out_settle_names_what_was_busy() {
+        let s = SettleOutcome {
+            waited_ms: 1000,
+            quiet: false,
+            saw_change: true,
+            pending: vec!["network".to_string(), "dom".to_string()],
+        };
+        let w = s.warning().expect("a non-quiet settle must warn");
+        assert!(w.contains("1000ms"), "{w}");
+        assert!(w.contains("request in flight"), "{w}");
+        assert!(w.contains("DOM still mutating"), "{w}");
+        assert!(w.contains(ENV_MAX_MS), "{w}");
+    }
+
+    #[test]
+    fn describes_known_signals_in_prose() {
+        assert_eq!(describe_pending(&[]), "nothing");
+        assert_eq!(
+            describe_pending(&["animation".to_string()]),
+            "animation running"
+        );
+        assert_eq!(describe_pending(&["custom".to_string()]), "custom");
+    }
+
+    #[test]
+    fn explicit_ceiling_beats_env_and_zero_survives() {
+        // `--no-settle` stamps 0, which must NOT be read as "unset" — that is
+        // the difference between skipping the wait and paying the default.
+        assert_eq!(resolve_max_ms(Some(0)), 0);
+        assert_eq!(resolve_max_ms(Some(4000)), 4000);
+    }
+
+    #[test]
+    fn max_ms_reads_the_stamped_action_field() {
+        assert_eq!(max_ms_for(&json!({ "settleMs": 0 })), 0);
+        assert_eq!(max_ms_for(&json!({ "settleMs": 750 })), 750);
+        assert_eq!(max_ms_for(&json!({})), DEFAULT_MAX_MS);
+    }
+
+    #[test]
+    fn env_ms_falls_back_on_garbage() {
+        assert_eq!(env_ms("AGENT_BROWSER_SETTLE_DEFINITELY_UNSET", 123), 123);
+    }
+
+    /// A streaming response (SSE, long-poll) never finishes. Counting it would
+    /// hold every later observation to the ceiling, so age it out.
+    #[test]
+    fn stale_requests_stop_blocking_the_wait() {
+        let since = Instant::now() - Duration::from_secs(60);
+        let fresh = Instant::now();
+        let ancient = Instant::now() - Duration::from_millis(NETWORK_STALE_MS + 500);
+        let in_flight = vec![
+            ("fresh".to_string(), fresh),
+            ("stream".to_string(), ancient),
+        ];
+        assert_eq!(pending_requests(&in_flight, since), 1);
+    }
+
+    /// Requests already in flight before the action are not this observation's
+    /// business — waiting on someone else's stream is how a fast page ends up
+    /// paying the ceiling.
+    #[test]
+    fn requests_older_than_the_action_are_ignored() {
+        let before = Instant::now() - Duration::from_millis(50);
+        let since = Instant::now();
+        let in_flight = vec![("prior".to_string(), before)];
+        assert_eq!(pending_requests(&in_flight, since), 0);
+    }
+
+    /// The reaction window scales with the ceiling, so `--settle-ms` stays the
+    /// single knob: a slower page gets both a longer wait and a longer window
+    /// in which a timer-driven render still counts.
+    #[test]
+    fn reaction_window_is_half_the_ceiling_and_never_below_the_quiet_window() {
+        assert_eq!(reaction_window_ms(1000, 100), 500);
+        assert_eq!(reaction_window_ms(3000, 100), 1500);
+        // A ceiling shorter than the quiet window cannot promise more than itself.
+        assert_eq!(reaction_window_ms(50, 100), 50);
+        assert_eq!(reaction_window_ms(150, 100), 100);
+    }
+
+    #[test]
+    fn quiet_script_carries_its_budgets() {
+        let js = page_quiet_script(100, 1000, 500);
+        assert!(js.contains("const QUIET = 100;"), "{js}");
+        assert!(js.contains("const REACTION = 500;"), "{js}");
+        assert!(js.contains("t0 + 1000"), "{js}");
+        // Infinite spinners must not be treated as a transition in progress.
+        assert!(js.contains("t.iterations === Infinity"), "{js}");
+        // `Promise` in the source is what makes `evaluate` await it rather than
+        // returning the pending promise object.
+        assert!(js.contains("Promise"), "{js}");
+    }
+}

--- a/cli/src/native/settle.rs
+++ b/cli/src/native/settle.rs
@@ -47,6 +47,10 @@ pub const DEFAULT_MAX_MS: u64 = 1000;
 /// How often the network signal is re-checked while the page itself is quiet.
 const NETWORK_POLL_MS: u64 = 25;
 
+/// Time reserved out of each page-side wait for the CDP round trip that carries
+/// its answer back, so the whole settle stays within the ceiling.
+const ROUND_TRIP_ALLOWANCE_MS: u64 = 100;
+
 /// A request that has been in flight this long stops counting as a settle
 /// blocker. Server-sent events, long-polls and streaming responses never
 /// "finish"; without this they would hold every observation to the ceiling.
@@ -68,6 +72,12 @@ pub struct SettleOutcome {
     /// animation. `quiet` with `saw_change: false` after an action is the
     /// honest form of "that did nothing": the wait watched for a reaction and
     /// none came, rather than never having looked.
+    ///
+    /// It only covers what happened *while waiting*: a mutation the action made
+    /// synchronously, before this observer existed, is invisible here. The
+    /// caller that has a before/after diff knows better, and `--observe` folds
+    /// that in (see `mark_changed`) so the reported flag never contradicts the
+    /// delta printed beside it.
     pub saw_change: bool,
     /// Signals still busy when the ceiling hit: `dom`, `animation`, `network`.
     /// Empty when `quiet`.
@@ -102,6 +112,14 @@ impl SettleOutcome {
             describe_pending(&self.pending),
             ENV_MAX_MS,
         ))
+    }
+
+    /// Fold in a change the caller observed that the wait could not: a DOM
+    /// mutation made synchronously during dispatch happens before the page-side
+    /// observer is installed, so the delta is the authority on whether anything
+    /// changed and this flag must not say otherwise.
+    pub fn mark_changed(&mut self, changed: bool) {
+        self.saw_change |= changed;
     }
 
     /// JSON shape attached to `--json` output.
@@ -234,6 +252,15 @@ pub async fn settle(
             continue;
         }
 
+        // Too little left for the page-side wait to learn anything: its budget
+        // would be zero, and a zero-length quiet window is satisfied the instant
+        // it is checked — a false "quiet" right at the ceiling. Wait out the
+        // remainder instead and let the loop report the timeout it really is.
+        if remaining <= ROUND_TRIP_ALLOWANCE_MS {
+            tokio::time::sleep(Duration::from_millis(remaining)).await;
+            continue;
+        }
+
         match page_quiet(state, quiet_ms.min(remaining), remaining, reaction_left).await {
             Ok(page) if page.pending.is_empty() => {
                 saw_change |= page.saw_change;
@@ -295,11 +322,21 @@ async fn page_quiet(
     reaction_ms: u64,
 ) -> Result<PageQuiet, String> {
     let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
-    let script = page_quiet_script(quiet_ms, budget_ms, reaction_ms);
-    // The page-side wait resolves on its own budget; the outer timeout only
-    // guards against a renderer that never answers at all.
+    // The page resolves a little before the deadline so the reply still fits
+    // inside it: `max_ms` is documented as the ceiling on the wait, and a grace
+    // period added on top of the budget would quietly overrun it (a 50ms
+    // ceiling waiting ~550ms). The room comes out of the page's budget, not off
+    // the end of the caller's.
+    let page_budget = budget_ms.saturating_sub(ROUND_TRIP_ALLOWANCE_MS);
+    if page_budget == 0 {
+        // Defensive: a zero budget makes the quiet window zero, which every page
+        // satisfies immediately. Saying "I could not look" beats reporting a
+        // quiet the wait never established.
+        return Err("no budget left for a settle probe".to_string());
+    }
+    let script = page_quiet_script(quiet_ms.min(page_budget), page_budget, reaction_ms);
     let value = tokio::time::timeout(
-        Duration::from_millis(budget_ms + 500),
+        Duration::from_millis(budget_ms),
         mgr.evaluate(&script, None),
     )
     .await

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -708,6 +708,18 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                 eprintln!("{}", color::dim(note));
             }
             print_with_boundaries(snapshot, origin, opts);
+            // `--with-screenshot`: the image is an output, so its path is
+            // reported and nothing more — the tree above is what the agent
+            // reads the page from.
+            if let Some(p) = data.get("screenshot").and_then(|v| v.as_str()) {
+                eprintln!("{} {}", color::dim("screenshot:"), p);
+            }
+            if let Some(e) = data.get("screenshotError").and_then(|v| v.as_str()) {
+                eprintln!(
+                    "{} --with-screenshot failed: {e}",
+                    color::warning_indicator()
+                );
+            }
             // The adaptive wait hit its ceiling with the page still moving
             // (#228). A mid-transition tree is indistinguishable from a settled
             // one once printed, so this line is the only thing that separates
@@ -1802,6 +1814,15 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             print_observed(obs);
         } else if let Some(snap) = observed_snapshot {
             print_observed_snapshot(snap);
+        }
+        if let Some(p) = data.get("screenshot").and_then(|v| v.as_str()) {
+            eprintln!("{} {}", color::dim("screenshot:"), p);
+        }
+        if let Some(e) = data.get("screenshotError").and_then(|v| v.as_str()) {
+            eprintln!(
+                "{} --with-screenshot failed: {e}",
+                color::warning_indicator()
+            );
         }
     } else {
         // Success response with no data payload — still confirm the command ran
@@ -4640,6 +4661,10 @@ Options:
                              capture that hit the ceiling says so.
   --no-settle                Capture immediately, without waiting for the page
                              to stop changing
+  --with-screenshot <path>   Save the pixels alongside a structural observation
+                             (`snapshot`, or an action with `--observe`), from
+                             the same settled moment. The tree is what you read;
+                             the image is for looking at
   --model <name>             AI model for chat (or AI_GATEWAY_MODEL env)
   -v, --verbose              Show tool commands and their raw output
   -q, --quiet                Show only AI text responses (hide tool calls)

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -622,6 +622,55 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
             }
             return;
         }
+        // `paste`: name the path the content took. "Pasted" through the page's
+        // own handler and "pasted" through our fallback insert can produce very
+        // different documents in a rich editor, so the difference is printed.
+        if let Some(chars) = data.get("pasted").and_then(|v| v.as_u64()) {
+            let format = data
+                .get("format")
+                .and_then(|v| v.as_str())
+                .unwrap_or("text");
+            let engine = data.get("engine").and_then(|v| v.as_str()).unwrap_or("");
+            println!(
+                "{} pasted {} chars as {} {}",
+                color::success_indicator(),
+                chars,
+                format,
+                color::dim(&format!("({engine})"))
+            );
+            return;
+        }
+        // `select-text`: say what was selected and where, so a caret placed at
+        // an offset you did not intend is visible before the next `type` lands
+        // in the wrong place.
+        if let Some(kind) = data.get("selectionType").and_then(|v| v.as_str()) {
+            let sel = data.get("selector").and_then(|v| v.as_str()).unwrap_or("");
+            let start = data.get("start").and_then(|v| v.as_i64()).unwrap_or(0);
+            let end = data.get("end").and_then(|v| v.as_i64()).unwrap_or(0);
+            let engine = data.get("engine").and_then(|v| v.as_str()).unwrap_or("");
+            match kind {
+                "cursor_before" | "cursor_after" => println!(
+                    "{} caret at {} in {} {}",
+                    color::success_indicator(),
+                    start,
+                    sel,
+                    color::dim(&format!("({engine})"))
+                ),
+                _ => {
+                    let selected = data.get("selected").and_then(|v| v.as_str()).unwrap_or("");
+                    println!(
+                        "{} selected {:?} at {}-{} in {} {}",
+                        color::success_indicator(),
+                        selected,
+                        start,
+                        end,
+                        sel,
+                        color::dim(&format!("({engine})"))
+                    );
+                }
+            }
+            return;
+        }
         if let Some(done) = data.get("performed").and_then(|v| v.as_str()) {
             let r = data.get("ref").and_then(|v| v.as_str()).unwrap_or("");
             // A stalled expand/collapse must not wear a plain ✓.
@@ -659,6 +708,13 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                 eprintln!("{}", color::dim(note));
             }
             print_with_boundaries(snapshot, origin, opts);
+            // The adaptive wait hit its ceiling with the page still moving
+            // (#228). A mid-transition tree is indistinguishable from a settled
+            // one once printed, so this line is the only thing that separates
+            // them.
+            if let Some(w) = data.get("settleWarning").and_then(|v| v.as_str()) {
+                eprintln!("{} {}", color::warning_indicator(), w);
+            }
             // Canvas-app hint: the tree was near-empty but the page paints to a
             // <canvas>, so refs are a dead end — point at the screenshot path.
             if let Some(note) = data.get("note").and_then(|v| v.as_str()) {
@@ -2682,6 +2738,71 @@ Examples:
 "##
         }
 
+        "paste" => {
+            r##"
+chrome-use paste - Paste content with a MIME type, without using the clipboard
+
+Usage: chrome-use paste <text> [--format text|md|html] [--selector <sel>]
+
+Options:
+  --format <f>         text (default), md, or html
+  --selector <sel>     Target element/@ref (default: whatever has focus)
+
+In a rich-text editor, pasting and typing produce different documents:
+`type "<b>bold</b>"` gives you those eleven characters, `paste --format html`
+gives you bold text. Newlines differ too — `type` sends Enter, which submits
+or splits a block in most editors, while a paste inserts the line break.
+
+`md` inserts Markdown *source* as plain text (predictable: no renderer sits
+between what you passed and what lands).
+
+The user's real clipboard is never touched: the content rides on a synthetic
+ClipboardEvent, not through navigator.clipboard or Ctrl+V. Because such an
+event is untrusted it has no default action, so an editor that ignores it gets
+the content through a real insert instead; the reply names which path ran.
+If neither takes, the command fails rather than reporting a paste that did
+nothing.
+
+Examples:
+  chrome-use paste "line one\nline two" --selector "#notes"
+  chrome-use paste "<b>bold</b> text" --format html --selector "#editor"
+  chrome-use paste "# Heading" --format md
+"##
+        }
+        "select-text" => {
+            r##"
+chrome-use select-text - Select a run of text inside an editable element
+
+Usage: chrome-use select-text <@ref|selector> <text> [options]
+
+Options:
+  --prefix <text>      Text immediately BEFORE the part you mean (disambiguation)
+  --suffix <text>      Text immediately AFTER it
+  --cursor-before      Place the caret before the match instead of selecting
+  --cursor-after       Place the caret after the match instead of selecting
+
+`fill` replaces the whole value and `type` appends; this is how you change one
+phrase inside a long field, or put the cursor somewhere and carry on typing.
+
+The prefix and suffix are context, not part of the selection: with
+`--prefix "please "` the text `confirm` is what gets selected, not
+`please confirm`. A phrase that appears more than once and has no
+disambiguation is refused with the count rather than resolved to the first
+one — and "not found" and "too many matches" are reported as the different
+problems they are.
+
+Works on <input>, <textarea> and contenteditable. Monaco and CodeMirror keep
+their own selection model and are refused with that reason: a DOM selection
+there looks applied and does nothing.
+
+Examples:
+  chrome-use select-text @e3 "tomorrow"
+  chrome-use select-text @e3 "confirm" --prefix "please "
+  chrome-use select-text @e3 "Hi Sam," --cursor-after
+  chrome-use type @e3 " thanks for the update"    # continues at the caret
+"##
+        }
+
         // === Snapshot ===
         "snapshot" => {
             r##"
@@ -4194,6 +4315,15 @@ Core Commands:
   check <sel>                Check checkbox
   uncheck <sel>              Uncheck checkbox
   select <sel> <val...>      Select dropdown option
+  paste <text>               Paste content with a MIME type instead of typing it
+                             [--format text|md|html] [--selector <sel>]. Never
+                             touches the real clipboard, and a newline stays a
+                             newline instead of becoming Enter
+  select-text <sel> <text>   Select one run of text inside an editable element,
+                             or place the caret next to it. --prefix/--suffix
+                             disambiguate a repeated phrase (they are context,
+                             not part of the selection); --cursor-before /
+                             --cursor-after leave a caret instead of a selection
   drag <src> <dst>           Drag and drop
   upload <sel> <files...>    Upload files
   download <sel> <path>      Download file from an element
@@ -4504,6 +4634,12 @@ Options:
                              erroring when the target element is absent
   --observe                  After a mutating action, return only what changed
                              (a11y delta + url + requests) — skip act→snapshot→diff
+  --settle-ms <ms>           Ceiling on the wait before an observation captures
+                             (default 1000, or AGENT_BROWSER_SETTLE_MS). The wait
+                             ends early on DOM quiet + no in-flight request; a
+                             capture that hit the ceiling says so.
+  --no-settle                Capture immediately, without waiting for the page
+                             to stop changing
   --model <name>             AI model for chat (or AI_GATEWAY_MODEL env)
   -v, --verbose              Show tool commands and their raw output
   -q, --quiet                Show only AI text responses (hide tool calls)
@@ -4556,6 +4692,8 @@ Environment:
   AGENT_BROWSER_COLOR_SCHEME     Color scheme preference (dark, light, no-preference)
   AGENT_BROWSER_DOWNLOAD_PATH    Default download directory for browser downloads
   AGENT_BROWSER_DEFAULT_TIMEOUT  Default action timeout in ms (default: 25000)
+  AGENT_BROWSER_SETTLE_MS        Ceiling on the pre-observation wait in ms (default: 1000; 0 disables)
+  AGENT_BROWSER_SETTLE_QUIET_MS  DOM-quiet window that ends the wait early in ms (default: 100)
   AGENT_BROWSER_SESSION_NAME     Auto-save/load state persistence name
   AGENT_BROWSER_STATE_EXPIRE_DAYS Auto-delete saved states older than N days (default: 30)
   AGENT_BROWSER_ENCRYPTION_KEY   64-char hex key for AES-256-GCM session encryption
@@ -4642,8 +4780,19 @@ fn print_observed(obs: &serde_json::Map<String, serde_json::Value>) {
         .get("changed")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    // How long the adaptive wait watched (#228). On "no change" this is the
+    // difference between "the page did nothing" and "we did not look": the
+    // wait keeps watching for a first reaction for half its ceiling before it
+    // is willing to say nothing happened.
+    let waited = obs
+        .get("settle")
+        .and_then(|s| s.get("waitedMs"))
+        .and_then(|v| v.as_u64());
     if !changed {
-        println!("{}", color::dim("observed: no change"));
+        match waited {
+            Some(ms) => println!("{}", color::dim(&format!("observed: no change ({ms}ms)"))),
+            None => println!("{}", color::dim("observed: no change")),
+        }
         return;
     }
     if let Some(url) = obs.get("urlChanged").and_then(|v| v.as_object()) {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2785,7 +2785,7 @@ If neither takes, the command fails rather than reporting a paste that did
 nothing.
 
 Examples:
-  chrome-use paste "line one\nline two" --selector "#notes"
+  chrome-use paste $'line one\nline two' --selector "#notes"   # $'...' so the shell sends a real newline
   chrome-use paste "<b>bold</b> text" --format html --selector "#editor"
   chrome-use paste "# Heading" --format md
 "##

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -4352,6 +4352,10 @@ Core Commands:
                              URL is read from inside the page instead (byte-exact,
                              no re-encode) — path required
   downloads [--limit N]      List downloads (--clear clears history)
+  bringToFront               Surface the active tab in the user's window. Tabs are
+                             driven in the background, where document.visibilityState
+                             stays 'hidden' — this is the way to make a page that
+                             gates its UI on visibility render for real
   scroll <dir> [px]          Scroll (up/down/left/right)
   scrollintoview <sel>       Scroll element into view
   wait <sel|ms>              Wait for element or time

--- a/docs/en/interacting.html
+++ b/docs/en/interacting.html
@@ -187,7 +187,7 @@
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
           <span class="du-code-name">paste</span>
         </div>
-<pre><code><span class="du-prompt">$</span> chrome-use paste <span class="du-str">"line one\nline two"</span> <span class="du-flag">--selector</span> <span class="du-str">"#notes"</span>
+<pre><code><span class="du-prompt">$</span> chrome-use paste <span class="du-str">$'line one\nline two'</span> <span class="du-flag">--selector</span> <span class="du-str">"#notes"</span>  <span class="du-cmt"># $'...' sends a real newline</span>
 <span class="du-prompt">$</span> chrome-use paste <span class="du-str">"&lt;b&gt;bold&lt;/b&gt; text"</span> <span class="du-flag">--format</span> html <span class="du-flag">--selector</span> <span class="du-str">"#editor"</span>
 <span class="du-prompt">$</span> chrome-use paste <span class="du-str">"# Heading"</span> <span class="du-flag">--format</span> md            <span class="du-cmt"># Markdown source as plain text</span></code></pre>
       </div>

--- a/docs/en/interacting.html
+++ b/docs/en/interacting.html
@@ -148,6 +148,60 @@
 
       <hr class="du-divider" />
 
+      <!-- ============ Editing inside a field / pasting ============ -->
+      <h2>Editing inside a field, and pasting with a MIME type</h2>
+      <p>
+        <code>fill</code> replaces a whole value and <code>type</code> appends. Changing one phrase
+        inside written text, or placing the caret somewhere and carrying on, is neither — that is
+        what <code>select-text</code> is for.
+      </p>
+
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">select-text</span>
+        </div>
+<pre><code><span class="du-prompt">$</span> chrome-use select-text @e3 <span class="du-str">"confirm"</span> <span class="du-flag">--prefix</span> <span class="du-str">"please "</span>  <span class="du-cmt"># selects `confirm`, not `please confirm`</span>
+<span class="du-prompt">$</span> chrome-use select-text @e3 <span class="du-str">"Hi Sam,"</span> <span class="du-flag">--cursor-after</span>       <span class="du-cmt"># a caret, not a selection</span>
+<span class="du-prompt">$</span> chrome-use type @e3 <span class="du-str">" quick note:"</span>                       <span class="du-cmt"># continues at the caret</span></code></pre>
+      </div>
+
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ A repeated phrase is refused, not resolved to the first one</div>
+        The prefix and suffix are context for finding the match, not part of the selection.
+        "Not found", "found but not with that context" and "matches N places" are three different
+        messages because they have three different fixes. Monaco and CodeMirror keep their own
+        selection model and are refused by name: a DOM selection there looks applied and does nothing.
+      </div>
+
+      <p>
+        In a rich-text editor, <strong>typing and pasting produce different documents</strong>:
+        <code>type "&lt;b&gt;bold&lt;/b&gt;"</code> gives you those eleven characters,
+        <code>paste --format html</code> gives you bold text. Newlines are the other reason —
+        <code>type</code> sends Enter, which submits or splits a block in most editors, while a
+        paste inserts the line break.
+      </p>
+
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">paste</span>
+        </div>
+<pre><code><span class="du-prompt">$</span> chrome-use paste <span class="du-str">"line one\nline two"</span> <span class="du-flag">--selector</span> <span class="du-str">"#notes"</span>
+<span class="du-prompt">$</span> chrome-use paste <span class="du-str">"&lt;b&gt;bold&lt;/b&gt; text"</span> <span class="du-flag">--format</span> html <span class="du-flag">--selector</span> <span class="du-str">"#editor"</span>
+<span class="du-prompt">$</span> chrome-use paste <span class="du-str">"# Heading"</span> <span class="du-flag">--format</span> md            <span class="du-cmt"># Markdown source as plain text</span></code></pre>
+      </div>
+
+      <div class="du-callout tip">
+        <div class="du-callout-title">✅ Your real clipboard is never touched</div>
+        The content rides on a synthetic <code>ClipboardEvent</code> — no <code>navigator.clipboard</code>
+        call, no Ctrl+V. Such an event is untrusted and has no default action, so an editor that listens
+        gets it through its own handler and one that ignores it gets a real insert; the reply names which
+        path ran. If neither takes, the command fails rather than printing a ✓.
+      </div>
+
+      <hr class="du-divider" />
+
       <!-- ============ Keyboard ============ -->
       <h2>Keyboard</h2>
       <p>

--- a/docs/en/real-chrome.html
+++ b/docs/en/real-chrome.html
@@ -370,7 +370,7 @@
         <code>document.visibilityState</code> stays <code>'hidden'</code>—focus emulation does not change it, and no CDP
         override does either. Almost nothing cares. The exception is a page that deliberately gates its UI on visibility
         (a device lease that must not be kept alive by a background tab, a video player, a game that pauses): it renders
-        its background branch, so <code>snapshot</code> comes back looking empty and every control reads as disabled.
+        its background branch, so <code>snapshot</code> can come back empty and the controls you expect may be missing or unavailable.
         <code>snapshot</code> now says so when the tree is near-empty and the tab is hidden. Surface it on purpose with
         <code>chrome-use bringToFront</code> and read it again—that is also the only thing that makes the user's view
         follow you, so use it deliberately, not by habit.

--- a/docs/en/real-chrome.html
+++ b/docs/en/real-chrome.html
@@ -360,10 +360,21 @@
       <h2>Silent by default</h2>
       <p>
         When driving the user's real Chrome, the agent works entirely in the <strong>background</strong>—new tabs open
-        unfocused, the agent never forces a tab to the front, and focus is emulated so background pages still render and
-        report <code>visibilityState: 'visible'</code>. You don't have to do anything; just don't expect the user's view to
-        follow you (only use an explicit <code>bringToFront</code> when you <strong>deliberately</strong> want to surface a tab).
+        unfocused and the agent never forces a tab to the front. Focus is emulated, so the page keeps rendering and keeps
+        running timers instead of being throttled. You don't have to do anything; just don't expect the user's view to
+        follow you.
       </p>
+
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ But a background tab really is hidden</div>
+        <code>document.visibilityState</code> stays <code>'hidden'</code>—focus emulation does not change it, and no CDP
+        override does either. Almost nothing cares. The exception is a page that deliberately gates its UI on visibility
+        (a device lease that must not be kept alive by a background tab, a video player, a game that pauses): it renders
+        its background branch, so <code>snapshot</code> comes back looking empty and every control reads as disabled.
+        <code>snapshot</code> now says so when the tree is near-empty and the tab is hidden. Surface it on purpose with
+        <code>chrome-use bringToFront</code> and read it again—that is also the only thing that makes the user's view
+        follow you, so use it deliberately, not by habit.
+      </div>
 
       <h2>Behavioral anti-bot: humanized input</h2>
       <p>

--- a/docs/en/troubleshooting.html
+++ b/docs/en/troubleshooting.html
@@ -134,6 +134,18 @@
         <code>AGENT_BROWSER_VERIFY_REF_TIMEOUT_MS</code> on very large pages), and an unconfirmed ref is never acted on.
       </div>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ Controls with no accessible name</div>
+        A bare <code>&lt;select&gt;</code> or an icon button has no accessible name, so role + name matches
+        <strong>every</strong> control of its kind and cannot re-anchor a stale ref on its own. Those fall back to
+        the <strong>value</strong> the snapshot recorded (a sort dropdown showing <code>Name (A to Z)</code> carries
+        its identity there), and it is only accepted when it narrows to exactly one candidate. When several remain,
+        the command still refuses — but it now says <em>N elements cannot be told apart</em> rather than
+        "no element with that role and name", which described a disappearance that had not happened. The fix for
+        that case is a fresh <code>snapshot</code> (it numbers duplicates, so the new ref carries an ordinal) or a
+        CSS selector.
+      </div>
+
       <h2>The element is in the DOM but not in the snapshot</h2>
       <p>
         It's probably offscreen, or not rendered yet. Scroll it into the viewport or wait for it to appear, then re-snapshot.

--- a/docs/en/troubleshooting.html
+++ b/docs/en/troubleshooting.html
@@ -136,7 +136,7 @@
 
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ Controls with no accessible name</div>
-        A bare <code>&lt;select&gt;</code> or an icon button has no accessible name, so role + name matches
+        A bare <code>&lt;select&gt;</code> or an unlabeled icon button has no accessible name, so role + name matches
         <strong>every</strong> control of its kind and cannot re-anchor a stale ref on its own. Those fall back to
         the <strong>value</strong> the snapshot recorded (a sort dropdown showing <code>Name (A to Z)</code> carries
         its identity there), and it is only accepted when it narrows to exactly one candidate. When several remain,

--- a/docs/en/waiting.html
+++ b/docs/en/waiting.html
@@ -91,6 +91,53 @@
 
       <hr class="du-divider" />
 
+      <!-- ============ SETTLE ============ -->
+      <h2>The read waits for you — settle</h2>
+      <p>
+        An observation is only worth what the page was doing when it was taken,
+        so <code>snapshot</code> and <code>--observe</code>
+        <strong>wait for the page to stop changing before they capture</strong>.
+        You do not have to guess a sleep in front of them:
+      </p>
+      <ul>
+        <li>the DOM has gone 100ms without a mutation,</li>
+        <li>no finite CSS transition or animation is still running (a spinner that loops forever is ignored — it never ends),</li>
+        <li>and no request fired by the action you just ran is still in flight.</li>
+      </ul>
+      <p>
+        Whichever takes longest wins, bounded by a 1 second ceiling. A static
+        page costs about 100ms; a click that fires an XHR waits for the response
+        instead of returning the pre-response tree as though it were the result.
+      </p>
+
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">bash</span>
+        </div>
+<pre><code><span class="du-prompt">$</span> chrome-use snapshot -i <span class="du-flag">--settle-ms</span> 3000   <span class="du-cmt"># raise the ceiling for a slow page</span>
+<span class="du-prompt">$</span> chrome-use snapshot -i <span class="du-flag">--no-settle</span>        <span class="du-cmt"># capture now, mid-flight</span></code></pre>
+      </div>
+
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ A ceiling that expires says so</div>
+        When the page is still moving at the ceiling, the reply carries
+        <code>Page had not settled after 1000ms (request in flight still active)</code>.
+        That means the tree may be mid-transition — re-read before trusting it.
+        A mid-transition capture passed off as the final one is worse than being
+        slow, so this line is never swallowed.
+      </div>
+
+      <p>
+        <code>AGENT_BROWSER_SETTLE_MS</code> sets the ceiling globally (0 disables
+        the wait) and <code>AGENT_BROWSER_SETTLE_QUIET_MS</code> sets the quiet
+        window. Waiting for something <strong>specific</strong> is still
+        <code>wait</code>'s job: the settle knows the page stopped, not that what
+        you wanted appeared.
+      </p>
+
+      <hr class="du-divider" />
+
       <!-- ============ EXPECT ============ -->
       <h2>Confirm the action landed — expect</h2>
       <p>

--- a/docs/en/waiting.html
+++ b/docs/en/waiting.html
@@ -129,6 +129,16 @@
       </div>
 
       <p>
+        Since the wait already happened, the pixels can ride along with it:
+        <code>--with-screenshot &lt;path&gt;</code> makes <code>snapshot</code> — or an action with
+        <code>--observe</code> — leave both the structure and an image from that
+        <strong>same settled moment</strong> (two separately-waited captures would describe two
+        different states, which is worse than not combining them). The tree still goes to stdout and
+        the image to disk: a screenshot is an <strong>output</strong> here, not the way an agent
+        reads a page.
+      </p>
+
+      <p>
         <code>AGENT_BROWSER_SETTLE_MS</code> sets the ceiling globally (0 disables
         the wait) and <code>AGENT_BROWSER_SETTLE_QUIET_MS</code> sets the quiet
         window. Waiting for something <strong>specific</strong> is still

--- a/docs/en/waiting.html
+++ b/docs/en/waiting.html
@@ -110,6 +110,15 @@
         instead of returning the pre-response tree as though it were the result.
       </p>
 
+      <p>
+        They differ in one way. A plain <code>snapshot</code> has no action to react to, so a still
+        page is its answer and it returns as soon as everything is quiet. After a mutating action,
+        <code>--observe</code> keeps watching for a <em>first</em> reaction for half the ceiling
+        (500ms by default) before it is willing to report <code>changed:false</code> — otherwise a
+        control that renders on a 300ms timer reads as "nothing happened". Only actions that really
+        change nothing pay that; anything that reacts ends the window at once.
+      </p>
+
       <div class="du-code">
         <div class="du-code-head">
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
@@ -122,7 +131,9 @@
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ A ceiling that expires says so</div>
         When the page is still moving at the ceiling, the reply carries
-        <code>Page had not settled after 1000ms (request in flight still active)</code>.
+        <code>Page had not settled after 1000ms (request in flight still active) — this capture
+        may be mid-transition. Re-read to confirm, or raise the ceiling with
+        AGENT_BROWSER_SETTLE_MS.</code>
         That means the tree may be mid-transition — re-read before trusting it.
         A mid-transition capture passed off as the final one is worse than being
         slow, so this line is never swallowed.

--- a/docs/interacting.html
+++ b/docs/interacting.html
@@ -163,7 +163,7 @@
 
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ 有多处匹配时它会拒绝，而不是替你挑第一个</div>
-        prefix / suffix 是**消歧用的上下文**，不属于被选中的内容。
+        prefix / suffix 是<strong>消歧用的上下文</strong>，不属于被选中的内容。
         「找不到」「找到了但上下文对不上」「有 N 处」是三条不同的提示 —— 解法本来就不同。
         Monaco / CodeMirror 有自己的选区模型，会被点名拒绝：在那上面做 DOM 选区看起来成功、实际没发生。
       </div>
@@ -179,7 +179,7 @@
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
           <span class="du-code-name">paste</span>
         </div>
-<pre><code><span class="du-prompt">$</span> chrome-use paste <span class="du-str">"第一行\n第二行"</span> <span class="du-flag">--selector</span> <span class="du-str">"#notes"</span>
+<pre><code><span class="du-prompt">$</span> chrome-use paste <span class="du-str">$'第一行\n第二行'</span> <span class="du-flag">--selector</span> <span class="du-str">"#notes"</span>  <span class="du-cmt"># $'...' 才是真换行</span>
 <span class="du-prompt">$</span> chrome-use paste <span class="du-str">"&lt;b&gt;粗体&lt;/b&gt;文字"</span> <span class="du-flag">--format</span> html <span class="du-flag">--selector</span> <span class="du-str">"#editor"</span>
 <span class="du-prompt">$</span> chrome-use paste <span class="du-str">"# 标题"</span> <span class="du-flag">--format</span> md            <span class="du-cmt"># Markdown 源码按纯文本插入</span></code></pre>
       </div>

--- a/docs/interacting.html
+++ b/docs/interacting.html
@@ -144,6 +144,55 @@
 
       <hr class="du-divider" />
 
+      <!-- ============ 字段内编辑 / 粘贴 ============ -->
+      <h2>字段内部编辑与带格式粘贴</h2>
+      <p>
+        <code>fill</code> 是整体替换，<code>type</code> 是追加。改一段写好的文字里的某一处、
+        或者只把光标放到某个位置继续写，这两个都做不到 —— 这是 <code>select-text</code> 的活。
+      </p>
+
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">select-text</span>
+        </div>
+<pre><code><span class="du-prompt">$</span> chrome-use select-text @e3 <span class="du-str">"确认"</span> <span class="du-flag">--prefix</span> <span class="du-str">"请"</span>   <span class="du-cmt"># 选中「确认」，不含「请」</span>
+<span class="du-prompt">$</span> chrome-use select-text @e3 <span class="du-str">"Hi Sam,"</span> <span class="du-flag">--cursor-after</span>  <span class="du-cmt"># 只放光标</span>
+<span class="du-prompt">$</span> chrome-use type @e3 <span class="du-str">" 顺便说一句："</span>                <span class="du-cmt"># 从光标处继续输入</span></code></pre>
+      </div>
+
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ 有多处匹配时它会拒绝，而不是替你挑第一个</div>
+        prefix / suffix 是**消歧用的上下文**，不属于被选中的内容。
+        「找不到」「找到了但上下文对不上」「有 N 处」是三条不同的提示 —— 解法本来就不同。
+        Monaco / CodeMirror 有自己的选区模型，会被点名拒绝：在那上面做 DOM 选区看起来成功、实际没发生。
+      </div>
+
+      <p>
+        富文本编辑器里，<strong>敲字和粘贴的结果不一样</strong>：<code>type "&lt;b&gt;粗体&lt;/b&gt;"</code>
+        得到的是这几个字符，<code>paste --format html</code> 得到的才是粗体。换行同理 ——
+        <code>type</code> 的换行会变成 Enter（在多数编辑器里等于提交或另起一块），<code>paste</code> 不会。
+      </p>
+
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">paste</span>
+        </div>
+<pre><code><span class="du-prompt">$</span> chrome-use paste <span class="du-str">"第一行\n第二行"</span> <span class="du-flag">--selector</span> <span class="du-str">"#notes"</span>
+<span class="du-prompt">$</span> chrome-use paste <span class="du-str">"&lt;b&gt;粗体&lt;/b&gt;文字"</span> <span class="du-flag">--format</span> html <span class="du-flag">--selector</span> <span class="du-str">"#editor"</span>
+<span class="du-prompt">$</span> chrome-use paste <span class="du-str">"# 标题"</span> <span class="du-flag">--format</span> md            <span class="du-cmt"># Markdown 源码按纯文本插入</span></code></pre>
+      </div>
+
+      <div class="du-callout tip">
+        <div class="du-callout-title">✅ 全程不碰你的真实剪贴板</div>
+        内容走的是合成 <code>ClipboardEvent</code>，不调用 <code>navigator.clipboard</code>，也不模拟 Ctrl+V。
+        这种事件是 untrusted 的、没有默认行为：监听 paste 的编辑器从自己的 handler 拿到内容，
+        不监听的则走一次真实插入 —— 回复里会写明走的是哪条。两条都没生效时它报错，不会打 ✓。
+      </div>
+
+      <hr class="du-divider" />
+
       <!-- ============ 键盘 ============ -->
       <h2>键盘</h2>
       <p>

--- a/docs/real-chrome.html
+++ b/docs/real-chrome.html
@@ -338,10 +338,19 @@
 
       <h2>默认静默运行</h2>
       <p>
-        驱动用户的真实 Chrome 时，agent 完全在<strong>后台</strong>工作——新标签页开出来时不聚焦，agent 从不强制把某个标签页顶到前台，
-        并且焦点是模拟的，所以后台页面仍然会渲染、并报告 <code>visibilityState: 'visible'</code>。你什么都不用做；
-        只是别指望用户的视图跟着你跑（只有当你<strong>刻意</strong>想让用户看到某个标签页时，才用显式的 <code>bringToFront</code> 把它顶到前台）。
+        驱动用户的真实 Chrome 时，agent 完全在<strong>后台</strong>工作——新标签页开出来时不聚焦，agent 从不强制把某个标签页顶到前台。
+        焦点是模拟的，所以页面照常渲染、计时器照常跑，不会被后台节流。你什么都不用做；只是别指望用户的视图跟着你跑。
       </p>
+
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ 但后台标签页确实是「隐藏」的</div>
+        <code>document.visibilityState</code> 始终是 <code>'hidden'</code>——焦点模拟改不了它，CDP 也没有能改它的开关。
+        绝大多数页面不在乎。例外是那些**刻意**按可见性决定要不要工作的页面（不让后台标签页续着设备租约、视频播放器、
+        会暂停的游戏）：它们渲染的是「后台分支」，于是 <code>snapshot</code> 看起来是空的、控件全是禁用的。
+        现在树接近为空且标签页隐藏时，<code>snapshot</code> 会把这件事说出来。遇到时用
+        <code>chrome-use bringToFront</code> 刻意把它顶到前台再读一次——这也是唯一会让用户视图跟着你跑的操作，
+        所以要刻意用，不要顺手用。
+      </div>
 
       <h2>行为层反-bot：拟人化输入</h2>
       <p>

--- a/docs/real-chrome.html
+++ b/docs/real-chrome.html
@@ -345,8 +345,8 @@
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ 但后台标签页确实是「隐藏」的</div>
         <code>document.visibilityState</code> 始终是 <code>'hidden'</code>——焦点模拟改不了它，CDP 也没有能改它的开关。
-        绝大多数页面不在乎。例外是那些**刻意**按可见性决定要不要工作的页面（不让后台标签页续着设备租约、视频播放器、
-        会暂停的游戏）：它们渲染的是「后台分支」，于是 <code>snapshot</code> 看起来是空的、控件全是禁用的。
+        绝大多数页面不在乎。例外是那些<strong>刻意</strong>按可见性决定要不要工作的页面（不让后台标签页续着设备租约、视频播放器、
+        会暂停的游戏）：它们渲染的是「后台分支」，于是 <code>snapshot</code> 可能是空的，你以为会有的控件不在或用不了。
         现在树接近为空且标签页隐藏时，<code>snapshot</code> 会把这件事说出来。遇到时用
         <code>chrome-use bringToFront</code> 刻意把它顶到前台再读一次——这也是唯一会让用户视图跟着你跑的操作，
         所以要刻意用，不要顺手用。

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -128,10 +128,10 @@
 
       <div class="du-callout note">
         <div class="du-callout-title">ℹ️ 没有可访问名的控件</div>
-        裸 <code>&lt;select&gt;</code>、图标按钮这类控件没有可访问名，于是 role + name 会匹配到页面上
+        裸 <code>&lt;select&gt;</code>、没有 aria-label 的图标按钮这类控件没有可访问名，于是 role + name 会匹配到页面上
         <strong>每一个</strong>同类控件，单靠它无法重锚一个失效的 ref。这种情况会退到快照记下的
         <strong>值</strong>（一个显示着 <code>Name (A to Z)</code> 的排序下拉，身份就在那里），
-        而且只有当它把候选缩到**恰好一个**时才采纳。仍然剩多个时命令照样拒绝 —— 但现在它会说
+        而且只有当它把候选缩到<strong>恰好一个</strong>时才采纳。仍然剩多个时命令照样拒绝 —— 但现在它会说
         <em>有 N 个元素无法区分</em>，而不是「页面上没有这个 role 和 name 的元素」：后者描述的是
         一件根本没发生的事（元素消失）。这时的解法是重新 <code>snapshot</code>（它会给重复项编号，
         新 ref 就带上了序号），或者直接用 CSS 选择器。

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -126,6 +126,17 @@
         <code>AGENT_BROWSER_VERIFY_REF_TIMEOUT_MS</code> 调大），无法确认的 ref 绝不会被动作。
       </div>
 
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ 没有可访问名的控件</div>
+        裸 <code>&lt;select&gt;</code>、图标按钮这类控件没有可访问名，于是 role + name 会匹配到页面上
+        <strong>每一个</strong>同类控件，单靠它无法重锚一个失效的 ref。这种情况会退到快照记下的
+        <strong>值</strong>（一个显示着 <code>Name (A to Z)</code> 的排序下拉，身份就在那里），
+        而且只有当它把候选缩到**恰好一个**时才采纳。仍然剩多个时命令照样拒绝 —— 但现在它会说
+        <em>有 N 个元素无法区分</em>，而不是「页面上没有这个 role 和 name 的元素」：后者描述的是
+        一件根本没发生的事（元素消失）。这时的解法是重新 <code>snapshot</code>（它会给重复项编号，
+        新 ref 就带上了序号），或者直接用 CSS 选择器。
+      </div>
+
       <h2>元素在 DOM 里，却不在快照里</h2>
       <p>
         多半是在屏幕外、或还没渲染出来。先把它滚进视口或等它出现，再重新快照。

--- a/docs/waiting.html
+++ b/docs/waiting.html
@@ -108,6 +108,13 @@
         而一次触发 XHR 的点击会等到响应回来，而不是把「响应前的树」当成结果返回。
       </p>
 
+      <p>
+        两者有一处不同：单独的 <code>snapshot</code> 没有动作要反应，页面静止就是答案，安静了立刻返回；
+        而动作之后的 <code>--observe</code> 会先花上限的一半（默认 500ms）盯着「有没有第一个反应」，
+        才肯报 <code>changed:false</code> —— 否则一个 300ms 后才渲染的控件会被读成「什么都没发生」。
+        这份代价只由真的什么都没做的动作承担；只要页面有反应，窗口立刻结束。
+      </p>
+
       <div class="du-code">
         <div class="du-code-head">
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
@@ -120,9 +127,10 @@
       <div class="du-callout warn">
         <div class="du-callout-title">⚠️ 上限到点了会说出来</div>
         页面到上限还在动时，回复里会带一行
-        <code>Page had not settled after 1000ms (request in flight still active)</code>——
-        意思是这张树可能是中间态，请重读一次再信它。中间态被当成最终态返回，
-        比慢更糟，所以这条永远不会被吞掉。
+        <code>Page had not settled after 1000ms (request in flight still active) — this capture
+        may be mid-transition. Re-read to confirm, or raise the ceiling with
+        AGENT_BROWSER_SETTLE_MS.</code>——意思是这张树可能是中间态，请重读一次再信它。
+        中间态被当成最终态返回，比慢更糟，所以这条永远不会被吞掉。
       </div>
 
       <p>

--- a/docs/waiting.html
+++ b/docs/waiting.html
@@ -91,6 +91,48 @@
 
       <hr class="du-divider" />
 
+      <!-- ============ SETTLE ============ -->
+      <h2>读之前它自己会等 — settle</h2>
+      <p>
+        一次观察值多少，取决于它拍下的那一刻页面在做什么。所以
+        <code>snapshot</code> 和 <code>--observe</code> <strong>会先等页面停下来再采集</strong>，
+        你不需要在前面自己塞一个 sleep：
+      </p>
+      <ul>
+        <li>DOM 连续 100ms 没有变更，</li>
+        <li>没有还在跑的有限时长过渡/动画（无限循环的 loading 转圈会被忽略——它永远不结束），</li>
+        <li>你刚触发的动作发出的请求都已经回来。</li>
+      </ul>
+      <p>
+        以最慢的那个为准，上限 1 秒。静态页面大约只花 100ms；
+        而一次触发 XHR 的点击会等到响应回来，而不是把「响应前的树」当成结果返回。
+      </p>
+
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">bash</span>
+        </div>
+<pre><code><span class="du-prompt">$</span> chrome-use snapshot -i <span class="du-flag">--settle-ms</span> 3000   <span class="du-cmt"># 慢页面：把上限调高</span>
+<span class="du-prompt">$</span> chrome-use snapshot -i <span class="du-flag">--no-settle</span>        <span class="du-cmt"># 就要中间态：不等，立刻采</span></code></pre>
+      </div>
+
+      <div class="du-callout warn">
+        <div class="du-callout-title">⚠️ 上限到点了会说出来</div>
+        页面到上限还在动时，回复里会带一行
+        <code>Page had not settled after 1000ms (request in flight still active)</code>——
+        意思是这张树可能是中间态，请重读一次再信它。中间态被当成最终态返回，
+        比慢更糟，所以这条永远不会被吞掉。
+      </div>
+
+      <p>
+        全局可用 <code>AGENT_BROWSER_SETTLE_MS</code>（设 0 关闭等待）和
+        <code>AGENT_BROWSER_SETTLE_QUIET_MS</code> 调。等<strong>某个具体条件</strong>
+        仍然是 <code>wait</code> 的活：settle 只知道页面停了，不知道你要的东西出现了没有。
+      </p>
+
+      <hr class="du-divider" />
+
       <!-- ============ EXPECT ============ -->
       <h2>确认动作生效 — expect</h2>
       <p>

--- a/docs/waiting.html
+++ b/docs/waiting.html
@@ -126,6 +126,13 @@
       </div>
 
       <p>
+        既然已经等过一次，像素就可以搭这趟车：<code>--with-screenshot &lt;path&gt;</code>
+        让 <code>snapshot</code> 或带 <code>--observe</code> 的动作在<strong>同一个稳定时刻</strong>
+        同时留下结构和截图（各等各的会得到两个时刻的东西，那比不合并还糟）。结构照旧走 stdout，
+        图片落盘并在输出里报路径 —— 截图在这里是<strong>输出</strong>，不是 agent 读页面的方式。
+      </p>
+
+      <p>
         全局可用 <code>AGENT_BROWSER_SETTLE_MS</code>（设 0 关闭等待）和
         <code>AGENT_BROWSER_SETTLE_QUIET_MS</code> 调。等<strong>某个具体条件</strong>
         仍然是 <code>wait</code> 的活：settle 只知道页面停了，不知道你要的东西出现了没有。

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -755,7 +755,11 @@ ceiling expires with the page still moving, the reply says so
 warning means the tree may be mid-transition, so re-read rather than trusting
 it. Spinners that loop forever are ignored on purpose; they never end. Tune
 with `--settle-ms <ms>` (or `AGENT_BROWSER_SETTLE_MS`) and switch it off with
-`--no-settle` when you deliberately want the page mid-flight. Waiting for
+`--no-settle` when you deliberately want the page mid-flight. Since the wait
+already happened, `--with-screenshot <path>` saves the pixels from that same
+settled moment (`snapshot -i --with-screenshot ./page.png`, or an action with
+`--observe`) — the tree is still what you read the page from; the image is an
+output to look at or attach, and never a substitute for the structural read. Waiting for
 something *specific* is still `wait`'s job — the settle only knows that the
 page stopped, not that what you wanted appeared.
 

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -744,6 +744,21 @@ After any page-changing action, pick one:
 Avoid bare `wait 2000` except when debugging — it makes scripts slow and
 flaky. Timeouts default to 25 seconds.
 
+**Do not sleep before reading the page.** `snapshot` and `--observe` wait by
+themselves: before capturing they wait for the DOM to stop mutating, for finite
+transitions to finish, and for requests fired by the action to come back —
+whichever takes longest, up to a 1 second ceiling, and they return the moment
+the page goes quiet (a static page costs about 100ms, not the ceiling). A
+`wait 2000` in front of a snapshot buys nothing and costs two seconds. If the
+ceiling expires with the page still moving, the reply says so
+(`Page had not settled after 1000ms (request in flight still active)`) — that
+warning means the tree may be mid-transition, so re-read rather than trusting
+it. Spinners that loop forever are ignored on purpose; they never end. Tune
+with `--settle-ms <ms>` (or `AGENT_BROWSER_SETTLE_MS`) and switch it off with
+`--no-settle` when you deliberately want the page mid-flight. Waiting for
+something *specific* is still `wait`'s job — the settle only knows that the
+page stopped, not that what you wanted appeared.
+
 ### Confirm an action worked — `expect`
 
 After acting, **assert the result instead of eyeballing a snapshot**. `expect`
@@ -793,6 +808,31 @@ additions. This is the one flag that collapses `navigate` + `snapshot` into a
 single call: `chrome-use navigate <url> --observe` gets you the page AND its
 interactive tree in one round trip. On a real task that halved the calls (6 → 3)
 at identical bytes returned.
+
+**Edit one phrase inside a field — `select-text`.** `fill` replaces the whole
+value and `type` appends, so changing a single word in a written paragraph, or
+placing the cursor and carrying on, used to need hand-written `eval`.
+`chrome-use select-text @e3 "confirm" --prefix "please "` selects exactly
+`confirm` (the prefix is context for finding it, not part of the selection);
+`--cursor-before` / `--cursor-after` leave a caret instead, so the next `type`
+lands there. Works on `<input>`, `<textarea>` and contenteditable. A phrase that
+appears more than once is refused with the count instead of resolved to the
+first one, and "not found", "found but not with that prefix/suffix" and "matches
+N places" are three different messages because they have three different fixes.
+Monaco and CodeMirror are refused by name — they keep their own selection model,
+where a DOM selection looks applied and does nothing; use `fill` there.
+
+**Paste with a MIME type — `paste`.** In a rich-text editor, typing and pasting
+produce different documents: `type "<b>bold</b>"` gives you those eleven
+characters, `chrome-use paste "<b>bold</b>" --format html --selector "#editor"`
+gives you bold text. Newlines are the other reason: `type` sends Enter, which in
+most editors submits or splits a block, while `paste` inserts the break — so
+prefer `paste` for multi-line content. `--format md` inserts Markdown source as
+plain text. **Your real clipboard is never touched**: the content rides on a
+synthetic ClipboardEvent, with no `navigator.clipboard` call and no Ctrl+V. Such
+an event is untrusted and has no default action, so an editor that listens gets
+it through its own handler and one that ignores it gets a real insert; the reply
+names which path ran, and a paste that changed nothing is an error, not a ✓.
 
 **Operate a control that click alone won't move — `actions` / `do`.** Some
 elements expose more than a click: a disclosure expands, a menu button opens a

--- a/skill-data/core/SKILL.md
+++ b/skill-data/core/SKILL.md
@@ -750,10 +750,18 @@ transitions to finish, and for requests fired by the action to come back —
 whichever takes longest, up to a 1 second ceiling, and they return the moment
 the page goes quiet (a static page costs about 100ms, not the ceiling). A
 `wait 2000` in front of a snapshot buys nothing and costs two seconds. If the
-ceiling expires with the page still moving, the reply says so
-(`Page had not settled after 1000ms (request in flight still active)`) — that
-warning means the tree may be mid-transition, so re-read rather than trusting
-it. Spinners that loop forever are ignored on purpose; they never end. Tune
+ceiling expires with the page still moving, the reply says so — `Page had not
+settled after 1000ms (request in flight still active) — this capture may be
+mid-transition. Re-read to confirm, or raise the ceiling with
+AGENT_BROWSER_SETTLE_MS.` — so re-read rather than trusting that tree.
+
+The two differ in one way. A plain `snapshot` has no action to react to, so a
+still page is its answer and it returns as soon as everything is quiet. After a
+mutating action, `--observe` keeps watching for a *first* reaction for half the
+ceiling (500ms by default) before it is willing to report `changed:false` —
+otherwise a control that renders on a 300ms timer reads as "nothing happened".
+Only actions that really change nothing pay that; anything that reacts ends the
+window at once. Spinners that loop forever are ignored on purpose; they never end. Tune
 with `--settle-ms <ms>` (or `AGENT_BROWSER_SETTLE_MS`) and switch it off with
 `--no-settle` when you deliberately want the page mid-flight. Since the wait
 already happened, `--with-screenshot <path>` saves the pixels from that same

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -58,6 +58,7 @@ chrome-use snapshot -i --max-bytes 4000   # Cap the tree; cuts between nodes, re
 chrome-use snapshot -i --max-bytes 4000 --from 70   # Read on from where the last one stopped
 chrome-use snapshot -i --settle-ms 3000   # Raise the pre-capture wait ceiling (default 1000ms)
 chrome-use snapshot -i --no-settle         # Capture now, without waiting for the page to stop changing
+chrome-use snapshot -i --with-screenshot ./page.png   # Tree on stdout + pixels on disk, from the same settled moment
 chrome-use read <url>          # Fetch a URL as agent-readable markdown/text (prefers .md/llms.txt, HTML→markdown fallback)
 chrome-use read                # No URL: read the rendered DOM of the active tab
 chrome-use read <url> --outline        # Heading outline only

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -91,7 +91,7 @@ chrome-use fill @e2 "text"     # Clear and type
 chrome-use type @e2 "text"     # Type without clearing (add --clear to clear first, --delay <ms> for per-key delay)
 chrome-use select-text @e2 "confirm" --prefix "please "   # Select one run of text inside the field (prefix/suffix disambiguate; they are not selected)
 chrome-use select-text @e2 "Hi Sam," --cursor-after       # Place the caret instead of selecting, so the next `type` continues there
-chrome-use paste "line one\nline two" --selector @e2      # Paste (newline stays a newline; the real clipboard is untouched)
+chrome-use paste $'line one\nline two' --selector @e2     # Paste ($'...' so the shell sends a real newline; the clipboard is untouched)
 chrome-use paste "<b>bold</b>" --format html --selector @e2  # Paste as text/html; --format md inserts Markdown source as plain text
 chrome-use press Enter         # Press key at current focus (alias: key); output names the target; ⚠ warns when the page has no listener for a JS-only key
 chrome-use press Enter --selector @e2  # Focus the target first (alias: --on)

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -99,6 +99,7 @@ chrome-use press Control+a     # Key combination
 chrome-use keydown Shift       # Hold key down
 chrome-use keyup Shift         # Release key
 chrome-use hover @e1           # Hover
+chrome-use bringToFront        # Surface the active tab (tabs are driven in the background, where document.visibilityState stays 'hidden')
 chrome-use check @e1           # Check checkbox
 chrome-use uncheck @e1         # Uncheck checkbox
 chrome-use select @e1 "value"  # Select by value/label; native setter commits controlled forms

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -56,6 +56,8 @@ chrome-use snapshot -i -f "SSH|Save"   # Keep matching lines + ancestor context 
 chrome-use snapshot -i --diff  # Only what changed since this session's last snapshot of the same page
 chrome-use snapshot -i --max-bytes 4000   # Cap the tree; cuts between nodes, reports what it omitted
 chrome-use snapshot -i --max-bytes 4000 --from 70   # Read on from where the last one stopped
+chrome-use snapshot -i --settle-ms 3000   # Raise the pre-capture wait ceiling (default 1000ms)
+chrome-use snapshot -i --no-settle         # Capture now, without waiting for the page to stop changing
 chrome-use read <url>          # Fetch a URL as agent-readable markdown/text (prefers .md/llms.txt, HTML→markdown fallback)
 chrome-use read                # No URL: read the rendered DOM of the active tab
 chrome-use read <url> --outline        # Heading outline only
@@ -86,6 +88,10 @@ chrome-use dblclick @e1        # Double-click
 chrome-use focus @e1           # Focus element
 chrome-use fill @e2 "text"     # Clear and type
 chrome-use type @e2 "text"     # Type without clearing (add --clear to clear first, --delay <ms> for per-key delay)
+chrome-use select-text @e2 "confirm" --prefix "please "   # Select one run of text inside the field (prefix/suffix disambiguate; they are not selected)
+chrome-use select-text @e2 "Hi Sam," --cursor-after       # Place the caret instead of selecting, so the next `type` continues there
+chrome-use paste "line one\nline two" --selector @e2      # Paste (newline stays a newline; the real clipboard is untouched)
+chrome-use paste "<b>bold</b>" --format html --selector @e2  # Paste as text/html; --format md inserts Markdown source as plain text
 chrome-use press Enter         # Press key at current focus (alias: key); output names the target; ⚠ warns when the page has no listener for a JS-only key
 chrome-use press Enter --selector @e2  # Focus the target first (alias: --on)
 chrome-use press Control+a     # Key combination

--- a/skill-data/real-chrome/SKILL.md
+++ b/skill-data/real-chrome/SKILL.md
@@ -194,11 +194,21 @@ browser has no headless/automation tells at all, so prefer it for anything
 anti-bot-sensitive.
 
 **Silent by default.** When driving the user's real Chrome the agent works
-entirely in the background — new tabs open un-focused, the agent never force-
-fronts a tab, and focus is emulated so the page still renders and reports
-`visibilityState: 'visible'`. You don't need to do anything; just don't expect
-the user's view to follow you (use the explicit `bringToFront` only if you
-deliberately want to surface a tab).
+entirely in the background — new tabs open un-focused and the agent never
+force-fronts a tab. Focus is emulated, so the page keeps rendering and keeps
+running timers instead of being throttled. You don't need to do anything; just
+don't expect the user's view to follow you.
+
+**But a background tab really is hidden.** `document.visibilityState` stays
+`'hidden'` — focus emulation does not change it, and no CDP override does
+either (issue #215). Almost nothing cares. The exception is a page that
+deliberately gates its UI on visibility (a device lease that must not be kept
+alive by a background tab, a video player, a game that pauses): it renders its
+background branch, so `snapshot` comes back looking empty and every control
+reads as disabled. `snapshot` now says so when the tree is near-empty and the
+tab is hidden. When you hit that, surface the tab on purpose with
+`chrome-use bringToFront` and read it again — that is also the only thing that
+makes the user's view follow you, so use it deliberately, not by habit.
 
 **Human-like input for behavioural anti-bot.** Beyond fingerprint stealth,
 `--humanize off|fast|human` (or `AGENT_BROWSER_HUMANIZE`) makes clicks follow a

--- a/skill-data/real-chrome/SKILL.md
+++ b/skill-data/real-chrome/SKILL.md
@@ -204,8 +204,8 @@ don't expect the user's view to follow you.
 either (issue #215). Almost nothing cares. The exception is a page that
 deliberately gates its UI on visibility (a device lease that must not be kept
 alive by a background tab, a video player, a game that pauses): it renders its
-background branch, so `snapshot` comes back looking empty and every control
-reads as disabled. `snapshot` now says so when the tree is near-empty and the
+background branch, so `snapshot` can come back empty and the controls you
+expect may be missing or unavailable. `snapshot` now says so when the tree is near-empty and the
 tab is hidden. When you hit that, surface the tab on purpose with
 `chrome-use bringToFront` and read it again — that is also the only thing that
 makes the user's view follow you, so use it deliberately, not by habit.


### PR DESCRIPTION
按 #232 排好的顺序做完了能在这一轮做完的七条，每条都有测试。剩下四条为什么没做，写在最后。

| issue | 做了什么 |
|---|---|
| #228 | 观察前的自适应等待：DOM 静默 + 动画 + 在飞的请求，上限 1 秒，超时会说出来 |
| #227 | `paste --format text\|md\|html`，全程不碰真实剪贴板 |
| #226 | `select-text`：字段内选中一段文字 / 放光标，带前后缀消歧 |
| #224 | 无 accessible name 的控件：按值恢复 @ref，并把「分不出来」和「不存在」分开说 |
| #229 | `--with-screenshot`：结构与像素来自同一个稳定时刻（复用 #228 的等待） |
| #231 | 基准记录正确率、warm/cold、二进制版本，失败调用单独计数 |
| #215 | 后台标签页确实是 hidden：纠正文档，并让 snapshot 说出来 |

---

## #228 观察前的自适应等待

`--observe` 动作后固定 `sleep(250ms)`，`snapshot` 完全不等。固定值两头不讨好：250ms 不够时把中间态当成结果返回（静默的错误，比慢更糟），够用时每次调用白付。

改成等信号：**DOM 静默**（100ms 无变更）、**有限时长的动画/过渡结束**（无限循环的 loading 转圈忽略掉——它永远不结束）、**动作发出的请求回来**。最后一条是页面侧的等待看不见的：一次点击触发的 XHR，整个往返里 DOM 都是静止的，而那份静止正是旧的 250ms 返回的那棵中间态的树。

上限 1 秒（`--settle-ms` / `AGENT_BROWSER_SETTLE_MS`，`--no-settle` 关掉）。到点还在动时回复里带一行 `Page had not settled after 1000ms (request in flight still active) — this capture may be mid-transition.`

**还有一类信号完全不存在**：`setTimeout` 里 450ms 后才插入的 DOM，在它发生前页面是静止的、没有动画、没有请求。所以动作之后的观察会先花上限的一半盯着「有没有反应」再肯说「什么都没变」；窗口跟着上限缩放，`--settle-ms` 因此是唯一的旋钮。代价只由真的什么都没做的动作承担。`snapshot` 不带这个窗口——没有动作要反应，静止就是答案。

网络这一半要求无条件记账 `requestWillBeSent` / `loadingFinished` / `loadingFailed`（原来只在 HAR 或 `network requests` 打开时才记），否则这个等待要看谁碰巧开了别的功能才睁眼；SSE / 长轮询按年龄淘汰。

验收对应 issue 的三条：慢渲染页面能等到最终态、静态页不再白付（实测约 115ms）、超时会明说 —— 外加飞在路上的请求，四个 e2e。

## #227 `paste --format`

`type "<b>粗体</b>"` 得到的是那几个字符，`paste --format html` 得到的才是粗体；换行也保持换行，而不是变成 Enter。

**不碰用户的真实剪贴板**：走合成 `ClipboardEvent` 上的 `DataTransfer`，不调用 `navigator.clipboard`，也不模拟 Ctrl+V（e2e 里把 clipboard 的方法换成计数器，断言为 0）。合成事件 untrusted、没有默认行为，所以效果要回读：监听 paste 的编辑器从自己的 handler 拿到内容（`engine=paste-event`），不监听的走一次真实插入（`insert-html` / `insert-text`）。两条都没生效时报错，不打 ✓。

## #226 `select-text`

`fill` 整体替换、`type` 追加，改一段写好的文字里的某一处只能退回 `eval`。`select-text @e3 "确认" --prefix "请"` 选中的是「确认」——prefix/suffix 是消歧上下文，不属于选区；`--cursor-before` / `--cursor-after` 只放光标。支持 `<input>` / `<textarea>`（setSelectionRange）与 contenteditable（Range/Selection）。

三种失败分开报：找不到 / 找到了但上下文对不上 / 有 N 处。第三种绝不替调用方挑第一个——把「候选太多」说成「没找到」正是 #224 反复咬人的地方。Monaco 与 CodeMirror 点名拒绝。

## #224 无 accessible name 的控件

裸 `<select>` 没有可访问名，role + name 会匹配到页面上每一个同类控件，节点一被替换就没救。补一条判别信号：**快照当时记下的值**，且只有缩到恰好一个时才采纳。方向不是放宽校验（#162 的教训），而是在 name 为空时换依据。

措辞同样改了：原来的「no element with that role and name is on the page now」描述的是「元素消失了」，实际发生的是「有太多个，分不出来」。现在会说有几个候选、值为什么也没能区分，并给出真的管用的两条出路。

e2e 两个，其中「靠值恢复」那条**临时关掉信号验证过它确实会失败**。

## #229 `--with-screenshot`

`snapshot -i --with-screenshot ./page.png`，或动作 `--observe --with-screenshot`。关键是 issue 自己点名的前提：#228 之后**复用同一次等待**，而不是各等各的——后者会得到两个时刻的东西，比不合并还糟。结构走 stdout，图片落盘只报路径：截图仍是输出，不是 agent 读页面的方式。采集走 `screenshot` 处理器本身，所以目标漂移与纯色空图两道护栏一并适用。

## #231 基准

只比往返和字节，会把「跑了一半就停」排在「跑完了」前面。现在：任务文件用 `#! assert <expect-args>` 声明终态并自动判定（**没有断言记 `none`，不记 pass**）；TSV 头部记二进制路径与版本、warm/cold、机器负载；每条调用记 exit code，失败调用单独计数。`BENCH_WARMUP=0` 用来故意测冷启动。

用桩二进制跑通了三条路径（部分断言失败→FAIL、无断言→none、冷启动→warm false）；真实浏览器路径在本沙箱里跑不了（daemon 起不来、外网被拦）。

## #215 后台标签页

skill 和文档写着「焦点是模拟的，所以后台页面报告 `visibilityState: 'visible'`」——这句是错的。焦点模拟不影响可见性，`visibilityState` 始终 `'hidden'`，CDP 也没有能改它的开关。绝大多数页面不在乎，例外是刻意按可见性决定要不要工作的页面：它们渲染后台分支，于是快照看起来是空的，而树里没有任何东西说明为什么。

`snapshot` 在树接近为空时本来就会探一次画布，那次探测顺便读 `visibilityState`（同一个 eval，不多花往返），隐藏时给出说明并指向 `bringToFront`。文档改成事实，`bringToFront` 补进 `--help` 与 commands 参考——issue 说得对：skill 里提到、`--help` 里找不到的命令，等于不存在。

---

## 测试

- 单测：settle 10、命令解析 5、#224 两条、#215 一条
- e2e 12 条，全部在真 Chromium 141 上跑通
- 既有单测与 e2e **无新增失败**：本机 40 个单测失败、25 个 e2e 失败在改动前后完全一致，都是环境原因（外网 `ERR_CONNECTION_RESET`、缺 ffmpeg、并行下的环境变量互扰）
- `cargo clippy -D warnings` 干净（`src/doctor/helpers.rs:48` 那条是本平台既有的，与本 PR 无关）

文档按 AGENTS.md 的六处清单更新：`--help` 与环境变量、README 中英、`skill-data/core`（SKILL.md + references）、`skill-data/real-chrome`、`docs/` 与 `docs/en/` 的 waiting / interacting / troubleshooting / real-chrome 八页、以及相关源码注释。

## 没做的四条，以及为什么

- **#230（`do @ref showMenu` 等同于 click）** —— issue 自己写着「先攒真实案例再动手，不要凭想象加重试逻辑」，这一轮没有新的失败组件可看。
- **#216（闲置约 2 分钟后标签页被重置成 about:blank）** —— 查了 idle 路径：默认 10 分钟，且对自己启动的浏览器是 `mgr.close()`（关掉进程），不是把标签页导航到 about:blank；对外部连接连关都不关（#210）。也就是说**报告里的 2 分钟重置不是这条路径**，根因还没找到，而本沙箱没有显示器、daemon 起不来，无法复现。凭猜加一个 `session hold` 反而会给出虚假的安全感。
- **#217 / #218（扩展 relay 抢/丢标签页、跨源 overlay widget）** —— 都需要真实 Chrome + 扩展 relay 才能复现和验证，同上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cwxFXikdWKBSro6E3AxRW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `select-text` for selecting text or positioning the cursor in editable fields.
  - Added `paste` with plain text, Markdown, and HTML formatting.
  - Added adaptive settling for snapshots and observations, including timeout controls, warnings, and optional screenshots.
  - Added cold-run and end-state verification options for benchmark replay.

- **Bug Fixes**
  - Improved error reporting for ambiguous or unsuccessful text interactions.
  - Snapshot output now identifies hidden tabs with near-empty content.

- **Documentation**
  - Expanded command, waiting, interaction, troubleshooting, browser, and benchmarking documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->