### PR TITLE
fix(ci): 发布构建前校验版本与说明

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -23,8 +23,29 @@ env:
   ZIG_VERSION: "0.16.0"
 
 jobs:
+  validate:
+    name: Validate release version and notes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - name: Check packaged version and reviewed notes
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          node scripts/check-version-sync.js
+          node scripts/release-notes.js "$RELEASE_TAG" > /dev/null
+
   build:
     name: Build ${{ matrix.name }}
+    needs: validate
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
v1.5.110 的七平台构建全部完成后，才因缺少匹配 CHANGELOG 段落导致发布失败。新增前置校验任务，让所有平台构建依赖版本同步和发布说明校验，尽早报告同类错误。最终发布步骤仍保留校验。YAML 解析及 5 项发布说明测试通过。不会修复或移动已经存在的 v1.5.110 标签。