### PR TITLE
fix(upload): 上传后的确认步骤不再补发第二次 change (#254)

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -3640,11 +3640,15 @@ impl BrowserManager {
 
         // `DOM.setFileInputFiles` (or the relay fallback above) has already
         // delivered the files and fired input/change. Read the live input only
-        // as confirmation. React dropzones are allowed to consume the FileList
-        // and synchronously clear or replace the input; that is successful page
-        // behavior, not a rejected upload (#208).
+        // as confirmation — and only read it. This step used to dispatch a
+        // second input/change "to be safe", which is the one thing a page's
+        // upload handler cannot tolerate: React/Livewire queued the file twice,
+        // and the second entry sat at 0% forever with no delete control and
+        // the form's Save button disabled (#254). React dropzones are allowed
+        // to consume the FileList and synchronously clear or replace the input;
+        // that is successful page behavior, not a rejected upload (#208).
         match self
-            .notify_and_count_file_input(&input_object_id, &effective_session_id)
+            .count_file_input(&input_object_id, &effective_session_id)
             .await
         {
             Ok(attached) if attached > 0 => Ok(UploadOutcome {
@@ -3749,7 +3753,12 @@ impl BrowserManager {
 
     /// Read the file input's `files.length` and dispatch bubbling `input`+`change`
     /// so Vue/React register the new files. Returns the attached file count.
-    async fn notify_and_count_file_input(
+    /// How many files the input holds now. Deliberately does not dispatch
+    /// anything: both delivery paths have already fired `input`/`change`
+    /// (Chrome does it natively for `DOM.setFileInputFiles`; the relay
+    /// fallback does it itself), and a page counts every `change` as a new
+    /// upload.
+    async fn count_file_input(
         &self,
         input_object_id: &str,
         session_id: &str,
@@ -3757,12 +3766,7 @@ impl BrowserManager {
         let func = r#"function() {
             const el = this;
             if (!el || el.tagName !== 'INPUT' || el.type !== 'file') return -1;
-            const n = el.files ? el.files.length : 0;
-            if (n > 0) {
-                el.dispatchEvent(new Event('input', { bubbles: true }));
-                el.dispatchEvent(new Event('change', { bubbles: true }));
-            }
-            return n;
+            return el.files ? el.files.length : 0;
         }"#;
 
         let result: EvaluateResult = self

--- a/cli/src/native/e2e_tests.rs
+++ b/cli/src/native/e2e_tests.rs
@@ -6764,6 +6764,61 @@ async fn e2e_upload_no_input_does_not_navigate() {
     assert_success(&resp);
 }
 
+/// One upload, one `change`. The post-upload confirmation step used to fire a
+/// second input/change on top of the one delivery already produced; a page
+/// that enqueues an upload per `change` then showed two entries, the second
+/// stuck at 0% with no way to remove it and the form's submit disabled (#254).
+#[tokio::test]
+#[ignore]
+async fn e2e_upload_fires_change_exactly_once() {
+    let mut state = DaemonState::new();
+    let resp = execute_command(
+        &json!({ "id": "1", "action": "launch", "headless": true }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let html = r#"<input id="f" type="file"><script>
+      window.__changes = 0; window.__inputs = 0;
+      f.addEventListener('change', () => { window.__changes++; });
+      f.addEventListener('input', () => { window.__inputs++; });
+    </script>"#;
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(html));
+    let resp = execute_command(
+        &json!({ "id": "2", "action": "navigate", "url": url }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+
+    let tmp = std::env::temp_dir().join(format!("ab-upload-once-{}.txt", std::process::id()));
+    std::fs::write(&tmp, "once").unwrap();
+    let resp = execute_command(
+        &json!({ "id": "3", "action": "upload", "selector": "#f", "files": [tmp.to_string_lossy()] }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(get_data(&resp)["attached"], 1);
+
+    let resp = execute_command(
+        &json!({ "id": "4", "action": "evaluate", "script": "[window.__changes, window.__inputs].join(',')" }),
+        &mut state,
+    )
+    .await;
+    assert_success(&resp);
+    assert_eq!(
+        get_data(&resp)["result"].as_str().unwrap(),
+        "1,1",
+        "upload must produce exactly one change and one input event"
+    );
+
+    let _ = std::fs::remove_file(&tmp);
+    let resp = execute_command(&json!({ "id": "99", "action": "close" }), &mut state).await;
+    assert_success(&resp);
+}
+
 /// React-style dropzones often consume the FileList synchronously and clear the
 /// input. Delivery succeeded and the CLI must return success with a soft warning.
 #[tokio::test]


### PR DESCRIPTION
Closes #254.

`DOM.setFileInputFiles` 本身会触发原生 `input`/`change`，relay 回退路径（`upload_files_via_page`）也自己派发一次；然后上传后的「确认」步骤 `notify_and_count_file_input` **又派发了一次**。页面的上传处理器每收到一次 `change` 就入队一次，于是 Livewire/React 上出现两条记录，第二条永远停在 0%、没有删除入口、Save 按钮被锁成 disabled。issue 里用计数守卫量到的 `__cc === 2` 就是这两次。

那段代码上方的注释一直写着「Read the live input only as confirmation」，代码却在派发。现在函数改名 `count_file_input`，只数不发。两条投递路径各自都已经发过事件，这一步没有任何情况需要补。

## 测试

新增 e2e `e2e_upload_fires_change_exactly_once`：页面计数 `change` 和 `input`，一次 upload 后必须是 `1,1`。改动前这条会得到 `2,2`。

既有的 `e2e_upload_consumed_and_cleared_is_not_a_false_failure`（#208，dropzone 同步清空 input 的情况）不受影响——它断言的是 `attached == 0` + 软警告，与派发无关。

e2e 只在 main push / workflow_dispatch 跑；PR 上是编译检查。在 190 上手动跑了这两条 e2e，结果贴在评论里。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File uploads no longer trigger duplicate `input` and `change` events during verification.
  * Upload event behavior is now consistent across supported delivery paths.

* **Tests**
  * Added regression coverage confirming that uploading a file emits exactly one `input` event and one `change` event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->