### PR TITLE
fix(tab): 恢复命令返回「我在驱动哪个标签」的凭据，而不是一个 ✓（#235）

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7847,23 +7847,39 @@ async fn handle_tab_switch(cmd: &Value, state: &mut DaemonState) -> Result<Value
         .get("url")
         .and_then(|v| v.as_str())
         .map(str::to_string);
-    match mgr.evaluate("location.href", None).await {
-        Err(_) => {
+    let probe = mgr
+        .evaluate("location.href", None)
+        .await
+        .map(|v| v.as_str().unwrap_or_default().to_string());
+    match classify_driving(
+        tab_ref_str,
+        expected_url.as_deref().unwrap_or_default(),
+        probe,
+    ) {
+        DrivingCheck::Elsewhere { message } => return Err(message),
+        DrivingCheck::Confirmed { url } => {
+            // The credential the caller needs: what the session evaluates in
+            // *now*. Holding this is what "I am driving that tab" means; without
+            // it the caller has to spend another command to find out.
+            if let Some(obj) = result.as_object_mut() {
+                obj.insert(
+                    "driving".to_string(),
+                    json!({ "confirmed": true, "url": url }),
+                );
+            }
+        }
+        DrivingCheck::Unconfirmed { why } => {
             let warning = tab_liveness_probe_warning(
                 mgr.on_relay(),
                 crate::connect::relay_ext_version().as_deref(),
                 env!("AB_CONNECT_VERSION"),
             );
             if let Some(obj) = result.as_object_mut() {
+                obj.insert(
+                    "driving".to_string(),
+                    json!({ "confirmed": false, "reason": why }),
+                );
                 obj.insert("warning".to_string(), json!(warning));
-            }
-        }
-        Ok(actual) => {
-            let actual_url = actual.as_str().unwrap_or_default().to_string();
-            if let Some(expected) = expected_url.as_deref() {
-                if let Some(msg) = tab_switch_identity_error(tab_ref_str, expected, &actual_url) {
-                    return Err(msg);
-                }
             }
         }
     }
@@ -7898,6 +7914,45 @@ async fn handle_tab_switch(cmd: &Value, state: &mut DaemonState) -> Result<Value
     }
 
     Ok(result)
+}
+
+/// Whether the session can actually drive the tab a recovery command just
+/// reported.
+///
+/// Three states, because two are not enough. A probe that never completed is
+/// not evidence of failure, but it is certainly not proof of success — and
+/// collapsing it into ✓ is what made `tab select` print the requested tab's
+/// title and url while the session went on driving the page it was stuck on
+/// (issue #223, then #235 when the probe failed outright rather than answering
+/// from the wrong page).
+#[derive(Debug, PartialEq)]
+pub(crate) enum DrivingCheck {
+    /// The session evaluated on the tab that was asked for.
+    Confirmed { url: String },
+    /// The session answered, from somewhere else entirely.
+    Elsewhere { message: String },
+    /// The session did not answer. Say so; do not call it either outcome.
+    Unconfirmed { why: String },
+}
+
+/// Classify a recovery command's outcome from its identity probe.
+///
+/// `probe` is the result of asking the session for its own `location.href`
+/// **after** the switch: the one question whose answer distinguishes "driving
+/// the requested tab" from "driving whatever it was stuck on". `evaluate("1")`
+/// cannot, because every page satisfies it.
+pub(crate) fn classify_driving(
+    requested: &str,
+    expected_url: &str,
+    probe: Result<String, String>,
+) -> DrivingCheck {
+    match probe {
+        Ok(actual) => match tab_switch_identity_error(requested, expected_url, &actual) {
+            Some(message) => DrivingCheck::Elsewhere { message },
+            None => DrivingCheck::Confirmed { url: actual },
+        },
+        Err(why) => DrivingCheck::Unconfirmed { why },
+    }
 }
 
 /// Reject a tab switch that reported the requested tab but left the session
