### PR TITLE
fix(connect): 先连上新 endpoint 再放弃旧的，连不上就保住原绑定 (#258)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2928,6 +2928,40 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
         true
     };
 
+    // An explicit endpoint (`--browser`, `connect <port|url>`, `--cdp`) replaces
+    // a connection we already hold. Establish the replacement BEFORE giving up
+    // the old one: closing first meant a typo'd profile name left the session
+    // bound to nothing, showing `about:blank`, while later commands still
+    // returned success — the caller had lost their page and was not told
+    // (issue #258).
+    let mut replacement: Option<BrowserManager> = None;
+    if needs_relaunch && state.browser.is_some() {
+        if let Some(endpoint) = cdp_url
+            .map(str::to_string)
+            .or_else(|| cdp_port.map(|p| p.to_string()))
+        {
+            super::browser::validate_launch_options(
+                launch_options.extensions.as_deref(),
+                true,
+                launch_options.profile.as_deref(),
+                storage_state,
+                launch_options.allow_file_access,
+                launch_options.executable_path.as_deref(),
+            )?;
+            match BrowserManager::connect_cdp(&endpoint).await {
+                Ok(mgr) => replacement = Some(mgr),
+                // The old connection is untouched, so say so: without this the
+                // caller cannot tell whether their session survived.
+                Err(e) => {
+                    return Err(format!(
+                        "could not connect to {endpoint}: {e}. This session is still driving \
+                         the browser it was already connected to — nothing was closed."
+                    ))
+                }
+            }
+        }
+    }
+
     if needs_relaunch {
         if let Some(ref mut b) = state.browser {
             b.close().await?;
@@ -2955,7 +2989,10 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if let Some(url) = cdp_url {
         state.reset_input_state();
-        state.browser = Some(BrowserManager::connect_cdp(url).await?);
+        state.browser = Some(match replacement.take() {
+            Some(mgr) => mgr,
+            None => BrowserManager::connect_cdp(url).await?,
+        });
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();
@@ -2967,7 +3004,10 @@ async fn handle_launch(cmd: &Value, state: &mut DaemonState) -> Result<Value, St
 
     if let Some(port) = cdp_port {
         state.reset_input_state();
-        state.browser = Some(BrowserManager::connect_cdp(&port.to_string()).await?);
+        state.browser = Some(match replacement.take() {
+            Some(mgr) => mgr,
+            None => BrowserManager::connect_cdp(&port.to_string()).await?,
+        });
         state.subscribe_to_browser_events();
         state.start_fetch_handler();
         state.start_dialog_handler();


### PR DESCRIPTION
Closes #258.

`handle_launch` 里 `needs_relaunch` 一为真就 `close()` 旧连接，然后才去连新的。于是一次打错的 `--browser` / `--cdp` 会让会话从「绑在 A 上」变成绑在不知道什么上、显示 `about:blank`，而后续不带 `--browser` 的命令照常 `success:true` —— 用户丢了页面，且没有被告知。

改成显式 endpoint（`--browser` / `connect <port|url>` / `--cdp`）先建立替代连接，成功了才关旧的；失败就带着原绑定返回错误并明说什么都没关：

```
✗ could not connect to ws://…: <原因>. This session is still driving the browser it
  was already connected to — nothing was closed.
```

只覆盖显式 endpoint 这条路径。真正的 relaunch（换了 launch 参数、进程已退出）本来就没有「旧的还能用」这回事，维持原样。

190 上 1306 通过。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf