### PR TITLE
fix(do): 判不出成败的动作不再返回一个不带保留的成功 (#230)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -4074,6 +4074,36 @@ pub(crate) fn action_stalled(
     }
 }
 
+/// Whether the accessibility state can decide, after the fact, that this action
+/// did what it was asked to do.
+///
+/// Only expand/collapse can: afterwards the element must offer the opposite
+/// action. For everything else the state after a success and the state after a
+/// no-op are the same, so `action_stalled` returning `false` means "cannot
+/// tell", not "it worked" — and a plain ✓ would turn the first into the second.
+/// `showMenu` is the case that motivated saying so: a menu drawn outside the
+/// page, or a component that opens on `mousedown` and closes again on `click`,
+/// leaves no trace in the tree either way (issue #230).
+pub(crate) fn action_outcome_is_decidable(chosen: super::snapshot::SecondaryAction) -> bool {
+    use super::snapshot::SecondaryAction as A;
+    matches!(chosen, A::Expand | A::Collapse)
+}
+
+/// What to tell the caller when the outcome cannot be decided from the tree.
+pub(crate) fn unconfirmable_action_note(
+    chosen: super::snapshot::SecondaryAction,
+    role: &str,
+    name: &str,
+) -> String {
+    format!(
+        "`{}` was dispatched to [{role} \"{name}\"], but the accessibility state cannot \
+         confirm the result: it looks the same whether the control responded or ignored the \
+         click. Read the page (`snapshot -i`, or the action with `--observe`) before treating \
+         this as done.",
+        chosen.as_str()
+    )
+}
+
 /// `do <@ref> <action>` — perform one of the actions the element actually
 /// exposes.
 ///
@@ -4165,6 +4195,9 @@ async fn handle_do_action(cmd: &Value, state: &mut DaemonState) -> Result<Value,
     // opposite action. When it still offers the same one, the control did not
     // move, and a bare ✓ would be exactly the silent success this command
     // exists to avoid.
+    // Three outcomes, not two: it moved, it did not move, or the tree cannot
+    // say. The third used to render as the first (#230).
+    let decidable = action_outcome_is_decidable(chosen);
     let mut warning = None;
     if let Some(ref now) = after_actions {
         if action_stalled(chosen, now) {
@@ -4179,17 +4212,28 @@ async fn handle_do_action(cmd: &Value, state: &mut DaemonState) -> Result<Value,
         }
     }
 
+    // `confirmed` is the field to branch on, and it is deliberately tri-state:
+    // true (the tree shows it moved), false (the tree shows it did not), null
+    // (the tree cannot say for this action). Callers that treat null as true
+    // are back to the silent success this command exists to avoid.
+    let confirmed = match (&after_actions, decidable) {
+        (Some(_), true) => Some(!warning.is_some()),
+        _ => None,
+    };
     let mut out = json!({
         "ref": selector,
         "role": role,
         "name": name,
         "performed": chosen.as_str(),
+        "confirmed": confirmed,
         "actionsNow": after_actions
             .as_ref()
             .map(|a| a.iter().map(|x| x.as_str()).collect::<Vec<_>>()),
     });
     if let Some(w) = warning {
         out["warning"] = json!(w);
+    } else if confirmed.is_none() {
+        out["note"] = json!(unconfirmable_action_note(chosen, &role, &name));
     }
     Ok(out)
 }
