### PR TITLE
fix(relay): 访问被拒时说出我们钉在哪个标签、它的 URL (#217)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1953,6 +1953,19 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                     msg.push_str(&note);
                 }
             }
+            // Say which page the failure was about. Without it a blocked
+            // debugger access is indistinguishable from a permissions problem
+            // and the reader has nothing to check (#217).
+            if super::browser::is_debugger_access_denied(&e) {
+                if let Some(note) = state
+                    .browser
+                    .as_ref()
+                    .and_then(|mgr| mgr.pinned_tab_summary())
+                    .map(|(tab, url)| pinned_tab_note(&tab, &url))
+                {
+                    msg.push_str(&note);
+                }
+            }
             error_response(&id, &msg)
         }
     };
@@ -14166,6 +14179,27 @@ fn success_response(id: &str, data: Value) -> Value {
     })
 }
 
+/// Append the pinned tab and its url to a blocked-access error.
+///
+/// Two readings, and the url decides which: an extension page is the cause
+/// itself; the page the caller expected means the pin did not move and the
+/// problem is elsewhere — which is the fact missing from every report of this
+/// so far (#217).
+fn pinned_tab_note(tab: &str, url: &str) -> String {
+    let diagnosis = if url.starts_with("chrome-extension://") {
+        " — that is an extension page, which Chrome will not let this extension drive. \
+         The tab navigated there; re-open your target url in it."
+    } else if url.starts_with("chrome://") || url.starts_with("devtools://") {
+        " — that is an internal Chrome page, which no extension can drive. \
+         Re-open your target url in it."
+    } else {
+        " — the pin did not move, so this is not the session driving somebody else's tab. \
+         A child frame on the page (an embedded extension widget) is the likely target of \
+         the block; `tab inspect` still reads browser-level metadata."
+    };
+    format!("\nThis session is driving {tab} ({url}){diagnosis}")
+}
+
 fn error_response(id: &str, error: &str) -> Value {
     let mut response = json!({
         "id": id,
@@ -15922,6 +15956,25 @@ mod tests {
         assert!(!action_stalled(A::Expand, &[A::Collapse, A::ShowMenu]));
         assert!(action_stalled(A::Collapse, &[A::Collapse]));
         assert!(!action_stalled(A::Collapse, &[A::Expand]));
+    }
+
+    /// The url is what turns "permissions bug?" into an answer, so each shape
+    /// has to say something different (#217).
+    #[test]
+    fn the_pinned_tab_note_reads_the_url_rather_than_repeating_the_error() {
+        let ext = pinned_tab_note("t1", "chrome-extension://abc/options.html");
+        assert!(ext.contains("t1"), "{ext}");
+        assert!(ext.contains("extension page"), "{ext}");
+
+        let internal = pinned_tab_note("t1", "chrome://settings");
+        assert!(internal.contains("internal Chrome page"), "{internal}");
+
+        // The case the reports keep hitting: the pin is exactly where it was
+        // asked to be, which rules out the usual hypothesis instead of
+        // repeating it.
+        let normal = pinned_tab_note("t1", "https://app.example.com/form");
+        assert!(normal.contains("the pin did not move"), "{normal}");
+        assert!(normal.contains("https://app.example.com/form"), "{normal}");
     }
 
     /// Increment/decrement leave the action set unchanged even when they work

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -555,7 +555,7 @@ pub(crate) fn is_stale_target_error(error: &str) -> bool {
 }
 
 /// A Chrome access decision is not a lost tab and cannot be fixed by reattachment.
-fn is_debugger_access_denied(error: &str) -> bool {
+pub(crate) fn is_debugger_access_denied(error: &str) -> bool {
     let lower = error.to_ascii_lowercase();
     lower.contains("debugger_access_denied:")
         || (lower.contains("cannot access a chrome-extension://")
@@ -2507,6 +2507,20 @@ impl BrowserManager {
             removed_index,
             self.pages.len(),
         );
+    }
+
+    /// The tab this session is pinned to, as `(handle, url)` — for saying which
+    /// page a failure was actually about.
+    ///
+    /// A `debugger_access_denied` reads as a permissions bug and gives the
+    /// reader nothing to check (issue #217). Naming the pinned tab and its url
+    /// settles it either way: a `chrome-extension://` url IS the cause, and the
+    /// expected page rules out "the relay followed the user's active tab" and
+    /// sends the next report somewhere useful.
+    pub fn pinned_tab_summary(&self) -> Option<(String, String)> {
+        let pinned = self.active_target_id.as_deref()?;
+        let page = self.pages.iter().find(|p| p.target_id == pinned)?;
+        Some((format_tab_id(page.tab_id), page.url.clone()))
     }
 
     pub fn tab_list(&self) -> Vec<Value> {


### PR DESCRIPTION
Addresses #217 里可以在不猜机制的前提下做的部分。

## 先说我没做什么

issue 写的原因是「**relay 跟着用户的活动标签跑**，而不是待在被要求驱动的那个标签上」。这是报告者的推断，不是观察到的 —— 观察到的只有：三条命令报 `Cannot access a chrome-extension:// URL of different extension`，而 `tabs` 照常显示目标标签为当前。

而代码里那条会挑到别的标签的兜底（`anyConnectedTab()`）**早就只对不带 sessionId/targetId 的浏览器级命令生效**了（#8.1 修的）。报告里那三条命令都带 sessionId，走不到那条路。所以这个机制不成立，我不照着它改行为。

## 做了什么：让下一次能查清

报错追加一行，说明这个会话钉在哪个标签、URL 是什么，并按 URL 给出不同结论：

- `chrome-extension://…` → **这就是原因**：标签自己导航到了扩展页，Chrome 不允许本扩展驱动它，重新打开目标 URL
- `chrome://` / `devtools://` → 内部页，任何扩展都驱动不了
- 正常页面 → **钉子没动，所以不是「驱动了别人的标签」**；更可能是页内某个子框架（嵌入的扩展小组件）被拒，`tab inspect` 仍能读浏览器级元数据

第三条是重点：它**证伪当前这个猜测**，把下一份报告指向别处，而不是重复它。issue 里 ask #2（错误要说清是哪个标签，而不是抛出 Chrome 原文）就是这条。

ask #1（`tab select` 固定目标）已经存在 —— `active_target_id` 是钉住的，`resolve_active_index` 优先它（#14）。ask #3（`tabs` 显示 relay 实际附着的标签）需要扩展侧新增一个上报，涉及商店审核周期，留在 issue 里。

## 测试

`the_pinned_tab_note_reads_the_url_rather_than_repeating_the_error`：三种 URL 形状各自给出不同结论，尤其正常 URL 必须出现「the pin did not move」。

纯 CLI，不改扩展。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf