### PR TITLE
fix: socket 路径超限说清字节花在哪、doctor 名字缩短 (#259)；flags 单测不再读真实环境 (#260)

### DIFF
--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -230,6 +230,41 @@ pub fn get_socket_dir() -> PathBuf {
     env::temp_dir().join(config_dir_basename(false))
 }
 
+/// Reject a socket path that cannot fit in `sun_path` before anything is
+/// created, and say how the 103 bytes were spent.
+#[cfg(unix)]
+fn ensure_socket_path_fits(session: &str) -> Result<(), String> {
+    socket_path_length_error(&get_socket_dir(), session).map_or(Ok(()), Err)
+}
+
+/// `Some(message)` when `dir/<session>.sock` exceeds the 103-byte `sun_path`
+/// limit. Takes the directory so it can be tested without touching the
+/// environment (the env is process-global and parallel tests share it).
+///
+/// Blaming the session name is wrong whenever the directory is what used up
+/// the budget — and it often is, since the name may be one we generated
+/// (`doctor` does, and a deep HOME then makes its check fail with advice the
+/// user cannot act on, issue #259). Say how the bytes were spent so the reader
+/// can see which half to change.
+#[cfg(unix)]
+fn socket_path_length_error(dir: &std::path::Path, session: &str) -> Option<String> {
+    let path_len = dir.join(format!("{session}.sock")).as_os_str().len();
+    if path_len <= 103 {
+        return None;
+    }
+    let dir_len = dir.as_os_str().len();
+    let budget = 103usize.saturating_sub(dir_len + 1 + ".sock".len());
+    Some(format!(
+        "Socket path is {path_len} bytes; the unix limit is 103.\n\
+         The directory {} takes {dir_len} of them, leaving {budget} for a session name, \
+         and '{session}' is {}.\n\
+         Point AGENT_BROWSER_SOCKET_DIR at a shorter directory \
+         (e.g. AGENT_BROWSER_SOCKET_DIR=/tmp/cu), or use a shorter --session name.",
+        dir.display(),
+        session.len(),
+    ))
+}
+
 #[cfg(unix)]
 fn get_socket_path(session: &str) -> PathBuf {
     get_socket_dir().join(format!("{}.sock", session))
@@ -977,17 +1012,7 @@ pub(crate) fn ensure_daemon_with_lifecycle_lock(
 
     // Pre-flight check: Validate socket path length (Unix limit is 104 bytes including null terminator)
     #[cfg(unix)]
-    {
-        let socket_path = get_socket_path(session);
-        let path_len = socket_path.as_os_str().len();
-        if path_len > 103 {
-            return Err(format!(
-                "Session name '{}' is too long. Socket path would be {} bytes (max 103).\n\
-                 Use a shorter session name or set AGENT_BROWSER_SOCKET_DIR to a shorter path.",
-                session, path_len
-            ));
-        }
-    }
+    ensure_socket_path_fits(session)?;
 
     // Pre-flight check: Verify socket directory is writable
     {
@@ -1881,5 +1906,29 @@ mod tests {
         assert!(!is_session_unresponsive_error(
             "Failed to read: connection reset by peer"
         ));
+    }
+
+    /// The 103-byte cap is usually spent by the directory, not by a name the
+    /// user chose — `doctor` generates its own. The message has to show both
+    /// halves, or it sends people to rename something that is not the problem.
+    #[cfg(unix)]
+    #[test]
+    fn a_too_long_socket_path_reports_where_the_bytes_went() {
+        let dir = PathBuf::from(format!("/{}", "d".repeat(120)));
+        let err = socket_path_length_error(&dir, "s").expect("120-byte dir cannot fit");
+        assert!(err.contains("the unix limit is 103"), "{err}");
+        assert!(
+            err.contains(&dir.display().to_string()),
+            "must name the dir: {err}"
+        );
+        assert!(err.contains("AGENT_BROWSER_SOCKET_DIR"), "{err}");
+
+        // A short directory leaves room; nothing to report.
+        assert_eq!(
+            socket_path_length_error(&PathBuf::from("/tmp/cu"), "s"),
+            None
+        );
+        // …and the name can still be what overflows it.
+        assert!(socket_path_length_error(&PathBuf::from("/tmp/cu"), &"x".repeat(120)).is_some());
     }
 }

--- a/cli/src/doctor/launch.rs
+++ b/cli/src/doctor/launch.rs
@@ -35,13 +35,20 @@ pub(super) fn check(checks: &mut Vec<Check>) {
         return;
     }
 
+    // Short on purpose. A unix socket path is capped at 103 bytes, and the
+    // whole config directory sits in front of the session name — under a deep
+    // HOME (a sandbox, a CI workspace, a container mount) a long name is what
+    // pushes it over, and the failure blames a name the user never chose
+    // (issue #259). Base-36 pid and millis keep it unique and readable while
+    // costing ~14 bytes instead of ~28.
+    let millis = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
     let session = format!(
         "doctor-{}-{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_millis())
-            .unwrap_or(0)
+        to_base36(std::process::id() as u128),
+        to_base36(millis)
     );
 
     // Armed after `ensure_daemon` succeeds so we don't send a stray `close`
@@ -185,4 +192,19 @@ impl Drop for LaunchGuard {
         let _ = send_command(close_cmd, &self.session);
         cleanup_stale_files(&self.session);
     }
+}
+
+/// Lowercase base-36, for keeping generated session names short.
+fn to_base36(mut n: u128) -> String {
+    const DIGITS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    if n == 0 {
+        return "0".to_string();
+    }
+    let mut out = Vec::new();
+    while n > 0 {
+        out.push(DIGITS[(n % 36) as usize]);
+        n /= 36;
+    }
+    out.reverse();
+    String::from_utf8(out).unwrap_or_default()
 }

--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -1531,10 +1531,17 @@ mod tests {
         assert_eq!(flags.executable_path, Some("/path/to/chromium".to_string()));
     }
 
+    /// A trailing `--executable-path` with nothing after it must not invent a
+    /// value — but it also must not be asserted against `None`, because
+    /// `AGENT_BROWSER_EXECUTABLE_PATH` legitimately supplies a default and the
+    /// test then fails on any machine that exports it (issue #260). Compare
+    /// against the no-argument parse instead: that is the property the flag is
+    /// actually responsible for, and it holds whatever the environment says.
     #[test]
     fn test_parse_executable_path_flag_no_value() {
+        let baseline = parse_flags(&args(""));
         let flags = parse_flags(&args("--executable-path"));
-        assert_eq!(flags.executable_path, None);
+        assert_eq!(flags.executable_path, baseline.executable_path);
     }
 
     #[test]


### PR DESCRIPTION
Closes #259, closes #260.

## #259

`doctor` 的会话名是我们生成的（`doctor-<pid>-<毫秒>`，约 28 字节），HOME 路径深时 socket 路径超 103 就失败，而提示说的是「**Session name** is too long」——用户按提示去改一个他没起过的名字，改不动。深 HOME 不只是临时目录：sandbox、CI workspace、容器挂载点都会踩到。

两处改：

- `doctor` 的名字改用 base36，`doctor-<pid36>-<ms36>` 约 14 字节，省回一半预算。
- 错误信息说清账：

```
Socket path is 161 bytes; the unix limit is 103.
The directory /very/deep/… takes 132 of them, leaving 0 for a session name, and 'doctor-…' is 28.
Point AGENT_BROWSER_SOCKET_DIR at a shorter directory (e.g. AGENT_BROWSER_SOCKET_DIR=/tmp/cu),
or use a shorter --session name.
```

检查逻辑抽成 `socket_path_length_error(dir, session)`，**目录作参数传入**——环境变量是进程全局的，并行测试共享，测试里改它会互相踩（这正是 #260 的教训）。

没有做自动回退到短目录：socket 目录必须在多次调用间稳定，条件回退会让两次调用挑不同目录、互相找不到会话。

## #260

`test_parse_executable_path_flag_no_value` 断言 `None`，而 `AGENT_BROWSER_EXECUTABLE_PATH` 是合法的默认来源——谁的 shell 里有这个变量，谁跑 `cargo test` 就挂。改成和「不传任何参数」的解析结果比较：那才是这个 flag 真正负责的性质，且与环境无关。

## 验证

在一台**设了** `AGENT_BROWSER_EXECUTABLE_PATH` 的机器上跑（改动前那台必挂）：

```
test result: ok. 1306 passed; 0 failed; 3 ignored
```

新增一条单测锁 #259 的措辞：120 字节的目录 → 报错必须含「the unix limit is 103」、目录路径本身、`AGENT_BROWSER_SOCKET_DIR`；短目录 + 短名字不报错；短目录 + 120 字节名字仍报错。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for Unix socket paths to account for both directory and session-name length limits.
  - Added clearer error messages explaining how the available path length is exceeded, helping users resolve configuration issues.
  - Shortened automatically generated launch-test session names to improve compatibility with the operating system’s socket path limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->