@@ -15922,6 +15966,38 @@ mod tests {
         assert!(!action_stalled(A::Expand, &[A::Collapse, A::ShowMenu]));
         assert!(action_stalled(A::Collapse, &[A::Collapse]));
         assert!(!action_stalled(A::Collapse, &[A::Expand]));
+    }
+
+    /// Only expand/collapse can be judged from the tree. For the rest,
+    /// `action_stalled` returning false means "cannot tell" — reporting that as
+    /// success is the shape this whole command exists to avoid (#230).
+    #[test]
+    fn only_expand_and_collapse_have_a_decidable_outcome() {
+        use super::super::snapshot::SecondaryAction as A;
+        assert!(action_outcome_is_decidable(A::Expand));
+        assert!(action_outcome_is_decidable(A::Collapse));
+        for a in [A::ShowMenu, A::Toggle, A::Increment, A::Decrement] {
+            assert!(!action_outcome_is_decidable(a), "{a:?} is not decidable");
+            assert!(!action_stalled(a, &[a]), "{a:?}");
+        }
+    }
+
+    /// The note has to say what was done and what to do next; "unknown" on its
+    /// own would just move the guessing to the caller.
+    #[test]
+    fn the_unconfirmable_note_names_the_action_and_a_way_to_check() {
+        let n = unconfirmable_action_note(
+            super::super::snapshot::SecondaryAction::ShowMenu,
+            "button",
+            "More",
+        );
+        assert!(n.contains("showMenu"), "{n}");
+        assert!(n.contains("button \"More\""), "{n}");
+        assert!(
+            n.contains("cannot \\\n         confirm") || n.contains("cannot confirm"),
+            "{n}"
+        );
+        assert!(n.contains("snapshot -i"), "{n}");
     }
 
     /// Increment/decrement leave the action set unchanged even when they work

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -708,11 +708,11 @@ fn print_response_body(resp: &Response, action: Option<&str>, opts: &OutputOptio
             let stalled = data.get("warning").and_then(|v| v.as_str());
             let unconfirmable = data.get("note").and_then(|v| v.as_str());
             let mark = if stalled.is_some() {
-                color::warning_indicator()
+                color::warning_indicator().to_string()
             } else if unconfirmable.is_some() {
                 color::dim("·")
             } else {
-                color::success_indicator()
+                color::success_indicator().to_string()
             };
             println!("{} {} on {}", mark, done, r);
             if let Some(now) = data.get("actionsNow").and_then(|v| v.as_array()) {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -702,10 +702,15 @@ fn print_response_body(resp: &Response, action: Option<&str>, opts: &OutputOptio
         }
         if let Some(done) = data.get("performed").and_then(|v| v.as_str()) {
             let r = data.get("ref").and_then(|v| v.as_str()).unwrap_or("");
-            // A stalled expand/collapse must not wear a plain ✓.
+            // Three marks for three outcomes: ✓ confirmed, ⚠ confirmed-stalled,
+            // and · dispatched-but-unconfirmable. A plain ✓ on the third would
+            // say the menu opened when nothing here knows that (#230).
             let stalled = data.get("warning").and_then(|v| v.as_str());
+            let unconfirmable = data.get("note").and_then(|v| v.as_str());
             let mark = if stalled.is_some() {
                 color::warning_indicator()
+            } else if unconfirmable.is_some() {
+                color::dim("·")
             } else {
                 color::success_indicator()
             };
@@ -726,6 +731,8 @@ fn print_response_body(resp: &Response, action: Option<&str>, opts: &OutputOptio
             }
             if let Some(w) = stalled {
                 eprintln!("{} {}", color::warning_indicator(), w);
+            } else if let Some(n) = unconfirmable {
+                eprintln!("{} {}", color::dim("·"), n);
             }
             return;
         }

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -148,6 +148,13 @@
         <span class="mark">没动的控件不会读起来像成功</span>。详见
         <a href="interacting.html">交互</a>。
       </p>
+      <p>
+        不过<span class="mark">只有 <code>expand</code> / <code>collapse</code> 事后判得出成败</span>——
+        做完元素必须提供相反的那个动作。<code>showMenu</code>、<code>toggle</code>、
+        <code>increment</code> / <code>decrement</code> 无论控件响应与否，树里看起来都一样，
+        所以它们标 <code>·</code> 而不是 <code>✓</code>，JSON 里 <code>confirmed</code> 为
+        <code>null</code>：已派发，结果未知。别把 <code>null</code> 当成功，自己读一眼页面。
+      </p>
 
       <div class="du-callout tip">
         <div class="du-callout-title">✅ 小贴士</div>

--- a/docs/en/commands.html
+++ b/docs/en/commands.html
@@ -155,6 +155,15 @@
         <span class="mark">a control that did not move cannot read as a success</span>. See
         <a href="interacting.html">Interacting</a>.
       </p>
+      <p>
+        But <span class="mark">only <code>expand</code> / <code>collapse</code> can be confirmed
+        afterwards</span> — the element must then offer the opposite action. For
+        <code>showMenu</code>, <code>toggle</code>, <code>increment</code> and
+        <code>decrement</code> the tree looks the same whether the control responded or ignored
+        the click, so those are marked <code>·</code> rather than <code>✓</code> and carry
+        <code>confirmed: null</code> in JSON — dispatched, outcome unknown. Read the page before
+        treating one as done; never read <code>null</code> as success.
+      </p>
 
       <div class="du-callout tip">
         <div class="du-callout-title">✅ Tip</div>

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -90,6 +90,13 @@ value range, `toggle` for a pressable control. `do` refuses anything outside tha
 set rather than doing something adjacent, and reports the set again afterwards so a
 control that refused to move does not read as success.
 
+**Only `expand`/`collapse` can be confirmed afterwards**, because the element must
+then offer the opposite action. For `showMenu`, `toggle`, `increment` and
+`decrement` the tree looks the same whether the control responded or ignored the
+click, so `do` marks those `·` instead of `✓` and sets `confirmed: null` in JSON
+— dispatched, outcome unknown. Read the page before treating one as done. Do not
+read `confirmed: null` as success.
+
 ## Interactions (use @refs from snapshot)
 
 ```bash


### PR DESCRIPTION
Closes #230 的可做部分。

## 问题

`do @ref showMenu` 和 `expand`/`collapse` 一样打 ✓。但 `action_stalled` 只对 expand/collapse 有判据（做完必须提供相反的动作），对 `showMenu` / `toggle` / `increment` / `decrement` **恒返回 false** —— 那是「判不出来」，不是「成功了」，而 ✓ 把前者说成了后者。

菜单画在页面之外、或者组件在 `mousedown` 上开、`click` 上又关，两种情况树里都没有痕迹。issue 里那句「click 派发成功、页面确实响应了、结果却是没打开」就是这个。

## 改法：三态

| | 标记 | JSON |
|---|---|---|
| 树显示它动了 | `✓` | `confirmed: true` |
| 树显示它没动 | `⚠` + warning（原有） | `confirmed: false` |
| 树说不了 | `·` + note | `confirmed: null` |

note 说明派发了什么、为什么判不出、怎么自己确认（`snapshot -i` 或带 `--observe`）。文档里明写**不要把 `null` 当成功**。

## 没做重试

issue 自己写了「先攒真实案例再动手，不要凭想象加重试逻辑」，理由也给了：一个真靠 `mousedown` 打开的菜单，click 开了又关，再补 `ArrowDown` 会在**已关闭**的菜单上做别的事 —— 而这恰恰是判不出开合的场景。所以这个 PR 只修「不谎报」，重试留给真实案例。

## 测试

- `only_expand_and_collapse_have_a_decidable_outcome`：四个不可判定动作逐个断言
- `the_unconfirmable_note_names_the_action_and_a_way_to_check`：note 必须含动作名、元素、以及一条可执行的检查方式

skill 和文档站中英三处同步。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Action results now indicate whether secondary actions were confirmed, stalled, or dispatched with an unknown outcome.
  - Unknown outcomes are clearly marked and include an explanatory note, helping distinguish them from successful actions.
  - JSON responses now include a `confirmed` field with `true`, `false`, or `null`.

- **Documentation**
  - Updated command references to explain confirmation behavior for accessibility actions and when a follow-up page read is needed.
  - Clarified that only expand and collapse actions can be verified after execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->