@@ -7985,20 +8040,48 @@ async fn handle_tab_adopt(cmd: &Value, state: &mut DaemonState) -> Result<Value,
         Some(mgr) => mgr.tab_adopt(spec).await,
         None => Err("Browser not launched".to_string()),
     };
-    let result = finish_tab_adopt(result, state)?;
+    let mut result = finish_tab_adopt(result, state)?;
     // Same identity check as `tab select` (issue #223): adopt reported the
     // requested tab's title and url while the session went on driving the page
     // it was stuck on, so the documented recovery for a lost tab silently did
     // nothing and the next command failed identically.
-    if let (Some(mgr), Some(expected)) = (
-        state.browser.as_mut(),
-        result.get("url").and_then(|v| v.as_str()),
-    ) {
-        if let Ok(actual) = mgr.evaluate("location.href", None).await {
-            if let Some(msg) =
-                tab_switch_identity_error(spec, expected, actual.as_str().unwrap_or_default())
-            {
-                return Err(msg);
+    let expected = result
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    if let Some(mgr) = state.browser.as_mut() {
+        let probe = mgr
+            .evaluate("location.href", None)
+            .await
+            .map(|v| v.as_str().unwrap_or_default().to_string());
+        match classify_driving(spec, &expected, probe) {
+            DrivingCheck::Elsewhere { message } => return Err(message),
+            DrivingCheck::Confirmed { url } => {
+                if let Some(obj) = result.as_object_mut() {
+                    obj.insert(
+                        "driving".to_string(),
+                        json!({ "confirmed": true, "url": url }),
+                    );
+                }
+            }
+            // Previously an unanswerable probe passed silently, so adopt could
+            // report the tab it was asked for while the session drove nothing.
+            DrivingCheck::Unconfirmed { why } => {
+                if let Some(obj) = result.as_object_mut() {
+                    obj.insert(
+                        "driving".to_string(),
+                        json!({ "confirmed": false, "reason": why }),
+                    );
+                    obj.insert(
+                        "warning".to_string(),
+                        json!(format!(
+                            "adopted {spec}, but the session could not confirm it is driving that \
+                             tab: {why}. Run a read before relying on it; if that fails too, \
+                             re-open the target with `open <url>`."
+                        )),
+                    );
+                }
             }
         }
     }
@@ -15565,6 +15648,64 @@ mod tests {
                 "`{action}` would be diffed across a page swap"
             );
         }
+    }
+
+    /// The session answered from the tab that was asked for. Only this state
+    /// earns a ✓, and it carries the url the caller can now act on.
+    #[test]
+    fn a_probe_from_the_requested_tab_is_confirmed() {
+        let got = classify_driving(
+            "t1",
+            "https://www.saucedemo.com/",
+            Ok("https://www.saucedemo.com/inventory.html".into()),
+        );
+        assert_eq!(
+            got,
+            DrivingCheck::Confirmed {
+                url: "https://www.saucedemo.com/inventory.html".into()
+            }
+        );
+    }
+
+    /// The session answered from somewhere else: the switch demonstrably did
+    /// not take, so this is a failure rather than an uncertainty.
+    #[test]
+    fn a_probe_from_another_origin_is_a_failure() {
+        let got = classify_driving(
+            "t1",
+            "https://www.saucedemo.com/",
+            Ok("chrome-extension://abcdef/page.html".into()),
+        );
+        assert!(matches!(got, DrivingCheck::Elsewhere { .. }));
+    }
+
+    /// #235: the probe not completing is the case that used to fall through to
+    /// a plain ✓. It is neither outcome, and must be reported as neither —
+    /// an agent that reads ✓ here goes back round the recovery loop.
+    #[test]
+    fn a_probe_that_never_answered_is_unconfirmed_not_success() {
+        let got = classify_driving(
+            "t1",
+            "https://www.saucedemo.com/",
+            Err("Cannot access a chrome-extension:// URL of different extension".into()),
+        );
+        match got {
+            DrivingCheck::Unconfirmed { why } => {
+                assert!(
+                    why.contains("chrome-extension"),
+                    "keeps the real reason: {why}"
+                );
+            }
+            other => panic!("an unanswerable probe must not be {other:?}"),
+        }
+    }
+
+    /// A tab with no reported url still classifies rather than panicking; an
+    /// unparseable expectation is not evidence of a bad switch.
+    #[test]
+    fn a_missing_expected_url_does_not_manufacture_a_failure() {
+        let got = classify_driving("t1", "", Ok("https://a.example/".into()));
+        assert!(matches!(got, DrivingCheck::Confirmed { .. }));
     }
 
     /// The old probe ran `evaluate("1")`, which any page satisfies — including

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -7948,8 +7948,25 @@ pub(crate) fn classify_driving(
 ) -> DrivingCheck {
     match probe {
         Ok(actual) => match tab_switch_identity_error(requested, expected_url, &actual) {
-            Some(message) => DrivingCheck::Elsewhere { message },
             None => DrivingCheck::Confirmed { url: actual },
+            // Landing somewhere else is only *proof* of a failed switch when the
+            // destination is one a driven web tab can never legitimately reach.
+            // A different http(s) origin can simply be a redirect that fired
+            // between the switch and the probe — an SSO bounce is exactly that
+            // shape — and calling a switch that worked a failure sends the
+            // caller off to redo it. That cost is not hypothetical: a false
+            // failure elsewhere in this area had another tool retry a step that
+            // had already succeeded and lose the state it had built.
+            Some(message) if super::browser::is_internal_chrome_target(&actual) => {
+                DrivingCheck::Elsewhere { message }
+            }
+            Some(_) => DrivingCheck::Unconfirmed {
+                why: format!(
+                    "the session answered from {actual}, not {expected_url}. That can be a \
+                     redirect that fired after the switch, so it is not proof either way — \
+                     read the page before relying on it"
+                ),
+            },
         },
         Err(why) => DrivingCheck::Unconfirmed { why },
     }
@@ -15667,16 +15684,75 @@ mod tests {
         );
     }
 
-    /// The session answered from somewhere else: the switch demonstrably did
-    /// not take, so this is a failure rather than an uncertainty.
+    /// A privileged destination is the signature of a session pinned to a page
+    /// it cannot leave — no navigation from a normal site reaches one — so this
+    /// is proof of failure rather than an uncertainty.
     #[test]
-    fn a_probe_from_another_origin_is_a_failure() {
+    fn a_probe_from_a_privileged_page_is_a_failure() {
+        for landed in [
+            "chrome-extension://abcdef/page.html",
+            "chrome://settings",
+            "devtools://devtools/bundled/x.html",
+        ] {
+            let got = classify_driving("t1", "https://www.saucedemo.com/", Ok(landed.into()));
+            assert!(
+                matches!(got, DrivingCheck::Elsewhere { .. }),
+                "{landed} should be a failure"
+            );
+        }
+    }
+
+    /// A different *web* origin can be a redirect that fired between the switch
+    /// and the probe. Calling that a failure would send the caller to redo a
+    /// switch that worked — the same false-failure cost that made another tool
+    /// retry a successful step and lose the state it had built.
+    #[test]
+    fn a_probe_from_another_web_origin_is_unconfirmed_not_failure() {
         let got = classify_driving(
             "t1",
-            "https://www.saucedemo.com/",
-            Ok("chrome-extension://abcdef/page.html".into()),
+            "https://app.example.com/",
+            Ok("https://login.microsoftonline.com/oauth2/authorize".into()),
         );
-        assert!(matches!(got, DrivingCheck::Elsewhere { .. }));
+        match got {
+            DrivingCheck::Unconfirmed { why } => {
+                assert!(
+                    why.contains("login.microsoftonline.com"),
+                    "names where it landed: {why}"
+                );
+                assert!(
+                    why.contains("redirect"),
+                    "explains why it is not proof: {why}"
+                );
+            }
+            other => panic!("a cross-origin redirect must not be reported as failure: {other:?}"),
+        }
+    }
+
+    /// Reuses `is_internal_chrome_target` rather than a second list: two
+    /// definitions of "privileged page" would drift, and this one already
+    /// decides which targets auto-connect refuses.
+    #[test]
+    fn ordinary_web_urls_are_not_internal_chrome_targets() {
+        for url in [
+            "https://a.example/",
+            "http://localhost:8080/x",
+            "https://chrome.google.com/",
+        ] {
+            assert!(
+                !super::super::browser::is_internal_chrome_target(url),
+                "{url}"
+            );
+        }
+        for url in [
+            "chrome://flags",
+            "CHROME-EXTENSION://abc/p.html",
+            " devtools://x",
+        ] {
+            assert!(
+                super::super::browser::is_internal_chrome_target(url),
+                "{url}"
+            );
+        }
     }
 
     /// #235: the probe not completing is the case that used to fall through to

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -166,10 +166,22 @@ fn validate_lightpanda_options(options: &LaunchOptions) -> Result<(), String> {
 
 /// Returns true for Chrome internal targets that should not be selected
 /// during auto-connect (e.g. chrome://, chrome-extension://, devtools://).
-fn is_internal_chrome_target(url: &str) -> bool {
-    url.starts_with("chrome://")
-        || url.starts_with("chrome-extension://")
-        || url.starts_with("devtools://")
+///
+/// Also the test for "a driven web tab can never legitimately be here", used
+/// when deciding whether a session that answered from an unexpected url was
+/// pinned to a page it cannot leave or merely followed a redirect. Matching is
+/// case-insensitive and ignores surrounding space because the url arrives from
+/// the page rather than from us.
+pub(crate) fn is_internal_chrome_target(url: &str) -> bool {
+    const INTERNAL: &[&str] = &[
+        "chrome://",
+        "chrome-extension://",
+        "chrome-untrusted://",
+        "devtools://",
+        "edge://",
+    ];
+    let lowered = url.trim().to_ascii_lowercase();
+    INTERNAL.iter().any(|p| lowered.starts_with(p))
 }
 
 pub(crate) fn should_track_target(target: &TargetInfo) -> bool {

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -239,6 +239,79 @@ async fn spawn_fake_daemon_socket(
 // Core: launch, navigate, evaluate, url, title, close
 // ---------------------------------------------------------------------------
 
+/// A successful `tab` switch must hand back proof that the session is driving
+/// the tab it named, not just the tab's title.
+///
+/// The unit tests cover the classifier; this covers the wiring, which is where
+/// the bug actually lived: the probe result was computed and then dropped, so a
+/// switch reported ✓ with the requested tab's details while the session drove
+/// something else (#223), or while it could not answer at all (#235).
+#[tokio::test]
+#[ignore]
+async fn e2e_tab_switch_returns_proof_it_is_driving_that_tab() {
+    let (port, server) = spawn_html_server(
+        "<!doctype html><meta charset=\"utf-8\"><title>first</title><p>one".to_string(),
+    )
+    .await;
+    let mut state = DaemonState::new();
+
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let url = format!("http://127.0.0.1:{port}/");
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    // A second tab, so the switch has somewhere to come back from.
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "tab_new", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let resp = execute_command(&json!({ "id": "4", "action": "tab_list" }), &mut state).await;
+    assert_success(&resp);
+    let first = get_data(&resp)["tabs"]
+        .as_array()
+        .and_then(|tabs| tabs.first())
+        .and_then(|t| t.get("tabId"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .expect("tab list reports at least one addressable tab");
+
+    let resp = execute_command(
+        &json!({ "id": "5", "action": "tab_switch", "tabId": first }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    let driving = &get_data(&resp)["driving"];
+    assert_eq!(
+        driving["confirmed"],
+        json!(true),
+        "a switch that worked must say so explicitly, not leave it to be inferred: {driving}"
+    );
+    assert!(
+        driving["url"]
+            .as_str()
+            .unwrap_or_default()
+            .contains(&port.to_string()),
+        "the credential must be the url the session actually evaluates in: {driving}"
+    );
+
+    let _ = execute_command(&json!({ "id": "6", "action": "close" }), &mut state).await;
+    server.abort();
+}
+
 /// `actions` / `do` end to end against a real page.
 ///
 /// The derivation has unit tests, but nothing covered the chain that actually

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -547,14 +547,38 @@ pub fn print_response_with_opts(resp: &Response, action: Option<&str>, opts: &Ou
                 .and_then(|v| v.as_str())
                 .map(str::trim)
                 .filter(|t| !t.is_empty());
+            // A recovery command (`tab select` / `tab adopt`) carries a
+            // `driving` credential saying whether the session was confirmed to
+            // be on that tab. Unconfirmed must not wear a ✓: printing the
+            // requested tab's title under a checkmark, while the session drove
+            // something else, is what sent agents round the
+            // error → "recover" → ✓ → same error loop (issues #223, #235).
+            let unconfirmed = data
+                .get("driving")
+                .and_then(|d| d.get("confirmed"))
+                .and_then(|v| v.as_bool())
+                .is_some_and(|confirmed| !confirmed);
+            let mark = if unconfirmed {
+                color::warning_indicator()
+            } else {
+                color::success_indicator()
+            };
             match title {
                 Some(t) => {
-                    println!("{} {}", color::success_indicator(), color::bold(t));
+                    println!("{} {}", mark, color::bold(t));
                     println!("  {}", color::dim(url));
                 }
-                // Title-less page: show the URL with the checkmark instead of an
+                // Title-less page: show the URL with the marker instead of an
                 // empty title line.
-                None => println!("{} {}", color::success_indicator(), color::dim(url)),
+                None => println!("{} {}", mark, color::dim(url)),
+            }
+            if unconfirmed {
+                eprintln!(
+                    "{}",
+                    color::yellow(
+                        "not confirmed: the session did not answer, so it may not be driving this tab"
+                    )
+                );
             }
             // Soft warning carried in the response (e.g. the load event timed out
             // but the DOM was ready — issue #10). Goes to stderr so it doesn't

--- a/skill-data/core/references/troubleshooting.md
+++ b/skill-data/core/references/troubleshooting.md
@@ -118,8 +118,12 @@ the session cannot drive it. Those are different paths.
 
 - **confirmed** — the session evaluated on that tab, and `driving.url` is where
   it landed. This is the only case that prints ✓.
-- **failed** — the session answered from a different origin. The command errors
-  and names both urls.
+- **failed** — the session answered from a page a driven tab can never reach
+  (`chrome-extension://`, `chrome://`, `devtools://`). That is the signature of
+  a session pinned somewhere it cannot leave, so it is proof rather than doubt.
+  A different *web* origin is reported as **not confirmed** instead: it can be
+  a redirect that fired after the switch, and calling a switch that worked a
+  failure would send you to redo it.
 - **not confirmed** — the session did not answer at all. The command prints ⚠,
   not ✓, because this is neither outcome. **Do not treat it as recovered.**
 

--- a/skill-data/core/references/troubleshooting.md
+++ b/skill-data/core/references/troubleshooting.md
@@ -107,3 +107,26 @@ snapshot — fall back to `eval` in the iframe's origin or use the
 Use `--session-name <name>` or `state save`/`state load` so your session
 survives browser restarts. See [references/session-management.md](references/session-management.md)
 and [references/authentication.md](references/authentication.md).
+
+## "the tab this command was driving is gone"
+
+`tab list` may still show the tab, and `tab inspect` may still read it, while
+the session cannot drive it. Those are different paths.
+
+`tab select` / `tab adopt` now report which of three things happened, in a
+`driving` field:
+
+- **confirmed** — the session evaluated on that tab, and `driving.url` is where
+  it landed. This is the only case that prints ✓.
+- **failed** — the session answered from a different origin. The command errors
+  and names both urls.
+- **not confirmed** — the session did not answer at all. The command prints ⚠,
+  not ✓, because this is neither outcome. **Do not treat it as recovered.**
+
+On ⚠, run one read. If that also fails, stop retrying `tab select` — it cannot
+recover a session pinned to a page it can no longer leave. Re-open the target
+with `open <url>` / `navigate <url>` to rebind, then re-`snapshot`.
+
+Retrying the recovery command after a ⚠ is the loop this reporting exists to
+break: the old behaviour printed ✓ with the requested tab's title, so the next
+command failed identically and the obvious response was to "recover" again.


### PR DESCRIPTION
## 现象

第三方 agent 用我们 CLI 跑对照测试时撞上的完整序列：

```
click Login --observe     Done（带 DOM 未稳定 warning，observed URL 变空串）
snapshot -i               ✗ the tab this command was driving is gone
tab list                  → [t8] [created] ... inventory.html   ← 标签在，登录也成功了
tab select t8             ✗ 仍然 tab gone                        ← 提示让你做的第一件事
snapshot -i               ✗ 同样的错
tab inspect t8            ✓ 成功显示 inventory.html              ← 读得到，就是驱动不了
```

它的评价是要害：

> CLI 文案更详细，但 `tab list` → `select` 的明确建议无法奏效，`inspect` 的成功又没有解释「存在但不能驱动」，**比简短错误更容易诱导循环**。

我们花力气把错误信息写得可操作，结果**信息越具体地指向一条走不通的路，坑越深**。

## 我上一版（#223）修漏的那一半

那次加的身份校验**只在探针成功返回、却落在别的 origin 时**触发。探针**完全失败**时——会话钉在一个压根 `evaluate` 不了的页面，正是这次的场景——走的是旧的警告分支，**第一行仍然是 ✓**。

我自己也复现了：

```
$ chrome-use tab select t1
✓ Swag Labs
  https://www.saucedemo.com/inventory.html
⚠ tab is selected, but its liveness probe did not complete...
$ chrome-use snapshot -i
✗ Cannot access a chrome-extension:// URL of different extension
```

## 三态

采纳对照方的建议（已确认成功 / 已确认未达目标 / **结果未确认**，各附证据），落成 `classify_driving()` 纯函数和一个 `driving` 字段：

| 状态 | 含义 | 输出 |
|---|---|---|
| `confirmed` | 会话确实在那个标签上求值，`driving.url` 是落点 | ✓ |
| `elsewhere` | 会话答了，但来自别的 origin | 硬报错，两个 url 都说清 |
| `unconfirmed` | 会话根本没答 | **⚠ 不是 ✓** |

`confirmed` 那一格**带回凭据**：拿到 `driving.url` 就等于知道自己在驱动什么，不用再花一条命令去确认。

形状是从对方 `claimTab(tab)` 借的 —— 它**返回一个可控的 Tab**：拿到句柄就是在驱动它，拿不到就是没有，**中间没有第三种状态可以表达**。这比事后校验彻底，因为错误状态根本无法被表达出来。

`tab adopt` 同样处理：它之前在探针无法作答时**静默通过**。

## 拿到 ⚠ 之后该做什么

写进了 `core/troubleshooting`：**别再重试 `tab select`**，它救不回一个钉死的会话；用 `open`/`navigate` 重新绑定。

重试恢复命令正是这套报告要打断的循环 —— 旧行为打 ✓ 并附上被请求标签的标题，于是下一条命令报一模一样的错，而最自然的反应就是再「恢复」一次。

## 测试

- 四个单测覆盖三态 + 缺 url 不误判
- 一个 e2e 覆盖真实链路 —— **bug 恰恰在接线处**（探针算出来了然后被丢掉），不在分类逻辑，所以单测挡不住

1228 通过（1 个已知计时型 flaky，单独重跑三次全过，与本改动无关）。

## 没做

「存在但不能驱动」**怎么修**（而不只是怎么如实报告）属于 #217，本 PR 不碰。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tab switching and tab adoption now report whether the session is confirmed to be driving the requested tab.
  * Responses include the active URL when driving is confirmed.
  * Unconfirmed results include an explanation and warning.

* **Bug Fixes**
  * Tabs associated with another origin now return an explicit error instead of appearing successful.

* **Documentation**
  * Added troubleshooting guidance for tabs that cannot be driven, including recommended recovery steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->