### PR TITLE
fix(session): stop 在原浏览器已不在时给出走得通的路径；--force 丢记录不关标签 (#256)

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -291,6 +291,22 @@ pub fn rename_session_group(session: &str, from: &str, to: &str) -> bool {
 }
 
 /// Ownership survives idle daemon exit; explicit stop must not silently ignore it.
+/// How many tabs the saved ownership record lists, regardless of endpoint —
+/// for telling the user what a stale record is about.
+pub fn created_target_count(session: &str) -> usize {
+    fs::read_to_string(get_created_targets_path(session))
+        .ok()
+        .and_then(|value| serde_json::from_str::<CreatedTargetRegistry>(&value).ok())
+        .map(|registry| registry.target_ids.len())
+        .unwrap_or(0)
+}
+
+/// Drop the saved ownership record without closing anything. The tabs stay
+/// open; only the session's claim on them is forgotten.
+pub fn forget_created_targets(session: &str) -> Result<(), String> {
+    write_created_targets(session, "", &HashSet::new())
+}
+
 pub fn has_created_targets(session: &str) -> bool {
     fs::read_to_string(get_created_targets_path(session))
         .ok()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -580,6 +580,34 @@ fn run_cookies_export(args: &[String], flags: &Flags) {
     }
 }
 
+/// What to say when the daemon is stopped but its tabs could not be closed.
+///
+/// The old text asked the user to "reconnect this session to its original
+/// browser with the original connection options" — but the daemon has just
+/// been killed, and the usual reason the tabs are unreachable is that the
+/// original browser endpoint no longer exists (a relay restart after an
+/// upgrade, a Chrome restart). Advice that cannot be followed reads as a dead
+/// end (#256). Say what is true instead: stopped; some tabs remain; here is
+/// how to either pick them back up or let go of the record.
+fn session_stop_incomplete_message(session: &str, error: &str, tabs: usize) -> String {
+    let tab_word = if tabs == 1 { "tab" } else { "tabs" };
+    format!(
+        "stopped session daemon {session}, but {tabs} {tab_word} it created could not be closed: {error}. \
+         This usually means the browser endpoint changed since those tabs were opened (an upgrade or a \
+         Chrome restart), not that anything is wrong with them — they are still open. \
+         Run `chrome-use open <url>` in this session to pick them back up, or \
+         `chrome-use session stop {session} --force` to drop the record and leave them as they are."
+    )
+}
+
+fn session_stop_forced_note(session: &str, tabs: usize) -> String {
+    let tab_word = if tabs == 1 { "tab" } else { "tabs" };
+    format!(
+        "stopped session daemon {session} and dropped its record of {tabs} {tab_word} — \
+         they were not closed and stay open in the browser; close them by hand if you no longer want them."
+    )
+}
+
 fn run_session_lifecycle(args: &[String], session: &str, json_mode: bool) {
     let subcommand = args.get(1).map(|s| s.as_str());
 
@@ -588,7 +616,13 @@ fn run_session_lifecycle(args: &[String], session: &str, json_mode: bool) {
         // sends SIGTERM first, so the daemon's shutdown handler runs `close()` and
         // tidies the tabs IT created (its tab group) before exiting.
         Some("stop") => {
-            let target = args.get(2).map(|s| s.as_str()).unwrap_or(session);
+            let force = args.iter().skip(2).any(|a| a == "--force");
+            let target = args
+                .iter()
+                .skip(2)
+                .find(|a| !a.starts_with("--"))
+                .map(|s| s.as_str())
+                .unwrap_or(session);
             if !validation::is_valid_session_name(target) {
                 let msg = validation::session_name_error(target);
                 if json_mode {
@@ -617,7 +651,31 @@ fn run_session_lifecycle(args: &[String], session: &str, json_mode: bool) {
                 Ok(())
             })();
             if let Err(error) = stopped {
-                let message = format!("session stop incomplete: {error}. Reconnect this session to its original browser with the original connection options, then run close. Saved tab ownership was retained.");
+                let tabs = connection::created_target_count(target);
+                if force {
+                    // The daemon is already gone; only the claim on its tabs
+                    // remains, and that claim cannot be exercised against a
+                    // browser we cannot reach. Forget it. Nothing is closed —
+                    // deletion rights come from the record, and we are giving
+                    // the record up, not using it.
+                    if let Err(e) = connection::forget_created_targets(target) {
+                        eprintln!(
+                            "{} could not drop the ownership record: {e}",
+                            color::error_indicator()
+                        );
+                        exit(1);
+                    }
+                    let note = session_stop_forced_note(target, tabs);
+                    if json_mode {
+                        print_json_value(
+                            json!({ "success": true, "data": { "stopped": target, "forgottenTabs": tabs } }),
+                        );
+                    } else {
+                        println!("{} {note}", color::success_indicator());
+                    }
+                    return;
+                }
+                let message = session_stop_incomplete_message(target, &error, tabs);
                 if json_mode {
                     print_json_error(&message);
                 } else {
@@ -3208,5 +3266,28 @@ mod tests {
         let mut cli_true_cmd = json!({ "action": "launch" });
         apply_hide_scrollbars_launch_option(&mut cli_true_cmd, true, true);
         assert_eq!(cli_true_cmd["hideScrollbars"], true);
+    }
+
+    // --- session stop wording (#256) ------------------------------------------
+
+    /// The advice must be followable after the daemon is already gone.
+    #[test]
+    fn stop_incomplete_message_does_not_ask_for_a_browser_that_no_longer_exists() {
+        let m = session_stop_incomplete_message("cu-x", "the connected browser does not match", 3);
+        assert!(m.starts_with("stopped session daemon cu-x"), "{m}");
+        assert!(m.contains("3 tabs"), "{m}");
+        assert!(m.contains("still open"), "{m}");
+        assert!(m.contains("--force"), "{m}");
+        assert!(
+            !m.contains("Reconnect this session to its original browser"),
+            "{m}"
+        );
+    }
+
+    #[test]
+    fn forced_stop_says_nothing_was_closed() {
+        let m = session_stop_forced_note("cu-x", 1);
+        assert!(m.contains("1 tab —"), "{m}");
+        assert!(m.contains("not closed"), "{m}");
     }
 }

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -630,7 +630,12 @@ pub fn to_ai_friendly_error(error: &str) -> String {
         if lower.contains("debugger_access_denied:") {
             return error.to_string();
         }
-        return format!("debugger_access_denied: Chrome blocked debugger access to protected extension content in this tab, which can be a child frame. Reattaching does not resolve this restriction. Use `tab inspect` for browser metadata or a separate test profile. Original error: {error}");
+        // The same words come back when the tab was opened by ANOTHER
+        // chrome-use session daemon (its extension context, not ours). That
+        // reads like a permissions problem and sends people debugging the
+        // wrong thing for a long time (#256); the fix is to stop the other
+        // daemon.
+        return format!("debugger_access_denied: Chrome blocked debugger access to protected extension content in this tab, which can be a child frame. Reattaching does not resolve this restriction. If this session did not open the tab, another chrome-use session daemon may hold it: run `chrome-use sessions`, then `chrome-use session stop <that session>`. Otherwise use `tab inspect` for browser metadata or a separate test profile. Original error: {error}");
     }
     // Top-level `await` in `eval` fails with a bare "await is not defined" /
     // "await is only valid in async" — unhelpful. Point at the wrapper (issue #65).

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -4601,6 +4601,8 @@ Sessions:
   session resume             Return control to the agent
   session stop [name]        Stop one session daemon (default: current) — graceful,
                              closes the tabs it created
+    --force                  If those tabs can no longer be reached (endpoint changed after
+                             an upgrade/restart), drop the record and leave them open
   session prune              Stop ALL session daemons now (closes their tabs; they
                              respawn clean on next use). For clearing idle daemons.
   sessions                   List running session daemons (alias of daemon status)


### PR DESCRIPTION
Addresses #256 第 2、3 条。第 1 条（升级后 `open` 退化成自启浏览器）没动——没复现，不猜。

## 第 2 条：`session stop` 卡死

升级或 Chrome 重启之后 relay 的 endpoint 变了，旧会话的标签归属记录（按 endpoint 哈希存）就对不上。`session stop` 的顺序是**先杀 daemon，再清标签**，清不掉就报：

> Reconnect this session to its original browser with the original connection options, then run close.

daemon 已经没了，原浏览器也没了，这条建议走不通。

现在：

```
✗ stopped session daemon cu-x, but 3 tabs it created could not be closed: <原因>.
  This usually means the browser endpoint changed since those tabs were opened (an upgrade or a
  Chrome restart), not that anything is wrong with them — they are still open.
  Run `chrome-use open <url>` in this session to pick them back up, or
  `chrome-use session stop cu-x --force` to drop the record and leave them as they are.
```

`--force`：删记录、**不关任何标签**，并明说：

```
✓ stopped session daemon cu-x and dropped its record of 3 tabs — they were not closed and stay
  open in the browser; close them by hand if you no longer want them.
```

删除权只能来自持久化的归属记录；`--force` 是放弃记录，不是绕过它去关标签。

## 第 3 条：`Cannot access a chrome-extension:// URL of different extension`

这句在标签是**别的 chrome-use 会话**开的时候也会出现——它的扩展上下文不是我们的。读起来像权限问题，issue 里为此排错了十几分钟方向全错，真正的解法是停掉另一个 daemon。提示里加了一句：

> If this session did not open the tab, another chrome-use session daemon may hold it: run `chrome-use sessions`, then `chrome-use session stop <that session>`.

## 测试

两条单测锁措辞：新提示不再出现「Reconnect this session to its original browser」、含标签数和 `--force`；`--force` 的输出含「not closed」。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf