### PR TITLE
feat(doctor): 给静默降级的 ChooseBrowser 集成配一条不静默的自检

### DIFF
--- a/cli/src/choosebrowser.rs
+++ b/cli/src/choosebrowser.rs
@@ -37,7 +37,7 @@ const SUPPORTED_VERSION: u32 = 2;
 /// and the App Store build another. Reading only the new path would find
 /// nothing for everyone using a released version today, so all three are
 /// tried and the first that parses wins.
-fn rules_paths() -> Vec<PathBuf> {
+pub fn rules_paths() -> Vec<PathBuf> {
     let Some(home) = dirs::home_dir() else {
         return Vec::new();
     };
@@ -300,6 +300,65 @@ pub fn resolve_profile_directory(local_state_json: &str, key: &str) -> Option<Re
             directory: dir.clone(),
             email: email_of(info),
         })
+}
+
+/// What the lookup found, step by step, for `doctor` to print.
+///
+/// The feature degrades silently by design — a missing file must not produce a
+/// message for the many people who do not use ChooseBrowser. That is right for
+/// them and blinding for everyone else: "not installed", "wrong path", "format
+/// not understood", "profile not connected" and "no rule matches" all present
+/// as the same thing, which is nothing at all. Three separate ways of never
+/// working shipped behind that sameness before a person ran six urls by hand
+/// and reasoned backwards.
+///
+/// So the silent path gets one loud counterpart. Nothing here changes
+/// behaviour; it only says out loud what the quiet path decided.
+#[derive(Debug)]
+pub struct Diagnosis {
+    /// Every location probed, and whether a file was there. Reported even on
+    /// success: "found it, but in the path you thought was retired" is its own
+    /// failure mode.
+    pub probed: Vec<(PathBuf, bool)>,
+    /// The file that answered, if any.
+    pub source: Option<PathBuf>,
+    /// Rules parsed out of it. `Some(0)` and `None` are different: zero rules
+    /// is an empty file, `None` is one we could not read.
+    pub parsed: Option<usize>,
+    /// Version found, when the file parsed far enough to carry one.
+    pub version: Option<u32>,
+}
+
+/// Probe the rules files without consulting any url.
+pub fn diagnose() -> Diagnosis {
+    let mut d = Diagnosis {
+        probed: Vec::new(),
+        source: None,
+        parsed: None,
+        version: None,
+    };
+    for path in rules_paths() {
+        let body = std::fs::read_to_string(&path).ok();
+        d.probed.push((path.clone(), body.is_some()));
+        let Some(body) = body else { continue };
+        if d.source.is_some() {
+            continue;
+        }
+        d.source = Some(path);
+        // Read the version even when the rest fails to deserialize: "version 3"
+        // and "malformed" are different problems with different fixes.
+        if let Ok(raw) = serde_json::from_str::<serde_json::Value>(&body) {
+            d.version = raw
+                .get("version")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+        }
+        d.parsed = serde_json::from_str::<RulesFile>(&body)
+            .ok()
+            .filter(|f| f.version == SUPPORTED_VERSION)
+            .map(|f| f.rules.len());
+    }
+    d
 }
 
 /// The whole lookup, against the real files. `None` for every ordinary reason:
@@ -628,6 +687,25 @@ mod tests {
         assert_eq!(compare_created_at(&None, &num(1)), Ordering::Greater);
         assert_eq!(compare_created_at(&num(1), &None), Ordering::Less);
         assert_eq!(compare_created_at(&None, &None), Ordering::Equal);
+    }
+
+    /// `Some(0)` and `None` must stay distinguishable: an empty rules file and
+    /// one we could not read need different messages, and collapsing them is
+    /// exactly the sameness this diagnosis exists to break.
+    #[test]
+    fn zero_rules_and_unreadable_rules_are_different_answers() {
+        assert_eq!(
+            serde_json::from_str::<RulesFile>(r#"{"version":2,"rules":[]}"#)
+                .ok()
+                .map(|f| f.rules.len()),
+            Some(0)
+        );
+        assert_eq!(
+            serde_json::from_str::<RulesFile>("{not json")
+                .ok()
+                .map(|f| f.rules.len()),
+            None
+        );
     }
 
     /// A url no rule covers is the ordinary case, not an error.

--- a/cli/src/doctor/choosebrowser.rs
+++ b/cli/src/doctor/choosebrowser.rs
@@ -1,0 +1,86 @@
+//! Read-only probe: can we see ChooseBrowser's rules, and would they route
+//! anything?
+//!
+//! The integration is silent by design — no rules file means no message, which
+//! is right for the many people who do not use that app. The cost is that every
+//! way of not working looks identical from outside: not installed, wrong path,
+//! version we do not read, format we could not parse, profile not connected,
+//! no rule for this url. Three separate never-worked bugs shipped behind that
+//! sameness. This check is the loud counterpart to the quiet path.
+//!
+//! Never `Fail`: not having ChooseBrowser is the normal case, not a fault.
+
+use super::{Check, Status};
+use crate::choosebrowser;
+
+pub(super) fn check(checks: &mut Vec<Check>) {
+    let category = "ChooseBrowser rules";
+    let d = choosebrowser::diagnose();
+
+    let Some(source) = d.source.as_ref() else {
+        // Say where we looked. "Not installed" and "installed somewhere we do
+        // not read" are different, and only the paths distinguish them.
+        let looked: Vec<String> = d
+            .probed
+            .iter()
+            .map(|(p, _)| p.display().to_string())
+            .collect();
+        checks.push(
+            Check::new(
+                "choosebrowser.rules",
+                category,
+                Status::Info,
+                "no rules file — profile selection is unaffected",
+            )
+            .with_fix(format!(
+                "if you do use ChooseBrowser, its rules are not in any path this build reads: {}",
+                looked.join(", ")
+            )),
+        );
+        return;
+    };
+
+    match (d.parsed, d.version) {
+        (Some(n), _) => {
+            checks.push(Check::new(
+                "choosebrowser.rules",
+                category,
+                Status::Pass,
+                // Which path answered belongs in the message, not a
+                // footnote: a released build still writes an older
+                // location, so "found, but in the one you thought was
+                // retired" is a real and confusing state.
+                format!("{n} rule(s) loaded from {}", source.display()),
+            ));
+        }
+        // Parsed as JSON, but not a version this build reads. Guessing at an
+        // unknown shape is how a link opens as the wrong account, so it is
+        // deliberately ignored — but silently ignoring it is what hid this
+        // class of problem before.
+        (None, Some(v)) => {
+            checks.push(
+                Check::new(
+                    "choosebrowser.rules",
+                    category,
+                    Status::Warn,
+                    format!(
+                        "{} is version {v}; this build reads version 2 only",
+                        source.display()
+                    ),
+                )
+                .with_fix("rules are ignored rather than guessed at — upgrade chrome-use"),
+            );
+        }
+        (None, None) => {
+            checks.push(Check::new(
+                "choosebrowser.rules",
+                category,
+                Status::Warn,
+                format!(
+                    "{} exists but did not parse — every rule in it is being ignored",
+                    source.display()
+                ),
+            ));
+        }
+    }
+}

--- a/cli/src/doctor/mod.rs
+++ b/cli/src/doctor/mod.rs
@@ -8,6 +8,7 @@
 //! repairs (reinstalling Chrome, purging old state files, generating a
 //! missing encryption key) are gated behind `--fix`.
 
+mod choosebrowser;
 mod chrome;
 mod config;
 mod daemon;
@@ -108,6 +109,7 @@ pub fn run_doctor(opts: DoctorOptions) -> i32 {
     security::check(&mut checks);
     providers::check(&mut checks);
     skill::check(&mut checks);
+    choosebrowser::check(&mut checks);
 
     if !opts.offline {
         network::check(&mut checks);


### PR DESCRIPTION
纯增量，**零行为改动** —— 只是把安静那条路的判断说出声。

## 为什么需要

ChooseBrowser 集成按设计是静默的：没有规则文件就不改行为、不打提示。对不用那个 app 的多数人这是对的。

代价是**每一种「没生效」从外面看长得一模一样**：没装、路径不对、版本不认、格式解析失败、profile 没连扩展、这个 URL 没有规则 —— 全都是「什么都没发生」。

#244 发布前有三个「从未生效」的 bug 就藏在这个一模一样里，全部单测覆盖不到，最后是靠人**手工跑六个 URL 反推**出来的，中间还试错了 session 复用和 `--launch` 两条岔路。

## 输出

```
ChooseBrowser rules
  pass  4 rule(s) loaded from /Users/leo/Library/Containers/com.choosebrowser.app/
        Data/Library/Application Support/ChooseBrowser/rules.json
```

**「在哪条路径找到的」在 message 里，不是脚注。** 线上已发布的直售版和商店版各写各的旧路径，「找到了，但找的是你以为已经废弃的那条」本身就是一种会让人困惑的状态 —— 上面这条真实输出命中的正好就是它。

## 四种结果分开报，因为修法不同

| 情况 | 状态 | 说什么 |
|---|---|---|
| 没有文件 | `info` | 列出**查过哪些路径** —— 「没装」和「装了但在我们不读的地方」只有路径能区分 |
| 读到了 | `pass` | 条数 + 来源路径 |
| 版本不认 | `warn` | 明说「忽略而不是猜」并建议升级 |
| 存在但解析不了 | `warn` | 明说「里面每一条规则都在被忽略」 |

永远不 `Fail` —— 没装 ChooseBrowser 是正常情况，不是故障。

版本不认时**故意不猜**：猜一个没见过的形状，正是链接开进错账号的来路。但静默地忽略它，又正是藏住这类问题的原因。所以忽略，且说出来。

## 一个刻意保留的区分

`Some(0)` 和 `None` 保持可区分 —— **空文件和读不出来是两回事**，合并它们正是这条自检要打破的那种「一模一样」。单独有测试守着。

## 来源

这条是 ChooseBrowser 那边的人在三轮联调之后提的，原话是「这条我认为是这次合作最值钱的产出，比三个 bug 本身值钱」。「还要能说出在哪条路径找到的」也是他补的 —— 正中旧路径那个坑。

1276 单测通过，clippy 干净。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only diagnostic check for ChooseBrowser rules to the doctor command.
  - Reports whether rules are missing, valid, unsupported, or malformed.
  - Displays discovered rule-file locations, the selected source, rule count, and version details when available.
  - Missing ChooseBrowser rules are reported as informational rather than failures.
- **Tests**
  - Added coverage distinguishing empty but valid rules files from malformed JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->