### PR TITLE
fix(tab): 跨 origin 跳转不算切换失败（#238 的补充）

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -8034,41 +8034,37 @@ async fn handle_tab_switch(cmd: &Value, state: &mut DaemonState) -> Result<Value
 }
 
 /// Reject a tab switch that reported the requested tab but left the session
-/// driving a different document.
+/// driving a page it could never have reached by navigating.
 ///
-/// Returns `None` when the switch landed where it should. Compares origins
-/// only: a page may redirect or rewrite its path between the switch and the
-/// probe, and failing that would be a false alarm — but landing on another
-/// origin (typically a `chrome-extension://` page the session was stuck on)
-/// is never the tab that was asked for.
+/// Returns `None` when the switch landed somewhere the requested tab plausibly
+/// could. Two things are deliberately *not* treated as proof of a failed
+/// switch, because between the switch and the probe a page is free to move:
+///
+/// * a different path on the same host — the ordinary case of a page settling;
+/// * a different **web** origin — an SSO bounce is exactly this shape.
+///
+/// Only an internal Chrome destination (`chrome-extension://`, `chrome://`,
+/// `devtools://`) is evidence: no navigation from a normal site arrives there,
+/// so it is the signature of a session pinned to a page it cannot leave.
+///
+/// The distinction matters because a false failure costs as much as a false
+/// success. Reporting a switch that worked as failed sends the caller to redo
+/// it, and redoing an action that already succeeded is how another tool in a
+/// side-by-side test lost the state it had built.
 pub(crate) fn tab_switch_identity_error(
     requested: &str,
     expected_url: &str,
     actual_url: &str,
 ) -> Option<String> {
-    // Compare scheme + host rather than `Origin::ascii_serialization`: that
-    // serializes every non-special scheme — `chrome-extension://` included — to
-    // the opaque "null", which would hide the exact case this check exists for.
-    let parts = |u: &str| {
-        url::Url::parse(u).ok().and_then(|p| {
-            let host = p.host_str().map(str::to_string)?;
-            Some((p.scheme().to_string(), host))
-        })
-    };
-    let (Some(want), Some(got)) = (parts(expected_url), parts(actual_url)) else {
-        // An unparseable or host-less url (`about:blank`, `data:`) on either
-        // side is not evidence of a bad switch.
-        return None;
-    };
-    if want == got {
+    if !super::browser::is_internal_chrome_target(actual_url) {
         return None;
     }
     Some(format!(
         "tab {requested} was resolved to {expected_url}, but the session is still driving \
-         {actual_url} — the switch did not take effect. This is usually a relay session \
-         pinned to a page it can no longer leave. Re-open the target with `open <url>` \
-         (or `navigate <url>`) to rebind the session; `tab select` / `tab adopt` cannot \
-         recover it from here."
+         {actual_url} — an internal Chrome page it cannot have navigated to, so the switch did \
+         not take effect. This is a relay session pinned to a page it can no longer leave. \
+         Re-open the target with `open <url>` (or `navigate <url>`) to rebind; `tab select` / \
+         `tab adopt` cannot recover it from here."
     ))
 }
 
@@ -15836,7 +15832,7 @@ mod tests {
     /// the wrong one. A switch that never took effect printed ✓ with the
     /// requested tab's title and url, and the next command failed identically.
     #[test]
-    fn tab_switch_reports_a_switch_that_landed_elsewhere() {
+    fn tab_switch_reports_a_switch_that_landed_on_an_internal_page() {
         let msg = tab_switch_identity_error(
             "t1",
             "https://www.saucedemo.com/",
@@ -15849,6 +15845,43 @@ mod tests {
         let msg = msg.unwrap();
         assert!(msg.contains("did not take effect"));
         assert!(msg.contains("chrome-extension://abcdef/page.html"));
+    }
+
+    /// A different **web** origin is not proof of a failed switch: an SSO bounce
+    /// puts the tab on another origin between the switch and the probe, and
+    /// calling that a failure sends the caller to redo a switch that worked.
+    ///
+    /// The cost is not hypothetical. In a side-by-side test, another tool hit a
+    /// false failure, retried a step that had already succeeded, and the reload
+    /// discarded the state it had built. A false failure is as expensive as a
+    /// false success, so the outcome here stays "unconfirmed" rather than
+    /// becoming a verdict the caller acts on.
+    #[test]
+    fn a_cross_origin_redirect_is_not_reported_as_a_failed_switch() {
+        assert!(tab_switch_identity_error(
+            "t1",
+            "https://app.example.com/",
+            "https://login.microsoftonline.com/oauth2/authorize",
+        )
+        .is_none());
+    }
+
+    /// Every internal Chrome scheme counts, and matching ignores case and
+    /// surrounding space because the url comes back from the page.
+    #[test]
+    fn every_internal_chrome_scheme_is_evidence_of_a_stuck_session() {
+        for landed in [
+            "chrome-extension://abcdef/page.html",
+            "chrome://settings",
+            "devtools://devtools/bundled/x.html",
+            "CHROME-EXTENSION://ABC/p.html",
+            " chrome://flags",
+        ] {
+            assert!(
+                tab_switch_identity_error("t1", "https://a.example/", landed).is_some(),
+                "{landed} is somewhere a driven tab cannot navigate to"
+            );
+        }
     }
 
     /// A page that redirects or rewrites its path between the switch and the

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -166,10 +166,22 @@ fn validate_lightpanda_options(options: &LaunchOptions) -> Result<(), String> {
 
 /// Returns true for Chrome internal targets that should not be selected
 /// during auto-connect (e.g. chrome://, chrome-extension://, devtools://).
-fn is_internal_chrome_target(url: &str) -> bool {
-    url.starts_with("chrome://")
-        || url.starts_with("chrome-extension://")
-        || url.starts_with("devtools://")
+///
+/// Also the test for "a driven web tab can never have navigated here", used
+/// when deciding whether a session that answered from an unexpected url was
+/// pinned to a page it cannot leave or had simply redirected. Matching is
+/// case-insensitive and tolerates surrounding space, because the url comes back
+/// from the page rather than from us.
+pub(crate) fn is_internal_chrome_target(url: &str) -> bool {
+    const INTERNAL: &[&str] = &[
+        "chrome://",
+        "chrome-extension://",
+        "chrome-untrusted://",
+        "devtools://",
+        "edge://",
+    ];
+    let lowered = url.trim().to_ascii_lowercase();
+    INTERNAL.iter().any(|prefix| lowered.starts_with(prefix))
 }
 
 pub(crate) fn should_track_target(target: &TargetInfo) -> bool {

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -3765,7 +3765,6 @@ mod tests {
         assert!(!descriptor_is_iframe("textarea[name=\"q\"]"));
     }
 
-    #[test]
     /// The descriptor is built from page-controlled `id`/`name` and printed to a
     /// terminal. An escape sequence in it could repaint the warning line.
     #[test]


### PR DESCRIPTION
接在 #238 之后的一处补充。原来的 PR #241 和它撞车了，**#238 是更好的底座**（它还检测「你刚刚才试过一次同样的恢复」，覆盖面也更广），所以关掉了那个，只把它没覆盖的这一处单独提出来。

## 问题

#238 把「未确认」补成了第三态，但 `tab_switch_identity_error` 仍然**无条件**把「落到别的 origin」判成失败：

```rust
if want == got { return None; }
Some("… the switch did not take effect …")
```

OAuth/SSO 跳转会让标签在切换和探针之间落到**另一个 web origin**。那会把一次**成功的**切换报成失败，然后调用方去重做。

**这个代价不是假设的。** 并排对照测试里，另一套工具正是因为一次**假失败**去重试了一个已经成功的操作，reload 之后把建好的状态弄丢了。假失败和假成功一样贵 —— #235 修的是后者，不该留着一个前者。

## 改法

只保留一个失败条件：落到**驱动中的网页标签永远无法导航到**的地方。

| 探针落点 | 判定 | 理由 |
|---|---|---|
| `chrome-extension://` / `chrome://` / `devtools://` … | **失败** | 正常站点的导航到不了这里，这是「会话钉死」的签名 |
| 另一个 web origin | 维持**未确认** | 可能是切换后才触发的跳转，两种可能都不排除 |
| 同 host 不同路径 | 未确认 | 页面自己在动，本来就不构成证据 |

调用方在「未确认」时已经被告知结果不确定，那才是诚实的报告；把它升级成失败只会让人去重做一件可能已经成了的事。

## 复用而非新造

判断用 `browser.rs` 已有的 `is_internal_chrome_target`（auto-connect 用它决定哪些 target 不能选）。**不该有第二份「什么算特权页面」的定义** —— 我第一版确实写了自己的一份，发现之后删了。两份一定会分叉。

顺带给那唯一一份补上 `chrome-untrusted://` / `edge://`，以及大小写和首尾空白容错：这个 url 是**页面回给我们的**，不是我们自己造的。

## 顺带修一个 main 上的红灯

`cli/src/native/interaction.rs` 有一处重复的 `#[test]`（不是本改动引入），导致 `cargo clippy --all-targets -- -D warnings` 在 main 上就编译失败。一行删掉。

## 测试

- 跨 origin 跳转不被报成失败（SSO 形状）
- 每一种内部 scheme 都算证据，含大小写和空白
- 既有的三条继续通过（原来那条测的就是 `chrome-extension://`，正落在新条件里，只把名字改准确了）

1236 通过，clippy 干净。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf