### PR TITLE
feat(profile): 读 ChooseBrowser 的站点规则，自动选对 Chrome profile（#244）

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,34 @@ Apache-2.0
 > Built by **leeguooooo** — field notes on AI agents, reverse engineering & Cloudflare Workers at **[blog.leeguoo.com](https://blog.leeguoo.com)** · follow on **[X @leeguooooo](https://x.com/leeguooooo)**
 
 <!-- use-family -->
+## Multi-profile Chrome: ChooseBrowser rules
+
+If you keep several Chrome profiles — work, personal, a client's — you already
+know which account each site belongs to, and you tell us with `--browser` every
+time.
+
+[ChooseBrowser](https://choosebrowser.leeguoo.com) is a macOS link router that
+stores that mapping. When it is installed, `chrome-use open <url>` without an
+explicit `--browser` follows the rule you already wrote for that site, and says
+so:
+
+```
+$ chrome-use open https://github.com/my-org/repo
+· using Chrome profile Profile 14 — a ChooseBrowser rule routes this site there
+  (github.com|/my-org*). Override with --browser <id|email>, or skip with
+  --no-choosebrowser.
+```
+
+Read-only, and invisible if you do not use it: no rules file means no behaviour
+change and no message. A rule naming a profile that is not running the extension
+falls back to the normal profile choice rather than opening the link as the
+wrong account.
+
+> **Disclosure:** ChooseBrowser is a paid macOS app (US$4.99, 7-day trial) by the
+> same author as chrome-use. This is a companion-tool note, not an independent
+> review. chrome-use needs none of it — the integration reads a file if it
+> happens to be there.
+
 ## The `*-use` family
 
 Small, composable CLIs that give an AI agent hands on one real thing. Same shape

--- a/README.zh.md
+++ b/README.zh.md
@@ -515,6 +515,30 @@ Apache-2.0
 > 由 **leeguooooo** 打造 —— AI agent、逆向工程与 Cloudflare Workers 的实战笔记见 **[blog.leeguoo.com](https://blog.leeguoo.com)** · 关注 **[X @leeguooooo](https://x.com/leeguooooo)**
 
 <!-- use-family -->
+## 多 profile 的 Chrome：读 ChooseBrowser 的规则
+
+同时开着工作号、个人号、客户号的人，心里本来就清楚「哪个站点用哪个账号」，
+只是每次都要用 `--browser` 再告诉我们一遍。
+
+[ChooseBrowser](https://choosebrowser.leeguoo.com) 是一个 macOS 链接路由工具，
+它把这份映射存了下来。装了它之后，`chrome-use open <url>` 在你没显式指定
+`--browser` 时会按你自己写的规则选 profile，并且会说明来源：
+
+```
+$ chrome-use open https://github.com/my-org/repo
+· using Chrome profile Profile 14 — a ChooseBrowser rule routes this site there
+  (github.com|/my-org*). Override with --browser <id|email>, or skip with
+  --no-choosebrowser.
+```
+
+只读，没装的话完全无感：没有规则文件就不改变任何行为、也不打任何提示。
+规则指向的 profile 如果没在跑扩展，会退回正常的 profile 选择逻辑，
+**而不是退而求其次开进别的账号**。
+
+> **利益披露：** ChooseBrowser 是一款付费 macOS 应用（US$4.99，7 天试用），
+> 作者与 chrome-use 是同一人。这是配套工具说明，不是独立第三方评价。
+> chrome-use 不依赖它——这个集成只是「文件恰好在就读一下」。
+
 ## `*-use` 家族
 
 一组小而互相独立的 CLI，各自把 agent 的手伸到一个真实的东西上。装法都一样：

--- a/cli/src/choosebrowser.rs
+++ b/cli/src/choosebrowser.rs
@@ -22,6 +22,7 @@
 //!   send as the wrong identity.
 
 use serde::Deserialize;
+use std::cmp::Ordering;
 use std::path::PathBuf;
 
 /// The one format this code understands. A different number means the file was
@@ -63,8 +64,16 @@ struct RulesFile {
 struct Rule {
     #[serde(default)]
     priority: i64,
+    /// Untyped because the real files carry a unix timestamp as a **number**
+    /// while the written contract shows a string. Declaring it as either one
+    /// made serde reject the whole document, and a document that fails to parse
+    /// is indistinguishable from "no rules" — the feature stayed silent with
+    /// every rule intact on disk.
+    ///
+    /// Only ever compared for ordering, so the concrete type does not matter as
+    /// long as comparison is stable.
     #[serde(default, rename = "createdAt")]
-    created_at: Option<String>,
+    created_at: Option<serde_json::Value>,
     /// `ruleId` in the file. The provenance line names it so the user can find
     /// the rule that redirected them; without the rename it silently stayed
     /// empty and the message said "a rule" with no way to look it up.
@@ -219,7 +228,7 @@ pub fn choose_for_url(rules_json: &str, url: &str) -> Option<ProfileChoice> {
         b.priority
             .cmp(&a.priority)
             .then(b.r#match.specificity().cmp(&a.r#match.specificity()))
-            .then(a.created_at.cmp(&b.created_at))
+            .then(compare_created_at(&a.created_at, &b.created_at))
     });
 
     let winner = candidates.first()?;
@@ -228,6 +237,22 @@ pub fn choose_for_url(rules_json: &str, url: &str) -> Option<ProfileChoice> {
         key,
         rule_id: winner.rule_id.clone(),
     })
+}
+
+/// Order two `createdAt` values without caring whether they are numbers or
+/// strings. Numbers compare numerically, everything else by its text; a missing
+/// value sorts last so a rule that records its age wins the tie over one that
+/// does not.
+fn compare_created_at(a: &Option<serde_json::Value>, b: &Option<serde_json::Value>) -> Ordering {
+    match (a, b) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+        (Some(x), Some(y)) => match (x.as_f64(), y.as_f64()) {
+            (Some(x), Some(y)) => x.partial_cmp(&y).unwrap_or(Ordering::Equal),
+            _ => x.to_string().cmp(&y.to_string()),
+        },
+    }
 }
 
 /// Turn a portable profile key into the `--profile-directory` value for *this*
@@ -562,6 +587,47 @@ mod tests {
         let resolved = resolve_profile_directory(&local_state(), "Profile 7").unwrap();
         assert_eq!(resolved.directory, "Profile 7");
         assert_eq!(resolved.email, None);
+    }
+
+    /// Verbatim from a real rules.json written by the shipped app.
+    ///
+    /// `createdAt` is a **number** here while the written contract shows a
+    /// string. Declaring it as either concrete type made serde reject the whole
+    /// document — and a document that fails to parse is indistinguishable from
+    /// "no rules", so the feature stayed silent with every rule intact on disk.
+    /// This fixture is the format as it actually ships, not as it is described.
+    #[test]
+    fn a_real_rules_file_from_the_shipped_app_parses() {
+        let real = r#"{"version":2,"rules":[
+          {"createdAt":1788593504,
+           "action":{"type":"always_open_in",
+                     "bundleIdentifier":"com.google.Chrome::profile::103695396640962395023"},
+           "match":{"path":"/leeguooooo*","domain":"github.com"},
+           "ruleId":"github.com|/leeguooooo*",
+           "priority":100}]}"#;
+        let got = choose_for_url(real, "https://github.com/leeguooooo/chrome-use")
+            .expect("a rule the shipped app wrote must parse");
+        assert_eq!(got.key, "103695396640962395023");
+        assert_eq!(got.rule_id.as_deref(), Some("github.com|/leeguooooo*"));
+    }
+
+    /// Ordering must survive either representation, and must not throw away a
+    /// rule just because its timestamp is typed differently.
+    #[test]
+    fn created_at_orders_across_numbers_and_strings() {
+        use serde_json::json;
+        let num = |n: i64| Some(json!(n));
+        let text = |s: &str| Some(json!(s));
+        assert_eq!(compare_created_at(&num(1), &num(2)), Ordering::Less);
+        assert_eq!(compare_created_at(&num(2), &num(1)), Ordering::Greater);
+        assert_eq!(
+            compare_created_at(&text("2020"), &text("2024")),
+            Ordering::Less
+        );
+        // A rule that records its age wins the tie over one that does not.
+        assert_eq!(compare_created_at(&None, &num(1)), Ordering::Greater);
+        assert_eq!(compare_created_at(&num(1), &None), Ordering::Less);
+        assert_eq!(compare_created_at(&None, &None), Ordering::Equal);
     }
 
     /// A url no rule covers is the ordinary case, not an error.

--- a/cli/src/choosebrowser.rs
+++ b/cli/src/choosebrowser.rs
@@ -65,8 +65,10 @@ struct Rule {
     priority: i64,
     #[serde(default, rename = "createdAt")]
     created_at: Option<String>,
-    #[serde(default)]
-    #[allow(dead_code)]
+    /// `ruleId` in the file. The provenance line names it so the user can find
+    /// the rule that redirected them; without the rename it silently stayed
+    /// empty and the message said "a rule" with no way to look it up.
+    #[serde(default, rename = "ruleId")]
     rule_id: Option<String>,
     #[serde(default)]
     r#match: Match,
@@ -92,6 +94,23 @@ struct Action {
     kind: Option<String>,
     #[serde(default, rename = "bundleIdentifier")]
     bundle_identifier: Option<String>,
+}
+
+/// A profile the rule named, resolved against this machine.
+///
+/// Carries the email as well as the directory because they answer different
+/// questions and only one of them works for each. The relay identifies a
+/// connected profile by its own id or by email — a directory name is not a
+/// dimension it knows — so selecting with the directory silently matched
+/// nothing and the whole feature never fired. The directory is still what a
+/// person recognises, so it is what the provenance line shows.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ResolvedProfile {
+    /// `Default`, `Profile 14` — this machine's on-disk name, for display.
+    pub directory: String,
+    /// The signed-in account, when there is one. This is what the relay can
+    /// actually match on.
+    pub email: Option<String>,
 }
 
 /// What a matched rule asks for: a Chrome profile identified by a key that
@@ -221,10 +240,17 @@ pub fn choose_for_url(rules_json: &str, url: &str) -> Option<ProfileChoice> {
 /// Compared case-insensitively against gaia id, then email, then display name,
 /// then the directory name itself — the same order the writer used when
 /// choosing what to store.
-pub fn resolve_profile_directory(local_state_json: &str, key: &str) -> Option<String> {
+pub fn resolve_profile_directory(local_state_json: &str, key: &str) -> Option<ResolvedProfile> {
     let state: serde_json::Value = serde_json::from_str(local_state_json).ok()?;
     let cache = state.get("profile")?.get("info_cache")?.as_object()?;
     let key = key.trim();
+    let email_of = |info: &serde_json::Value| {
+        info.get("user_name")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(str::to_string)
+    };
 
     for field in ["gaia_id", "user_name", "gaia_name", "name", "shortcut_name"] {
         for (dir, info) in cache {
@@ -233,22 +259,28 @@ pub fn resolve_profile_directory(local_state_json: &str, key: &str) -> Option<St
                 .and_then(|v| v.as_str())
                 .is_some_and(|v| v.trim().eq_ignore_ascii_case(key))
             {
-                return Some(dir.clone());
+                return Some(ResolvedProfile {
+                    directory: dir.clone(),
+                    email: email_of(info),
+                });
             }
         }
     }
     // Last resort: the key may itself be a directory name, which the writer
     // falls back to when a profile has no identifying fields at all.
     cache
-        .keys()
-        .find(|dir| dir.eq_ignore_ascii_case(key))
-        .cloned()
+        .iter()
+        .find(|(dir, _)| dir.eq_ignore_ascii_case(key))
+        .map(|(dir, info)| ResolvedProfile {
+            directory: dir.clone(),
+            email: email_of(info),
+        })
 }
 
 /// The whole lookup, against the real files. `None` for every ordinary reason:
 /// ChooseBrowser is not installed, the format is newer than we understand, no
 /// rule covers this url, or the profile it names is not on this machine.
-pub fn profile_directory_for_url(url: &str) -> Option<(String, ProfileChoice)> {
+pub fn profile_for_url(url: &str) -> Option<(ResolvedProfile, ProfileChoice)> {
     // First path that both exists and yields a decision. A file that parses to
     // "no rule covers this url" is a real answer, so keep looking only while
     // nothing has answered at all.
@@ -262,8 +294,8 @@ pub fn profile_directory_for_url(url: &str) -> Option<(String, ProfileChoice)> {
     // A key that resolves to nothing means launching with no profile argument.
     // Falling back to *some other* profile would open the link as the wrong
     // identity, which is worse than opening it as the default one.
-    let dir = resolve_profile_directory(&local_state, &choice.key)?;
-    Some((dir, choice))
+    let profile = resolve_profile_directory(&local_state, &choice.key)?;
+    Some((profile, choice))
 }
 
 #[cfg(test)]
@@ -382,6 +414,19 @@ mod tests {
         );
     }
 
+    /// The provenance line names the rule so the user can find and edit it.
+    /// The field is `ruleId` in the file; without the rename it deserialized to
+    /// `None` and the message pointed at nothing.
+    #[test]
+    fn the_matched_rule_id_comes_back_for_the_provenance_line() {
+        let f = rules(
+            r#"{"ruleId":"github.com|/my-org*","match":{"domain":"github.com"},
+                "action":{"bundleIdentifier":"com.google.Chrome::profile::k"}}"#,
+        );
+        let got = choose_for_url(&f, "https://github.com/my-org/repo").unwrap();
+        assert_eq!(got.rule_id.as_deref(), Some("github.com|/my-org*"));
+    }
+
     /// A rule pointing at another browser, or at Chrome without a profile, is
     /// not a Chrome profile choice and must not be forced into one.
     #[test]
@@ -417,20 +462,28 @@ mod tests {
     fn a_portable_key_resolves_to_this_machines_directory() {
         let s = local_state();
         assert_eq!(
-            resolve_profile_directory(&s, "103695396640962395023").as_deref(),
+            resolve_profile_directory(&s, "103695396640962395023")
+                .map(|p| p.directory)
+                .as_deref(),
             Some("Default")
         );
         assert_eq!(
-            resolve_profile_directory(&s, "leo@gmail.com").as_deref(),
+            resolve_profile_directory(&s, "leo@gmail.com")
+                .map(|p| p.directory)
+                .as_deref(),
             Some("Default")
         );
         assert_eq!(
-            resolve_profile_directory(&s, "Work").as_deref(),
+            resolve_profile_directory(&s, "Work")
+                .map(|p| p.directory)
+                .as_deref(),
             Some("Profile 14")
         );
         // A profile with no account at all falls back to its directory name.
         assert_eq!(
-            resolve_profile_directory(&s, "Profile 7").as_deref(),
+            resolve_profile_directory(&s, "Profile 7")
+                .map(|p| p.directory)
+                .as_deref(),
             Some("Profile 7")
         );
     }
@@ -440,11 +493,15 @@ mod tests {
     fn key_matching_ignores_case_and_surrounding_space() {
         let s = local_state();
         assert_eq!(
-            resolve_profile_directory(&s, " work@example.com ").as_deref(),
+            resolve_profile_directory(&s, " work@example.com ")
+                .map(|p| p.directory)
+                .as_deref(),
             Some("Profile 14")
         );
         assert_eq!(
-            resolve_profile_directory(&s, "LEO@GMAIL.COM").as_deref(),
+            resolve_profile_directory(&s, "LEO@GMAIL.COM")
+                .map(|p| p.directory)
+                .as_deref(),
             Some("Default")
         );
     }
@@ -462,6 +519,49 @@ mod tests {
         );
         assert_eq!(resolve_profile_directory(&s, "999999999999"), None);
         assert_eq!(resolve_profile_directory(&s, ""), None);
+    }
+
+    /// The resolution must also carry something the **relay** can select on.
+    ///
+    /// This is the bug that made the whole feature dead on arrival: resolution
+    /// returned only the on-disk directory name, and the relay identifies a
+    /// connected profile by its own id or by the signed-in address — a
+    /// directory is not a dimension it has. Every lookup therefore missed, and
+    /// missed *silently*, because "that profile isn't running the extension" is
+    /// a legitimate outcome. The rules parsed perfectly the entire time.
+    ///
+    /// Unit tests on either side stayed green because the break was between
+    /// them, so this one asserts the property the caller actually needs.
+    #[test]
+    fn a_resolved_profile_carries_an_identity_the_relay_can_match() {
+        let s = local_state();
+        let signed_in = resolve_profile_directory(&s, "103695396640962395023").unwrap();
+        assert_eq!(signed_in.directory, "Default");
+        assert_eq!(
+            signed_in.email.as_deref(),
+            Some("leo@gmail.com"),
+            "the relay selects by email; without it the caller has nothing to pass"
+        );
+
+        // Resolving by any of the other fields must carry the email too — the
+        // key that matched says nothing about what the caller then needs.
+        assert_eq!(
+            resolve_profile_directory(&s, "Work")
+                .unwrap()
+                .email
+                .as_deref(),
+            Some("Work@Example.COM")
+        );
+    }
+
+    /// A profile with no signed-in account has no email to offer. That is not a
+    /// failure to report — the relay could not match it either — so the caller
+    /// simply falls through to its existing behaviour.
+    #[test]
+    fn a_profile_with_no_account_resolves_without_an_email() {
+        let resolved = resolve_profile_directory(&local_state(), "Profile 7").unwrap();
+        assert_eq!(resolved.directory, "Profile 7");
+        assert_eq!(resolved.email, None);
     }
 
     /// A url no rule covers is the ordinary case, not an error.

--- a/cli/src/choosebrowser.rs
+++ b/cli/src/choosebrowser.rs
@@ -1,0 +1,487 @@
+//! Read ChooseBrowser's site → profile rules so an `open` lands in the account
+//! the user already decided that site belongs to.
+//!
+//! People with several Chrome profiles keep a mapping of "this site uses that
+//! account" in their head, and pass `--browser` every time to tell us. Many of
+//! them have already written that mapping down — in ChooseBrowser, a macOS
+//! link router that stores it as readable JSON. Reading it means the mapping
+//! does not have to be maintained twice.
+//!
+//! Three properties are load-bearing:
+//!
+//! * **Invisible when absent.** No file means no behaviour change and no
+//!   message. Most users do not have ChooseBrowser, and they should never learn
+//!   that this code exists.
+//! * **Read only.** The rules file is written atomically with a backup by an
+//!   app the user is actively using. A second writer would eventually destroy
+//!   the rules they built; changing them belongs behind an interface agreed
+//!   with that project, not in a file poke from here.
+//! * **Never guess a profile.** A key that resolves to nothing degrades to
+//!   launching with no profile argument. Opening a link in the *wrong* account
+//!   is worse than opening it in the default one — it can post, purchase or
+//!   send as the wrong identity.
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+/// The one format this code understands. A different number means the file was
+/// written by a version whose shape we have not seen; guessing at it is how a
+/// link ends up in the wrong account.
+const SUPPORTED_VERSION: u32 = 2;
+
+/// Where the rules can live, newest location first.
+///
+/// The App Group container is where both builds are converging, but the
+/// currently shipped direct-sale DMG still writes its own sandboxed location
+/// and the App Store build another. Reading only the new path would find
+/// nothing for everyone using a released version today, so all three are
+/// tried and the first that parses wins.
+fn rules_paths() -> Vec<PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    vec![
+        // Shared App Group container — both builds, going forward.
+        home.join("Library/Group Containers/6ZPXG4KVVS.com.choosebrowser/rules.json"),
+        // Direct-sale build, currently shipped.
+        home.join("Library/Application Support/ChooseBrowser/rules.json"),
+        // App Store build, currently shipped (sandboxed).
+        home.join(
+            "Library/Containers/com.choosebrowser.app/Data/Library/Application Support/ChooseBrowser/rules.json",
+        ),
+    ]
+}
+
+#[derive(Debug, Deserialize)]
+struct RulesFile {
+    version: u32,
+    #[serde(default)]
+    rules: Vec<Rule>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct Rule {
+    #[serde(default)]
+    priority: i64,
+    #[serde(default, rename = "createdAt")]
+    created_at: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    rule_id: Option<String>,
+    #[serde(default)]
+    r#match: Match,
+    action: Action,
+}
+
+/// Keys that appear must all match; keys that are absent are wildcards. An
+/// empty `match` therefore matches every url, which is how a catch-all rule is
+/// expressed.
+#[derive(Debug, Deserialize, Default, Clone)]
+struct Match {
+    #[serde(default)]
+    domain: Option<String>,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    scheme: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct Action {
+    #[serde(default, rename = "type")]
+    kind: Option<String>,
+    #[serde(default, rename = "bundleIdentifier")]
+    bundle_identifier: Option<String>,
+}
+
+/// What a matched rule asks for: a Chrome profile identified by a key that
+/// survives being moved between machines.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ProfileChoice {
+    /// The portable key from the rule — a gaia id, an email, a display name.
+    /// Deliberately not a directory name; see [`resolve_profile_directory`].
+    pub key: String,
+    /// Which rule produced it, for the provenance line the user sees.
+    pub rule_id: Option<String>,
+}
+
+/// `com.google.Chrome::profile::<key>` — anything else (a different browser, or
+/// Chrome with no profile) is not a Chrome profile choice.
+fn parse_chrome_profile_key(bundle_identifier: &str) -> Option<String> {
+    let (bundle, key) = bundle_identifier.split_once("::profile::")?;
+    if !bundle.eq_ignore_ascii_case("com.google.Chrome") {
+        return None;
+    }
+    let key = key.trim();
+    (!key.is_empty()).then(|| key.to_string())
+}
+
+/// `*.example.com` matches `example.com` and any subdomain; anything else is an
+/// exact, case-insensitive host match.
+fn domain_matches(pattern: &str, host: &str) -> bool {
+    let pattern = pattern.trim().to_ascii_lowercase();
+    let host = host.trim().to_ascii_lowercase();
+    match pattern.strip_prefix("*.") {
+        Some(suffix) => host == suffix || host.ends_with(&format!(".{suffix}")),
+        None => host == pattern,
+    }
+}
+
+/// `/my-org*` matches `/my-org` itself as well as anything under it. Without
+/// the star the whole path must be equal.
+fn path_matches(pattern: &str, path: &str) -> bool {
+    match pattern.strip_suffix('*') {
+        Some(prefix) => path.starts_with(prefix),
+        None => path == pattern,
+    }
+}
+
+impl Match {
+    fn matches(&self, url: &url::Url) -> bool {
+        if let Some(scheme) = &self.scheme {
+            if !url.scheme().eq_ignore_ascii_case(scheme.trim()) {
+                return false;
+            }
+        }
+        if let Some(domain) = &self.domain {
+            match url.host_str() {
+                Some(host) if domain_matches(domain, host) => {}
+                _ => return false,
+            }
+        }
+        if let Some(path) = &self.path {
+            if !path_matches(path, url.path()) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// How specific this rule is, used to break ties at equal priority: a rule
+    /// naming more things should win over a broader one that happens to have
+    /// been created first.
+    fn specificity(&self) -> usize {
+        [
+            self.domain.as_ref(),
+            self.path.as_ref(),
+            self.scheme.as_ref(),
+        ]
+        .iter()
+        .filter(|v| v.is_some())
+        .count()
+    }
+}
+
+/// Pick the rule that governs `url`: highest priority, then most specific, then
+/// oldest. Returns `None` when nothing matches — which is not a failure, just
+/// a url the user never wrote a rule for.
+pub fn choose_for_url(rules_json: &str, url: &str) -> Option<ProfileChoice> {
+    let parsed: RulesFile = serde_json::from_str(rules_json).ok()?;
+    if parsed.version != SUPPORTED_VERSION {
+        return None;
+    }
+    let url = url::Url::parse(url).ok()?;
+
+    let mut candidates: Vec<&Rule> = parsed
+        .rules
+        .iter()
+        .filter(|r| {
+            // Only "always open in" expresses a routing decision; other action
+            // types (ask, block) are not ours to act on.
+            r.action
+                .kind
+                .as_deref()
+                .is_none_or(|k| k.eq_ignore_ascii_case("always_open_in"))
+                && r.r#match.matches(&url)
+        })
+        .collect();
+
+    candidates.sort_by(|a, b| {
+        b.priority
+            .cmp(&a.priority)
+            .then(b.r#match.specificity().cmp(&a.r#match.specificity()))
+            .then(a.created_at.cmp(&b.created_at))
+    });
+
+    let winner = candidates.first()?;
+    let key = parse_chrome_profile_key(winner.action.bundle_identifier.as_deref()?)?;
+    Some(ProfileChoice {
+        key,
+        rule_id: winner.rule_id.clone(),
+    })
+}
+
+/// Turn a portable profile key into the `--profile-directory` value for *this*
+/// machine.
+///
+/// The key is deliberately not a directory name: Chrome numbers profiles in
+/// creation order, so the same account is `Profile 3` on one machine and
+/// `Profile 11` on another. Chrome's own `Local State` carries the mapping.
+///
+/// Compared case-insensitively against gaia id, then email, then display name,
+/// then the directory name itself — the same order the writer used when
+/// choosing what to store.
+pub fn resolve_profile_directory(local_state_json: &str, key: &str) -> Option<String> {
+    let state: serde_json::Value = serde_json::from_str(local_state_json).ok()?;
+    let cache = state.get("profile")?.get("info_cache")?.as_object()?;
+    let key = key.trim();
+
+    for field in ["gaia_id", "user_name", "gaia_name", "name", "shortcut_name"] {
+        for (dir, info) in cache {
+            if info
+                .get(field)
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| v.trim().eq_ignore_ascii_case(key))
+            {
+                return Some(dir.clone());
+            }
+        }
+    }
+    // Last resort: the key may itself be a directory name, which the writer
+    // falls back to when a profile has no identifying fields at all.
+    cache
+        .keys()
+        .find(|dir| dir.eq_ignore_ascii_case(key))
+        .cloned()
+}
+
+/// The whole lookup, against the real files. `None` for every ordinary reason:
+/// ChooseBrowser is not installed, the format is newer than we understand, no
+/// rule covers this url, or the profile it names is not on this machine.
+pub fn profile_directory_for_url(url: &str) -> Option<(String, ProfileChoice)> {
+    // First path that both exists and yields a decision. A file that parses to
+    // "no rule covers this url" is a real answer, so keep looking only while
+    // nothing has answered at all.
+    let choice = rules_paths().into_iter().find_map(|p| {
+        let body = std::fs::read_to_string(p).ok()?;
+        choose_for_url(&body, url)
+    })?;
+    let local_state = dirs::home_dir()
+        .map(|h| h.join("Library/Application Support/Google/Chrome/Local State"))
+        .and_then(|p| std::fs::read_to_string(p).ok())?;
+    // A key that resolves to nothing means launching with no profile argument.
+    // Falling back to *some other* profile would open the link as the wrong
+    // identity, which is worse than opening it as the default one.
+    let dir = resolve_profile_directory(&local_state, &choice.key)?;
+    Some((dir, choice))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rules(body: &str) -> String {
+        format!(r#"{{"version":2,"rules":[{body}]}}"#)
+    }
+
+    /// A version we have not seen means a shape we have not seen. Guessing at
+    /// it is how a link lands in the wrong account, so an unknown version is
+    /// simply "no rules" rather than a best effort.
+    #[test]
+    fn an_unknown_version_yields_nothing() {
+        let f = r#"{"version":3,"rules":[{"match":{"domain":"a.example"},
+            "action":{"bundleIdentifier":"com.google.Chrome::profile::x"}}]}"#;
+        assert_eq!(choose_for_url(f, "https://a.example/"), None);
+    }
+
+    /// Malformed or truncated JSON is the same story: no rules, no message,
+    /// no behaviour change.
+    #[test]
+    fn unreadable_json_yields_nothing() {
+        for body in ["", "{", "null", "[]", r#"{"rules":[]}"#] {
+            assert_eq!(choose_for_url(body, "https://a.example/"), None, "{body:?}");
+        }
+    }
+
+    /// Keys present in `match` must all hold; keys absent are wildcards.
+    #[test]
+    fn every_key_present_in_match_must_hold() {
+        let f = rules(
+            r#"{"match":{"domain":"a.example","path":"/x"},
+                "action":{"bundleIdentifier":"com.google.Chrome::profile::k"}}"#,
+        );
+        assert!(choose_for_url(&f, "https://a.example/x").is_some());
+        assert_eq!(
+            choose_for_url(&f, "https://a.example/y"),
+            None,
+            "path must hold"
+        );
+        assert_eq!(
+            choose_for_url(&f, "https://b.example/x"),
+            None,
+            "domain must hold"
+        );
+    }
+
+    /// An empty `match` is every key wildcarded, which is how a catch-all is
+    /// written.
+    #[test]
+    fn an_empty_match_is_a_catch_all() {
+        let f =
+            rules(r#"{"match":{},"action":{"bundleIdentifier":"com.google.Chrome::profile::k"}}"#);
+        assert!(choose_for_url(&f, "https://anything.example/deep/path").is_some());
+    }
+
+    /// `*.example.com` covers the bare domain as well as subdomains — a user
+    /// writing it means "this site", not "only its subdomains".
+    #[test]
+    fn a_leading_star_domain_covers_the_bare_domain_too() {
+        assert!(domain_matches("*.example.com", "example.com"));
+        assert!(domain_matches("*.example.com", "mail.example.com"));
+        assert!(domain_matches("*.example.com", "a.b.example.com"));
+        assert!(!domain_matches("*.example.com", "notexample.com"));
+        assert!(!domain_matches("*.example.com", "example.com.evil.test"));
+    }
+
+    /// `/my-org*` matches `/my-org` itself, not only paths beneath it.
+    #[test]
+    fn a_trailing_star_path_covers_the_prefix_itself() {
+        assert!(path_matches("/my-org*", "/my-org"));
+        assert!(path_matches("/my-org*", "/my-org/repo"));
+        assert!(!path_matches("/my-org*", "/other"));
+        assert!(path_matches("/exact", "/exact"));
+        assert!(!path_matches("/exact", "/exact/more"));
+    }
+
+    /// Priority first, then specificity, then age. Specificity matters because
+    /// a rule naming domain *and* path is a more deliberate statement than a
+    /// domain-only rule that happens to be older.
+    #[test]
+    fn the_winner_is_priority_then_specificity_then_age() {
+        let f = rules(
+            r#"{"priority":10,"createdAt":"2020-01-01","match":{"domain":"a.example"},
+                "action":{"bundleIdentifier":"com.google.Chrome::profile::low"}},
+               {"priority":100,"createdAt":"2024-01-01","match":{"domain":"a.example"},
+                "action":{"bundleIdentifier":"com.google.Chrome::profile::high"}}"#,
+        );
+        assert_eq!(
+            choose_for_url(&f, "https://a.example/").unwrap().key,
+            "high"
+        );
+
+        let f = rules(
+            r#"{"priority":50,"createdAt":"2020-01-01","match":{"domain":"a.example"},
+                "action":{"bundleIdentifier":"com.google.Chrome::profile::broad"}},
+               {"priority":50,"createdAt":"2024-01-01","match":{"domain":"a.example","path":"/x*"},
+                "action":{"bundleIdentifier":"com.google.Chrome::profile::narrow"}}"#,
+        );
+        assert_eq!(
+            choose_for_url(&f, "https://a.example/x").unwrap().key,
+            "narrow"
+        );
+
+        let f = rules(
+            r#"{"priority":50,"createdAt":"2024-01-01","match":{"domain":"a.example"},
+                "action":{"bundleIdentifier":"com.google.Chrome::profile::newer"}},
+               {"priority":50,"createdAt":"2020-01-01","match":{"domain":"a.example"},
+                "action":{"bundleIdentifier":"com.google.Chrome::profile::older"}}"#,
+        );
+        assert_eq!(
+            choose_for_url(&f, "https://a.example/").unwrap().key,
+            "older"
+        );
+    }
+
+    /// A rule pointing at another browser, or at Chrome without a profile, is
+    /// not a Chrome profile choice and must not be forced into one.
+    #[test]
+    fn only_a_chrome_profile_bundle_id_is_a_profile_choice() {
+        assert_eq!(
+            parse_chrome_profile_key("com.google.Chrome::profile::abc").as_deref(),
+            Some("abc")
+        );
+        assert_eq!(parse_chrome_profile_key("com.apple.Safari"), None);
+        assert_eq!(parse_chrome_profile_key("com.google.Chrome"), None);
+        assert_eq!(
+            parse_chrome_profile_key("org.mozilla.firefox::profile::abc"),
+            None
+        );
+        assert_eq!(
+            parse_chrome_profile_key("com.google.Chrome::profile::   "),
+            None
+        );
+    }
+
+    fn local_state() -> String {
+        r#"{"profile":{"info_cache":{
+            "Default":     {"gaia_id":"103695396640962395023","user_name":"leo@gmail.com","name":"Leo"},
+            "Profile 14":  {"gaia_id":"102211906995000000001","user_name":"Work@Example.COM","name":"Work"},
+            "Profile 7":   {"name":"No Account"}
+        }}}"#
+            .to_string()
+    }
+
+    /// The stored key can be any of several identifying fields; each must
+    /// resolve to the directory name this machine happens to use.
+    #[test]
+    fn a_portable_key_resolves_to_this_machines_directory() {
+        let s = local_state();
+        assert_eq!(
+            resolve_profile_directory(&s, "103695396640962395023").as_deref(),
+            Some("Default")
+        );
+        assert_eq!(
+            resolve_profile_directory(&s, "leo@gmail.com").as_deref(),
+            Some("Default")
+        );
+        assert_eq!(
+            resolve_profile_directory(&s, "Work").as_deref(),
+            Some("Profile 14")
+        );
+        // A profile with no account at all falls back to its directory name.
+        assert_eq!(
+            resolve_profile_directory(&s, "Profile 7").as_deref(),
+            Some("Profile 7")
+        );
+    }
+
+    /// Emails and names arrive with whatever case the user typed.
+    #[test]
+    fn key_matching_ignores_case_and_surrounding_space() {
+        let s = local_state();
+        assert_eq!(
+            resolve_profile_directory(&s, " work@example.com ").as_deref(),
+            Some("Profile 14")
+        );
+        assert_eq!(
+            resolve_profile_directory(&s, "LEO@GMAIL.COM").as_deref(),
+            Some("Default")
+        );
+    }
+
+    /// The most important guarantee here: a key naming a profile this machine
+    /// does not have resolves to nothing, so the caller launches with no
+    /// profile argument. Substituting a different profile would open the link
+    /// as the wrong identity — able to post, buy or send as someone else.
+    #[test]
+    fn an_unknown_key_resolves_to_nothing_rather_than_some_other_profile() {
+        let s = local_state();
+        assert_eq!(
+            resolve_profile_directory(&s, "someone-else@example.com"),
+            None
+        );
+        assert_eq!(resolve_profile_directory(&s, "999999999999"), None);
+        assert_eq!(resolve_profile_directory(&s, ""), None);
+    }
+
+    /// A url no rule covers is the ordinary case, not an error.
+    #[test]
+    fn a_url_no_rule_covers_yields_nothing() {
+        let f = rules(
+            r#"{"match":{"domain":"a.example"},
+                "action":{"bundleIdentifier":"com.google.Chrome::profile::k"}}"#,
+        );
+        assert_eq!(choose_for_url(&f, "https://elsewhere.example/"), None);
+    }
+
+    /// Action types other than "always open in" are decisions we are not being
+    /// asked to make.
+    #[test]
+    fn only_always_open_in_routes() {
+        let f = rules(
+            r#"{"match":{"domain":"a.example"},
+                "action":{"type":"ask","bundleIdentifier":"com.google.Chrome::profile::k"}}"#,
+        );
+        assert_eq!(choose_for_url(&f, "https://a.example/"), None);
+    }
+}

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4813,6 +4813,7 @@ mod tests {
 
     fn default_flags() -> Flags {
         Flags {
+            no_choosebrowser: false,
             session: "test".to_string(),
             session_explicit: true,
             json: false,

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -411,6 +411,10 @@ pub struct Flags {
     /// `--browser <id|email-substr>`: pin this session to a specific connected
     /// Chrome profile's relay endpoint (issue #60). Resolved to a `relay-cdp-url-<id>`.
     pub browser: Option<String>,
+    /// Skip the ChooseBrowser rule lookup for this invocation. The lookup is
+    /// silent when ChooseBrowser is not installed, so this exists for the user
+    /// who *has* rules and wants one command to ignore them.
+    pub no_choosebrowser: bool,
     /// `--as <vault-account-id>`: before executing the command, verify the
     /// session's live cookies match this cookie-use account's fingerprint;
     /// on mismatch auto-apply the account's session (or fail with --as-strict).
@@ -803,6 +807,7 @@ pub fn parse_flags(args: &[String]) -> Flags {
     };
 
     let mut flags = Flags {
+        no_choosebrowser: false,
         json: env_var_is_truthy("AGENT_BROWSER_JSON") || config.json.unwrap_or(false),
         headed: env_var_is_truthy("AGENT_BROWSER_HEADED") || config.headed.unwrap_or(false),
         debug: env_var_is_truthy("AGENT_BROWSER_DEBUG") || config.debug.unwrap_or(false),
@@ -1047,6 +1052,9 @@ pub fn parse_flags(args: &[String]) -> Flags {
                     flags.browser = Some(s.clone());
                     i += 1;
                 }
+            }
+            "--no-choosebrowser" => {
+                flags.no_choosebrowser = true;
             }
             "--as" => {
                 if let Some(s) = args.get(i + 1) {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod account;
 mod chat;
+mod choosebrowser;
 mod color;
 mod commands;
 mod connect;
@@ -175,6 +176,32 @@ fn session_command_route(sub: Option<&str>) -> SessionCommandRoute {
 /// extension renames the group, so the daemon is asked to do that; when it
 /// cannot (no daemon yet, or an older extension), the reply says which tabs the
 /// new name applies to rather than implying it applied to all of them.
+/// The url this invocation is about to open, for the ChooseBrowser lookup.
+///
+/// Only the commands that *navigate* carry one. A `snapshot` or a `click` acts
+/// on whatever the session already has open, so consulting a routing rule there
+/// would answer a question nobody asked — and could move the session to another
+/// profile mid-task.
+fn target_url_for_choosebrowser(argv: &[String]) -> Option<String> {
+    const NAVIGATES: &[&str] = &["open", "goto", "navigate"];
+    let verb = argv.first()?.as_str();
+    if !NAVIGATES.contains(&verb) {
+        return None;
+    }
+    let candidate = argv
+        .iter()
+        .skip(1)
+        .find(|a| !a.starts_with('-') && a.contains('.'))?;
+    // Accept what the user typed the way `open` does, so a bare host still
+    // routes: `open github.com` is the common shape.
+    let normalized = if candidate.contains("://") {
+        candidate.clone()
+    } else {
+        format!("https://{candidate}")
+    };
+    url::Url::parse(&normalized).ok().map(|u| u.to_string())
+}
+
 fn run_session_name(session: &str, json_mode: bool, zh: bool) {
     let requested: Vec<String> = std::env::args()
         .skip_while(|a| a != "name")
@@ -1828,8 +1855,44 @@ fn main() {
         // the agent lands on a logged-out profile. Default instead to the profile
         // the user is actively using (most recently focused window); if that's
         // ambiguous, keep the legacy default but warn loudly with how to pick.
+        //
+        // Before guessing from focus, though: the user may already have written
+        // down which account this site belongs to. ChooseBrowser stores exactly
+        // that mapping, and a rule they authored beats any inference we make
+        // from which window they happen to be looking at (issue #244).
+        let cb_pick = if flags.no_choosebrowser {
+            None
+        } else {
+            target_url_for_choosebrowser(&clean)
+                .and_then(|u| choosebrowser::profile_directory_for_url(&u))
+        };
+        if let Some((dir, choice)) = cb_pick {
+            // A rule naming a profile the relay has no endpoint for means that
+            // profile is not running the extension. Fall through to the
+            // existing behaviour rather than failing: the rule is advice about
+            // which account the site belongs to, not a requirement that it be
+            // reachable right now.
+            if let Ok(url) = connect::relay_url_for_browser(&dir) {
+                flags.cdp = Some(url);
+                flags.auto_connect = false;
+                // Say where the choice came from. Without this the user sees
+                // a different account open than the window they were looking
+                // at, with nothing to explain it.
+                eprintln!(
+                        "{} using Chrome profile {} — a ChooseBrowser rule routes this site there{}. Override with --browser <id|email>, or skip with --no-choosebrowser.",
+                        color::dim("·"),
+                        dir,
+                        choice
+                            .rule_id
+                            .as_deref()
+                            .map(|r| format!(" ({r})"))
+                            .unwrap_or_default(),
+                    );
+            }
+        }
+
         let profiles = connect::list_relay_profiles();
-        if profiles.len() >= 2 {
+        if flags.cdp.is_none() && profiles.len() >= 2 {
             match connect::most_recently_focused_profile() {
                 Some((id, email, ws)) => {
                     flags.cdp = Some(ws);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1863,16 +1863,28 @@ fn main() {
         let cb_pick = if flags.no_choosebrowser {
             None
         } else {
-            target_url_for_choosebrowser(&clean)
-                .and_then(|u| choosebrowser::profile_directory_for_url(&u))
+            target_url_for_choosebrowser(&clean).and_then(|u| choosebrowser::profile_for_url(&u))
         };
-        if let Some((dir, choice)) = cb_pick {
+        if let Some((profile, choice)) = cb_pick {
             // A rule naming a profile the relay has no endpoint for means that
             // profile is not running the extension. Fall through to the
             // existing behaviour rather than failing: the rule is advice about
             // which account the site belongs to, not a requirement that it be
             // reachable right now.
-            if let Ok(url) = connect::relay_url_for_browser(&dir) {
+            // Select by email, not by directory name. The relay knows a profile
+            // by its own id or by the signed-in address; a directory name is
+            // not a dimension it has, so selecting with one matched nothing —
+            // silently, because a miss here is a legitimate "that profile isn't
+            // running the extension". The rules parsed correctly the whole time
+            // and the conclusion was simply never usable.
+            // A profile with no signed-in account gives the relay nothing to
+            // match on either, so there is nothing to try — fall through to the
+            // existing behaviour rather than inventing a selector.
+            let relay_url = profile
+                .email
+                .as_deref()
+                .and_then(|email| connect::relay_url_for_browser(email).ok());
+            if let Some(url) = relay_url {
                 flags.cdp = Some(url);
                 flags.auto_connect = false;
                 // Say where the choice came from. Without this the user sees
@@ -1881,7 +1893,7 @@ fn main() {
                 eprintln!(
                         "{} using Chrome profile {} — a ChooseBrowser rule routes this site there{}. Override with --browser <id|email>, or skip with --no-choosebrowser.",
                         color::dim("·"),
-                        dir,
+                        profile.directory,
                         choice
                             .rule_id
                             .as_deref()

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -4698,6 +4698,11 @@ Options:
   --browser <id|email>       Pin this session to a specific connected Chrome profile
                              (run `chrome-use browsers` to list; for multi-profile
                              relay setups). Sticky per session.
+  --no-choosebrowser         Ignore ChooseBrowser's site rules for this command.
+                             When that app is installed, `open <url>` without an
+                             explicit --browser follows the rule the user already
+                             wrote for that site. Nothing happens either way if
+                             it isn't installed.
   --color-scheme <scheme>    Color scheme: dark, light, no-preference (or AGENT_BROWSER_COLOR_SCHEME)
   --download-path <path>     Default download directory (or AGENT_BROWSER_DOWNLOAD_PATH)
   --content-boundaries       Wrap page output in boundary markers (or AGENT_BROWSER_CONTENT_BOUNDARIES)

--- a/docs/en/real-chrome.html
+++ b/docs/en/real-chrome.html
@@ -172,6 +172,47 @@
         the correct <code>--browser</code>.
       </div>
 
+      <h3>Let your rules pick: ChooseBrowser</h3>
+      <p>
+        You already know which account each site belongs to; you just tell us again with
+        <code>--browser</code> every time.
+        <a href="https://choosebrowser.leeguoo.com">ChooseBrowser</a> is a macOS link router that
+        stores that mapping. With it installed, <code>open</code> follows the rule you wrote —
+        <span class="mark">only when you did not pass <code>--browser</code></span> — and says where
+        the choice came from.
+      </p>
+
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">a rule fires</span>
+        </div>
+<pre><code><span class="du-prompt">$</span> chrome-use open https://github.com/my-org/repo
+<span class="du-cmt">· using Chrome profile Profile 14 — a ChooseBrowser rule routes this site there</span>
+<span class="du-cmt">  (github.com|/my-org*). Override with --browser &lt;id|email&gt;, or skip with --no-choosebrowser.</span></code></pre>
+      </div>
+
+      <p>
+        Read-only, and invisible if you do not use it: no rules file means no behaviour change and
+        no message. A rule naming a profile that is not running the extension falls back to the
+        normal profile choice <span class="mark">rather than opening the link as some other
+        account</span> — the wrong identity can post, purchase and send as you.
+      </p>
+      <p>
+        Rules are consulted before the "most recently focused window" guess, because a rule is
+        something you wrote down and the focus is something we infer. Only navigating commands
+        (<code>open</code> / <code>goto</code> / <code>navigate</code>) consult them;
+        <code>snapshot</code> and <code>click</code> act on what the session already has open.
+      </p>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ Disclosure</div>
+        ChooseBrowser is a paid macOS app (US$4.99, 7-day trial) by the same author as chrome-use.
+        This is a companion-tool note, not an independent review. chrome-use does not depend on it.
+      </div>
+
+      <hr class="du-divider" />
+
       <h2>--launch vs --profile auto</h2>
       <p>
         <code>--launch</code> opens an <strong>isolated blank test profile</strong>—no cookies, no logins, no extensions

--- a/docs/real-chrome.html
+++ b/docs/real-chrome.html
@@ -166,6 +166,45 @@
         错的 profile 上显示未登录 ≠ 登录丢失——先跑 <code>browsers</code>，再带上正确的 <code>--browser</code> 重跑。
       </div>
 
+      <h3>让规则替你选：ChooseBrowser</h3>
+      <p>
+        「哪个站点用哪个账号」这件事，你心里本来就有数，只是每次都要用
+        <code>--browser</code> 再说一遍。
+        <a href="https://choosebrowser.leeguoo.com">ChooseBrowser</a> 是一个 macOS 链接路由工具，
+        它把这份映射存了下来；装了它之后，<code>open</code> 在你<span class="mark">没显式指定
+        <code>--browser</code></span> 时会按你写的规则选 profile，并说明来源。
+      </p>
+
+      <div class="du-code">
+        <div class="du-code-head">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="du-code-name">规则生效时</span>
+        </div>
+<pre><code><span class="du-prompt">$</span> chrome-use open https://github.com/my-org/repo
+<span class="du-cmt">· using Chrome profile Profile 14 — a ChooseBrowser rule routes this site there</span>
+<span class="du-cmt">  (github.com|/my-org*). Override with --browser &lt;id|email&gt;, or skip with --no-choosebrowser.</span></code></pre>
+      </div>
+
+      <p>
+        只读，没装的话完全无感——没有规则文件就不改变任何行为、也不打提示。
+        规则指向的 profile 如果没在跑扩展，会退回正常的 profile 选择，
+        <span class="mark">而不是退而求其次开进别的账号</span>：把链接开进错的账号，
+        那个身份能发帖、能下单、能替人发消息。
+      </p>
+      <p>
+        规则排在「猜最近聚焦的窗口」之前——规则是你写下的意图，比从你正看着哪个窗口做的推断可信。
+        只有 <code>open</code> / <code>goto</code> / <code>navigate</code> 这类会导航的命令才查它；
+        <code>snapshot</code>、<code>click</code> 作用在会话已经打开的东西上，不查。
+      </p>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ 利益披露</div>
+        ChooseBrowser 是一款付费 macOS 应用（US$4.99，7 天试用），作者与 chrome-use 是同一人。
+        这是配套工具说明，不是独立第三方评价。chrome-use 不依赖它。
+      </div>
+
+      <hr class="du-divider" />
+
       <h2>--launch vs --profile auto</h2>
       <p>
         <code>--launch</code> 会开一个<strong>隔离的空白测试 profile</strong>——没有 cookie、没有登录、没有扩展


### PR DESCRIPTION
多 profile 的人开链接时每次都要手动 `--browser`，而「哪个站点用哪个账号」这份映射，他们往往已经在 [ChooseBrowser](https://choosebrowser.leeguoo.com) 里维护过一份。读一下就不用维护两遍。

```
$ chrome-use open https://github.com/leeguooooo/chrome-use
· using Chrome profile Default — a ChooseBrowser rule routes this site there
  (github.com|/leeguooooo*). Override with --browser <id|email>, or skip with --no-choosebrowser.
```

## 三条承重的性质

**没装的人完全无感。** 文件不存在就跳过 —— 不打警告、不提示降级、不给开关看。大多数用户没装，他们不该知道这段代码存在。

**只读。** 规则文件是那个 app 原子写加备份的，用户正在用它。第二个写入方迟早会毁掉他们建的规则。

**绝不猜 profile。** key 解析不到就退回「不带 profile 参数启动」。把链接开进**错误的**账号比开进默认账号严重得多 —— 那个身份能发帖、能下单、能替人发消息。单独有测试守着。

## 设计决定

**插在「没显式 `--browser`」那一支，且排在「猜最近聚焦窗口」之前。** 规则是用户明确写下的意图，比我们从他正看着哪个窗口做的推断可信。

**只有 `open` / `goto` / `navigate` 查规则。** `snapshot` / `click` 作用在会话已经打开的东西上，查路由等于回答没人问的问题，还可能让会话在任务中途跳到别的 profile。

**`--launch` 不查规则。** 它起的是隔离的空白 Chrome，不走 relay、没有任何登录态，「路由到某个账号」在那里没有意义。（写在这里是因为它看起来像漏了 —— 复验的人就差点当成 bug 报回来。）

**用邮箱选 relay，用目录名展示。** 一个 profile 在三个系统里有三套标识：ChooseBrowser 存 gaia_id、Chrome 用目录名、relay 用自己的 uuid 加邮箱。人认得 `Profile 14`，relay 认不得。

**三条路径都探。** 线上已发布的直售版和商店版各用各的旧路径，共享的 App Group 容器要等下个版本。只探新路径等于对现有所有用户静默失效。

## 这个功能发布前两次「从未生效」

两次都是单测全绿、功能一动不动，而且**失败都是静默的** —— 这个设计的前提就是「读不到就当没有」，于是任何一环断掉长得都一模一样。

1. **跨模块标识不匹配**：解析只返回目录名，而 relay 按 uuid 或邮箱匹配，恒失败。两侧单测各自都对，断的是中间那个接缝。
2. **`createdAt` 是数字不是字符串**：serde 拒绝整份文档，四条规则完好躺在盘上，一条都读不出来。

第二条是我自己造的，值得记清楚：需求里 `createdAt` **只出现在「按 createdAt 升序排」这一句话里，从来没给过类型**，契约文档在私有仓库我读不到。我从字段名推断它是日期字符串，写了 `Option<String>`，**然后回头说「文档写的是字符串」**。文档里写的其实是数字。

从名字推断类型是错的第一步；把推断说成事实、还赖给文档，比错本身更糟。（`AGENTS.md` 里新加的那节讲的就是这个。）

现在它不指定具体类型，单独写比较函数：数字按数值比、其余按文本比、缺失排最后。只用于排序，类型无所谓，只要比较稳定。

## 测试

18 个单测覆盖整份契约：版本不认就当读不了、坏 JSON 静默跳过、`match` 里出现的键必须全中、空 `match` 是通配、`*.` 前缀域名连裸域一起匹配、`/x*` 连 `/x` 本身一起匹配、优先级→特异性→创建时间排序、只有 `always_open_in` 参与路由、非 Chrome 的 bundle id 不当 profile 用、key 的多级回退、**未知 key 绝不退而求其次**、解析结果必须带 relay 能匹配的身份、以及**一条从真实 `rules.json` 逐字复制的规则**。

最后一条是关键：文档描述格式，描述不了真实文件的样子。只测文档等于什么都没测。

**端到端由 ChooseBrowser 那边复验通过**，六种情况全对：两条命中规则的打出来源提示；两条指向未连扩展 profile 的静默回退；无规则的静默；`--no-choosebrowser` 静默。

1254 单测通过，clippy 干净。

## 下一步（不在本 PR）

`--remember`：用户**显式**传了 `--browser` 打开某站点时，那本身就是一次明确的路由决定，那时提议写回才有依据。纯显式、零推断，UX 按「提议」而不是「已完成」写 —— ChooseBrowser 每次保存都会弹窗让用户确认，URL 打开成功不等于规则已保存。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf