### PR TITLE
fix(read): 客户端渲染的页面不再返回一个像「页面是空的」的空字符串 (#255)

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -437,6 +437,11 @@ fn print_response_body(resp: &Response, action: Option<&str>, opts: &OutputOptio
                     .or_else(|| data.get("url").and_then(|v| v.as_str()));
                 print_with_boundaries(content, origin, opts);
             }
+            // A thin answer that looks like an app shell: say so on stderr,
+            // where it cannot be mistaken for part of the page (#255).
+            if let Some(warning) = data.get("warning").and_then(|v| v.as_str()) {
+                eprintln!("{} {}", color::warning_indicator(), warning);
+            }
             return;
         }
 

--- a/cli/src/read.rs
+++ b/cli/src/read.rs
@@ -261,9 +261,90 @@ pub async fn run_read(raw_url: &str, options: ReadOptions) -> Result<Value, Stri
     }
 
     let (source, content) = content_from_fetch(&primary, &options)?;
+    if source == "html-fallback" {
+        if let Some(problem) = app_shell_verdict(&primary.body, &content) {
+            match problem {
+                AppShell::Nothing(why) => {
+                    return Err(format!(
+                        "read got no readable text from {} — the HTML is a JavaScript app shell ({why}) \
+                         that only renders in a browser, not an empty page. Open it instead: \
+                         `chrome-use open <url>` then `text`, `snapshot`, or `read` with no url.",
+                        primary.final_url
+                    ));
+                }
+                AppShell::Little(why) => {
+                    let mut value =
+                        read_json_from_content(&target, &primary, source, content, &options);
+                    value["warning"] = json!(format!(
+                        "only {} characters of readable text — the HTML looks like a JavaScript app shell ({why}); \
+                         the real page content may only render in a browser (`chrome-use open <url>` then `text`).",
+                        value["content"].as_str().map(|c| c.trim().chars().count()).unwrap_or(0)
+                    ));
+                    return Ok(value);
+                }
+            }
+        }
+    }
     Ok(read_json_from_content(
         &target, &primary, source, content, &options,
     ))
+}
+
+/// What a fetch of a client-rendered page looks like from the outside.
+enum AppShell {
+    /// No readable text at all — the answer would have been an empty string,
+    /// which reads as "this page is empty", not "this page needs a browser".
+    Nothing(&'static str),
+    /// A few words (a title, a `<noscript>` notice) — enough to look like an
+    /// answer, not enough to be one.
+    Little(&'static str),
+}
+
+/// Readable text under this many characters, on a page that carries an app
+/// mount point, is treated as "the shell, not the page".
+const APP_SHELL_LITTLE_TEXT: usize = 200;
+
+/// Decide whether `html` is a JavaScript application shell whose content was
+/// never in the response. `content` is the readable text already extracted.
+///
+/// `read` fetches with an HTTP client and does not run JavaScript, so a Nuxt
+/// or Next page comes back as `<div id="__nuxt"></div>` plus scripts. The
+/// extractor then returns "" — identical to what a genuinely empty page
+/// returns, and the caller cannot tell the two apart. One person concluded
+/// from that empty string (and from `curl` agreeing, which it always will)
+/// that a public product page sat behind a login wall, and wrote up advice
+/// on that basis (#255). Failing to render and having nothing to render must
+/// not produce the same answer.
+fn app_shell_verdict(html: &str, content: &str) -> Option<AppShell> {
+    let lower = html.to_ascii_lowercase();
+    if !lower.contains("<script") {
+        return None;
+    }
+    let why = if lower.contains("id=\"__nuxt\"") || lower.contains("id=\"__nuxt\"") {
+        "a Nuxt mount point"
+    } else if lower.contains("id=\"__next\"") {
+        "a Next.js mount point"
+    } else if lower.contains("id=\"___gatsby\"") {
+        "a Gatsby mount point"
+    } else if lower.contains("id=\"root\"") || lower.contains("id=\"app\"") {
+        "an empty app mount point"
+    } else if lower.contains("<noscript") {
+        "a <noscript> fallback"
+    } else {
+        // Scripts but no recognisable mount: only the empty case is confident.
+        return content
+            .trim()
+            .is_empty()
+            .then_some(AppShell::Nothing("scripts and no text"));
+    };
+    let chars = content.trim().chars().count();
+    if chars == 0 {
+        Some(AppShell::Nothing(why))
+    } else if chars < APP_SHELL_LITTLE_TEXT {
+        Some(AppShell::Little(why))
+    } else {
+        None
+    }
 }
 
 async fn run_llms_index(
@@ -1909,5 +1990,57 @@ Inline [Authentication](/inline-auth) should not become a TOC item.
         let data = run_read(&base, options).await.unwrap();
         assert_eq!(data["source"], "raw");
         assert_eq!(data["content"], "{\"ok\":true}\n");
+    }
+
+    // --- client-rendered pages (#255) --------------------------------------
+
+    /// The whole point: an app shell must not come back as an empty answer.
+    #[test]
+    fn a_nuxt_shell_with_no_text_is_a_refusal_not_an_empty_page() {
+        let html = r#"<!doctype html><html><head><title>x</title></head>
+            <body><div id="__nuxt"></div><script src="/_nuxt/entry.js"></script></body></html>"#;
+        let content = html_to_markdownish(html);
+        match app_shell_verdict(html, &content) {
+            Some(AppShell::Nothing(why)) => assert!(why.contains("Nuxt"), "{why}"),
+            other => panic!(
+                "expected Nothing, got {}",
+                match other {
+                    Some(AppShell::Little(w)) => format!("Little({w})"),
+                    _ => "None".to_string(),
+                }
+            ),
+        }
+    }
+
+    /// A title and a "please enable JavaScript" line is not the page either.
+    #[test]
+    fn a_shell_with_a_noscript_notice_is_flagged_not_trusted() {
+        let html = r#"<html><body><div id="root"></div>
+            <noscript>You need to enable JavaScript to run this app.</noscript>
+            <script src="/static/js/main.js"></script></body></html>"#;
+        let content = html_to_markdownish(html);
+        assert!(!content.trim().is_empty());
+        assert!(matches!(
+            app_shell_verdict(html, &content),
+            Some(AppShell::Little(_))
+        ));
+    }
+
+    /// Server-rendered pages carry scripts too; text is what decides.
+    #[test]
+    fn a_rendered_page_with_scripts_is_left_alone() {
+        let body = "<p>".to_string() + &"real content here. ".repeat(20) + "</p>";
+        let html = format!(
+            r#"<html><body><div id="app">{body}</div><script>init()</script></body></html>"#
+        );
+        let content = html_to_markdownish(&html);
+        assert!(app_shell_verdict(&html, &content).is_none());
+    }
+
+    /// No scripts means no rendering step was skipped: an empty page is empty.
+    #[test]
+    fn an_empty_static_page_is_just_empty() {
+        let html = "<html><body></body></html>";
+        assert!(app_shell_verdict(html, "").is_none());
     }
 }

--- a/cli/src/read.rs
+++ b/cli/src/read.rs
@@ -2015,15 +2015,23 @@ Inline [Authentication](/inline-auth) should not become a TOC item.
     /// A title and a "please enable JavaScript" line is not the page either.
     #[test]
     fn a_shell_with_a_noscript_notice_is_flagged_not_trusted() {
-        let html = r#"<html><body><div id="root"></div>
+        let html = r#"<html><body><div id="root"><h1>Loading…</h1></div>
             <noscript>You need to enable JavaScript to run this app.</noscript>
             <script src="/static/js/main.js"></script></body></html>"#;
         let content = html_to_markdownish(html);
-        assert!(!content.trim().is_empty());
+        assert!(
+            !content.trim().is_empty(),
+            "the extractor dropped the placeholder text: {content:?}"
+        );
         assert!(matches!(
             app_shell_verdict(html, &content),
             Some(AppShell::Little(_))
         ));
+        // No placeholder at all: the extractor may drop <noscript>, and then
+        // this is the empty case — still a refusal, never a pass.
+        let bare = r#"<html><body><div id="root"></div>
+            <noscript>enable JavaScript</noscript><script src="/x.js"></script></body></html>"#;
+        assert!(app_shell_verdict(bare, &html_to_markdownish(bare)).is_some());
     }
 
     /// Server-rendered pages carry scripts too; text is what decides.


### PR DESCRIPTION
Closes #255.

`read <url>` 用 HTTP 客户端抓，不执行 JS。Nuxt/Next 页面拿回来是 `<div id="__nuxt"></div>` 加脚本，提取器返回 `""` —— 和一个真正空的页面一模一样。issue 里的后果：两个「空」（`read` 和 `curl`）指向同一个错误结论，一个公开页被判成登录墙。

## 改动

html-fallback 之后多看一眼 HTML：

- **有脚本 + app 挂载点（`__nuxt` / `__next` / `root` / `app` / `___gatsby` / `<noscript>`）+ 没有可读文本** → `Err`，退出 1：
  ```
  ✗ read got no readable text from https://… — the HTML is a JavaScript app shell (a Nuxt mount point)
    that only renders in a browser, not an empty page. Open it instead: `chrome-use open <url>`
    then `text`, `snapshot`, or `read` with no url.
  ```
- **有挂载点 + 一点点文本（< 200 字，通常是标题加「请启用 JavaScript」）** → 正常返回，但带 `warning` 字段，`read` 的打印器把它打到 stderr。
- **没有脚本的空页** → 还是空页。那是真答案，不改。
- **有脚本、没有可识别挂载点、且完全没文本** → 也报错（「scripts and no text」）；有文本就不动。

取的是 issue 里的选项 2 + 3（提示 + 非零退出）。选项 1（`read` 自己等 SPA 渲染）没做：那要把 `read <url>` 从纯 HTTP 变成开标签页，行为和成本都变了，值得单独讨论；现在至少不再给出静默的错误答案。

`read`（无 url，读当前标签）不受影响——那条路径拿的是渲染后的 DOM。

## 测试

四条单测：Nuxt 壳无文本 → Nothing；`root` + noscript 提示 → Little；服务端渲染的页有脚本也有文本 → 不动；无脚本的空页 → 不动。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `read` command now detects pages that require JavaScript rendering.
  - Pages with minimal extracted content display a warning alongside the results.
  - Pages that cannot provide meaningful content now return guidance to use `chrome-use open`.

- **Bug Fixes**
  - Warnings from successful `read` operations are now displayed in text mode without interrupting the page content output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->