### PR TITLE
fix: serving a skill reference is a success, and must report as one

### DIFF
--- a/cli/src/skills.rs
+++ b/cli/src/skills.rs
@@ -305,7 +305,8 @@ fn resolve_supplementary(skill_dir: &Path, stem: &str) -> Option<(String, String
 
 /// Split `core/waiting` into `("core", Some("waiting"))`, leaving a plain skill
 /// name alone. Only the first separator matters, so `core/references/waiting`
-/// keeps its subdirectory for [`resolve_supplementary`] to strip.
+/// hands `references/waiting` to [`resolve_supplementary`], which honours that
+/// directory rather than discarding it.
 fn split_reference_request(name: &str) -> (&str, Option<&str>) {
     match name.split_once('/') {
         Some((skill, rest)) if !skill.is_empty() && !rest.is_empty() => (skill, Some(rest)),

--- a/cli/src/skills.rs
+++ b/cli/src/skills.rs
@@ -274,28 +274,32 @@ fn read_skill_tiered(skill_md: &Path, full: bool) -> Option<String> {
 /// have made that detail unreachable rather than deferred. Deferred loading is
 /// only deferred if there is a way to load it.
 ///
-/// The stem is matched with and without an extension, and against both
-/// subdirectories, so `core/waiting`, `core/waiting.md` and
-/// `core/references/waiting.md` all resolve to the same file.
+/// The stem is matched with and without an extension, and a bare stem is
+/// matched against both subdirectories, so `core/waiting`, `core/waiting.md`
+/// and `core/references/waiting.md` all resolve to the same file.
+///
+/// A request that names its directory is honoured as written. Matching a
+/// `templates/` request on the basename alone would silently serve
+/// `references/` instead -- that directory is enumerated first, so it always
+/// wins a tie -- and handing back a different file than the one asked for,
+/// under a `✓`, is the failure this repo exists to avoid.
 fn resolve_supplementary(skill_dir: &Path, stem: &str) -> Option<(String, String)> {
-    let wanted = stem
-        .trim_start_matches("references/")
-        .trim_start_matches("templates/")
-        .trim_end_matches(".md")
-        .to_ascii_lowercase();
-    if wanted.is_empty() {
+    let requested = stem.trim_end_matches(".md").to_ascii_lowercase();
+    if requested.is_empty() {
         return None;
     }
+    // `references/waiting` pins the directory; `waiting` does not.
+    let pinned = requested.starts_with("references/") || requested.starts_with("templates/");
+
     collect_supplementary_files(skill_dir)
         .into_iter()
         .find(|(rel, _)| {
-            let base = rel
-                .rsplit('/')
-                .next()
-                .unwrap_or(rel)
-                .trim_end_matches(".md")
-                .to_ascii_lowercase();
-            base == wanted
+            let rel = rel.trim_end_matches(".md").to_ascii_lowercase();
+            if pinned {
+                rel == requested
+            } else {
+                rel.rsplit('/').next().unwrap_or(&rel) == requested
+            }
         })
 }
 
@@ -393,6 +397,13 @@ fn run_get(
 ) {
     let all_skills = discover_skills(skills_dirs, override_used);
 
+    // References resolved from this request, held until the loop ends so that
+    // `--json` emits ONE document. Printing inside the loop concatenates a
+    // top-level object per name, which no JSON parser accepts -- and the
+    // ordinary skill path already batches, so the two disagreed.
+    let mut references: Vec<serde_json::Value> = Vec::new();
+    let mut printed_references = 0usize;
+
     let targets: Vec<&SkillInfo> = if get_all {
         all_skills.iter().filter(|s| !s.hidden).collect()
     } else {
@@ -415,17 +426,16 @@ fn run_get(
                     Some(s) => match resolve_supplementary(&s.dir, stem) {
                         Some((rel, content)) => {
                             if json_mode {
-                                println!(
-                                    "{}",
-                                    serde_json::to_string(&json!({
-                                        "success": true,
-                                        "skill": s.name,
-                                        "reference": rel,
-                                        "content": content,
-                                    }))
-                                    .unwrap_or_default()
-                                );
+                                references.push(json!({
+                                    "skill": s.name,
+                                    "reference": rel,
+                                    "content": content,
+                                }));
                             } else {
+                                if printed_references > 0 {
+                                    println!("\n---\n");
+                                }
+                                printed_references += 1;
                                 println!("{}", content.trim_end());
                             }
                             continue;
@@ -495,7 +505,33 @@ fn run_get(
         targets
     };
 
+    // A request for references only leaves `targets` empty, which is success,
+    // not the "no skill name" error below.
+    //
+    // One reference keeps the flat shape it has always emitted -- a consumer
+    // reading `.content` off a single get must not break to fix a multi-get it
+    // never made. More than one nests under `references`, because the
+    // alternative is several top-level objects and no parser accepts that.
+    if !references.is_empty() {
+        let doc = if references.len() == 1 {
+            let mut obj = references.remove(0);
+            if let Some(map) = obj.as_object_mut() {
+                map.insert("success".to_string(), json!(true));
+            }
+            obj
+        } else {
+            json!({ "success": true, "references": references })
+        };
+        println!("{}", serde_json::to_string(&doc).unwrap_or_default());
+        if targets.is_empty() {
+            return;
+        }
+    }
+
     if targets.is_empty() {
+        if printed_references > 0 {
+            return;
+        }
         if json_mode {
             println!(
                 "{}",
@@ -995,6 +1031,38 @@ mod tests {
         assert_eq!(files[0].0, "references/auth.md");
         assert_eq!(files[1].0, "references/commands.md");
         assert_eq!(files[2].0, "templates/example.sh");
+    }
+
+    /// A request that names its directory must get that directory's file.
+    ///
+    /// `collect_supplementary_files` walks `references/` before `templates/`,
+    /// so a basename-only match hands back the reference for every colliding
+    /// stem -- silently serving a different file than the one asked for.
+    #[test]
+    fn an_explicit_directory_is_not_traded_for_the_other_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let refs_dir = tmp.path().join("references");
+        let templates_dir = tmp.path().join("templates");
+        fs::create_dir_all(&refs_dir).unwrap();
+        fs::create_dir_all(&templates_dir).unwrap();
+        fs::write(refs_dir.join("waiting.md"), "# reference\n").unwrap();
+        fs::write(templates_dir.join("waiting.md"), "# template\n").unwrap();
+
+        let (rel, content) = resolve_supplementary(tmp.path(), "templates/waiting").unwrap();
+        assert_eq!(rel, "templates/waiting.md");
+        assert!(content.contains("template"), "{content}");
+
+        let (rel, _) = resolve_supplementary(tmp.path(), "references/waiting.md").unwrap();
+        assert_eq!(rel, "references/waiting.md");
+
+        // A bare stem stays a bare stem: first match wins, as before.
+        let (rel, _) = resolve_supplementary(tmp.path(), "waiting").unwrap();
+        assert_eq!(rel, "references/waiting.md");
+
+        // A pinned directory that holds no such file resolves to nothing
+        // rather than falling back to the other directory.
+        fs::remove_file(templates_dir.join("waiting.md")).unwrap();
+        assert!(resolve_supplementary(tmp.path(), "templates/waiting").is_none());
     }
 
     /// A bare skill name must keep working; only an embedded separator asks

--- a/cli/src/skills.rs
+++ b/cli/src/skills.rs
@@ -509,11 +509,13 @@ fn run_get(
     // A request for references only leaves `targets` empty, which is success,
     // not the "no skill name" error below.
     //
-    // One reference keeps the flat shape it has always emitted -- a consumer
-    // reading `.content` off a single get must not break to fix a multi-get it
-    // never made. More than one nests under `references`, because the
-    // alternative is several top-level objects and no parser accepts that.
-    if !references.is_empty() {
+    // One reference on its own keeps the flat shape it has always emitted -- a
+    // consumer reading `.content` off a single get must not break to fix a
+    // multi-get it never made. Anything else nests, because the alternative is
+    // several top-level objects and no parser accepts that. A request mixing
+    // references and skills carries both in ONE document for the same reason:
+    // `--json` exists so a program can read the output.
+    if !references.is_empty() && targets.is_empty() {
         let doc = if references.len() == 1 {
             let mut obj = references.remove(0);
             if let Some(map) = obj.as_object_mut() {
@@ -524,9 +526,7 @@ fn run_get(
             json!({ "success": true, "references": references })
         };
         println!("{}", serde_json::to_string(&doc).unwrap_or_default());
-        if targets.is_empty() {
-            return;
-        }
+        return;
     }
 
     if targets.is_empty() {
@@ -574,13 +574,18 @@ fn run_get(
                 obj
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string(&json!({ "success": true, "data": items })).unwrap_or_default()
-        );
+        let mut doc = json!({ "success": true, "data": items });
+        if !references.is_empty() {
+            doc["references"] = json!(references);
+        }
+        println!("{}", serde_json::to_string(&doc).unwrap_or_default());
     } else {
         for (i, s) in targets.iter().enumerate() {
-            if i > 0 {
+            // References printed above are part of the same stream, so the
+            // first skill still needs a separator after them. Without one a
+            // reference runs straight into a SKILL.md whose own frontmatter
+            // opens with `---`, which reads as a separator but is not.
+            if i > 0 || printed_references > 0 {
                 println!("\n---\n");
             }
             let skill_md = s.dir.join("SKILL.md");

--- a/cli/tests/skills_get_cli.rs
+++ b/cli/tests/skills_get_cli.rs
@@ -132,6 +132,59 @@ fn an_explicit_template_request_is_not_served_the_reference() {
     assert!(doc["content"].as_str().unwrap().contains("alpha reference"));
 }
 
+/// A request mixing a reference and a skill is still ONE JSON document.
+///
+/// The reference branch and the skill branch each printed their own top-level
+/// object, so asking for both produced two concatenated values -- the same
+/// unparseable output as the multi-reference case, by a different route.
+#[test]
+fn a_reference_and_a_skill_together_are_one_document() {
+    let tmp = fixture();
+    let (stdout, stderr, code) = run(&tmp, &["--json", "demo/alpha", "demo"]);
+    assert_eq!(code, 0, "stderr={stderr}");
+
+    let doc: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("not one document: {e}\n{stdout}"));
+    assert_eq!(doc["success"], serde_json::json!(true));
+
+    let refs = doc["references"]
+        .as_array()
+        .expect("the reference is carried");
+    assert_eq!(refs.len(), 1, "{doc}");
+    assert_eq!(
+        refs[0]["reference"],
+        serde_json::json!("references/alpha.md")
+    );
+
+    let data = doc["data"].as_array().expect("the skill is carried");
+    assert_eq!(data.len(), 1, "{doc}");
+    assert_eq!(data[0]["name"], serde_json::json!("demo"));
+}
+
+/// The same request in text mode separates the reference from the skill.
+///
+/// A SKILL.md opens with `---` frontmatter, so a reference printed directly
+/// above it runs into what looks like a separator but is the skill's own
+/// header -- the reader cannot tell where one ends.
+#[test]
+fn a_reference_and_a_skill_together_are_separated_in_text_mode() {
+    let tmp = fixture();
+    let (stdout, _, code) = run(&tmp, &["demo/alpha", "demo"]);
+    assert_eq!(code, 0);
+
+    let reference_end = stdout.find("alpha reference").expect("the reference") + 1;
+    let skill_start = stdout.find("name: demo").expect("the skill frontmatter");
+    let between = &stdout[reference_end..skill_start];
+    // The separator is a BLANK-LINE-delimited `---`. A bare `---\n` would also
+    // match the skill's own frontmatter opener, which is the very thing that
+    // makes unseparated output ambiguous -- an assertion accepting it passes
+    // on the bug.
+    assert!(
+        between.contains("\n\n---\n\n"),
+        "no separator between reference and skill: {stdout:?}"
+    );
+}
+
 /// Text mode separates several references instead of running them together.
 ///
 /// Without a separator two files arrive as one run-on document, and a reader

--- a/cli/tests/skills_get_cli.rs
+++ b/cli/tests/skills_get_cli.rs
@@ -1,0 +1,140 @@
+//! Integration tests for `chrome-use skills get`.
+//!
+//! These spawn the real CLI binary so the assertion is on what a caller
+//! actually receives on stdout -- the only place a "several top-level JSON
+//! objects" bug is visible. `AGENT_BROWSER_SKILLS_DIR` points at a throwaway
+//! skill tree so the test never depends on the shipped skill-data.
+
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+const BIN: &str = env!("CARGO_BIN_EXE_chrome-use");
+
+/// A skill with two references, and a template whose name collides with one.
+fn fixture() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let skill = tmp.path().join("demo");
+    fs::create_dir_all(skill.join("references")).unwrap();
+    fs::create_dir_all(skill.join("templates")).unwrap();
+    fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: demo\ndescription: a demo skill\n---\n\nbody\n",
+    )
+    .unwrap();
+    fs::write(skill.join("references/alpha.md"), "# alpha reference\n").unwrap();
+    fs::write(skill.join("references/beta.md"), "# beta reference\n").unwrap();
+    fs::write(skill.join("templates/alpha.md"), "# alpha template\n").unwrap();
+    tmp
+}
+
+fn run(tmp: &TempDir, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(BIN)
+        .args(["skills", "get"])
+        .args(args)
+        .env("AGENT_BROWSER_SKILLS_DIR", tmp.path())
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the CLI runs");
+    (
+        String::from_utf8(out.stdout).expect("stdout is utf-8"),
+        String::from_utf8(out.stderr).expect("stderr is utf-8"),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn skills_get(tmp: &TempDir, args: &[&str]) -> String {
+    run(tmp, args).0
+}
+
+/// Serving a reference is a success, and must exit like one.
+///
+/// The reference branch `continue`s past the target collection, so `targets`
+/// ends up empty and the "No skill name provided" error fires -- after the
+/// content has already been printed. Every reference get therefore ended in a
+/// spurious error line and a non-zero exit, which is the whole feature's
+/// documented path reporting failure on success.
+#[test]
+fn serving_a_reference_exits_zero_and_says_nothing_else() {
+    let tmp = fixture();
+
+    let (stdout, stderr, code) = run(&tmp, &["demo/beta"]);
+    assert_eq!(code, 0, "stdout={stdout} stderr={stderr}");
+    assert!(stdout.contains("beta reference"), "{stdout}");
+    assert!(!stderr.contains("No skill name provided"), "{stderr}");
+
+    let (stdout, stderr, code) = run(&tmp, &["--json", "demo/beta"]);
+    assert_eq!(code, 0, "stdout={stdout} stderr={stderr}");
+    assert!(!stdout.contains("No skill name provided"), "{stdout}");
+}
+
+/// Two references in one `--json` call must be ONE parseable document.
+///
+/// Printing per name concatenates top-level objects, which every JSON parser
+/// rejects -- and `--json` exists precisely so a program can read the output.
+#[test]
+fn two_references_in_json_mode_are_a_single_document() {
+    let tmp = fixture();
+    let stdout = skills_get(&tmp, &["--json", "demo/alpha", "demo/beta"]);
+
+    let doc: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("not one document: {e}\n{stdout}"));
+    assert_eq!(doc["success"], serde_json::json!(true));
+
+    let refs = doc["references"].as_array().expect("a references array");
+    assert_eq!(refs.len(), 2, "{doc}");
+    assert_eq!(
+        refs[0]["reference"],
+        serde_json::json!("references/alpha.md")
+    );
+    assert_eq!(
+        refs[1]["reference"],
+        serde_json::json!("references/beta.md")
+    );
+    assert!(refs[0]["content"]
+        .as_str()
+        .unwrap()
+        .contains("alpha reference"));
+}
+
+/// One reference keeps the flat shape it already emitted: fixing the multi-get
+/// must not break a caller that only ever asked for one.
+#[test]
+fn a_single_reference_keeps_its_flat_shape() {
+    let tmp = fixture();
+    let stdout = skills_get(&tmp, &["--json", "demo/beta"]);
+
+    let doc: serde_json::Value = serde_json::from_str(stdout.trim()).expect("one document");
+    assert_eq!(doc["success"], serde_json::json!(true));
+    assert_eq!(doc["skill"], serde_json::json!("demo"));
+    assert_eq!(doc["reference"], serde_json::json!("references/beta.md"));
+    assert!(doc["content"].as_str().unwrap().contains("beta reference"));
+    assert!(doc.get("references").is_none(), "{doc}");
+}
+
+/// An explicit directory is served as written, not traded for the other one.
+#[test]
+fn an_explicit_template_request_is_not_served_the_reference() {
+    let tmp = fixture();
+
+    let stdout = skills_get(&tmp, &["--json", "demo/templates/alpha"]);
+    let doc: serde_json::Value = serde_json::from_str(stdout.trim()).expect("one document");
+    assert_eq!(doc["reference"], serde_json::json!("templates/alpha.md"));
+    assert!(doc["content"].as_str().unwrap().contains("alpha template"));
+
+    let stdout = skills_get(&tmp, &["--json", "demo/references/alpha"]);
+    let doc: serde_json::Value = serde_json::from_str(stdout.trim()).expect("one document");
+    assert_eq!(doc["reference"], serde_json::json!("references/alpha.md"));
+    assert!(doc["content"].as_str().unwrap().contains("alpha reference"));
+}
+
+/// Text mode separates several references instead of running them together.
+#[test]
+fn two_references_in_text_mode_are_separated() {
+    let tmp = fixture();
+    let stdout = skills_get(&tmp, &["demo/alpha", "demo/beta"]);
+
+    assert!(stdout.contains("alpha reference"), "{stdout}");
+    assert!(stdout.contains("beta reference"), "{stdout}");
+    assert!(stdout.contains("---"), "{stdout}");
+}

--- a/cli/tests/skills_get_cli.rs
+++ b/cli/tests/skills_get_cli.rs
@@ -28,6 +28,9 @@ fn fixture() -> TempDir {
     tmp
 }
 
+/// Run `skills get` against the fixture and return stdout, stderr and the
+/// exit code -- all three, because a command can print the right thing and
+/// still tell its caller it failed.
 fn run(tmp: &TempDir, args: &[&str]) -> (String, String, i32) {
     let out = Command::new(BIN)
         .args(["skills", "get"])
@@ -43,6 +46,7 @@ fn run(tmp: &TempDir, args: &[&str]) -> (String, String, i32) {
     )
 }
 
+/// Stdout only, for the cases that assert on content rather than status.
 fn skills_get(tmp: &TempDir, args: &[&str]) -> String {
     run(tmp, args).0
 }
@@ -129,6 +133,9 @@ fn an_explicit_template_request_is_not_served_the_reference() {
 }
 
 /// Text mode separates several references instead of running them together.
+///
+/// Without a separator two files arrive as one run-on document, and a reader
+/// cannot tell where the first ends.
 #[test]
 fn two_references_in_text_mode_are_separated() {
     let tmp = fixture();


### PR DESCRIPTION
Follow-up to #239, split out of #238 so its reference loader isn't reviewed under a title that doesn't mention it.

## The one that matters: every reference get reports failure on success

On `main` at v1.5.107:

```
$ chrome-use skills get demo/beta
# beta reference
✗ No skill name provided. Usage: chrome-use skills get <name>
$ echo $?
1
```

The reference branch `continue`s past the target collection, so `targets` ends up empty and the missing-name error fires — after the content has already been printed. `--json` is worse: it emits the reference object *and* an `{"success": false, …}` object, two top-level documents, then exits 1.

So `chrome-use skills get core/references/waiting`, the documented path of the loading added in #239, currently prints the right thing and then tells the caller it failed. An agent reading the exit code concludes the reference doesn't exist. This is the one failure mode AGENTS.md puts first, pointed the other way: not a silent success, but a silent *failure* on a command that worked.

I found this while verifying the two CodeRabbit findings below — neither report caught it.

## The two reported findings

**Multiple references under `--json` emit multiple top-level documents.** The reference branch printed inside the `names` loop while the ordinary skill path accumulates into `targets` and prints once. `skills get --json a/x b/y` produced concatenated objects that no parser accepts. Now accumulated and emitted once.

A single reference **keeps its existing flat shape** (`{success, skill, reference, content}`) — fixing a multi-get nobody has made yet must not break the single get that is the normal case. More than one nests under `references`. Text mode gains a `---` separator instead of running the files together.

**`resolve_supplementary` matched on the basename only.** `collect_supplementary_files` walks `references/` before `templates/`, so an explicit `templates/waiting` was served `references/waiting.md` — the first directory wins every tie. A request that names its directory is now matched on the full relative path; a bare stem still matches either, as before. Latent today: no stem collides across the two directories in any shipped skill (`core`, `dogfood`, `slack`), so nothing is currently mis-resolving.

## Tests

`cli/tests/skills_get_cli.rs` (new) drives the real binary, because concatenated JSON documents and exit codes are only visible to a caller — a unit test on the resolver would not have caught the exit-code bug at all.

- `serving_a_reference_exits_zero_and_says_nothing_else`
- `two_references_in_json_mode_are_a_single_document`
- `a_single_reference_keeps_its_flat_shape`
- `an_explicit_template_request_is_not_served_the_reference`
- `two_references_in_text_mode_are_separated`

Plus `an_explicit_directory_is_not_traded_for_the_other_one` as a unit test on the resolver, covering the duplicate-stem case in both directions and the pinned-directory miss.

**All five integration tests fail against the code before this change** — verified by reverting `skills.rs` and re-running; the JSON one reports `trailing characters at line 2 column 1`, which is the concatenation.

`cargo clippy --profile ci --features e2e-tests -- -D warnings` clean. Unit suite 1179 passed / 40 failed, the 40 being this sandbox's pre-existing environment failures (HOME/env-dependent tests), unchanged by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cwxFXikdWKBSro6E3AxRW

---
_Generated by [Claude Code](https://claude.ai/code/session_016cwxFXikdWKBSro6E3AxRW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed explicit `references/` and `templates/` requests so they return content from the requested directory.
  * Fixed reference-only requests incorrectly reporting that no skill name was provided.
  * Improved multiple-reference output by combining results into a single JSON document or separating text results with `---`.
  * Preserved a flat JSON format when retrieving a single reference.

* **Tests**
  * Added coverage for directory-specific matching and reference retrieval in text and JSON modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->