### PR TITLE
fix(frame): 接受 frames 打印的那个序号，并把跨域浮层的排查路径写进文档 (#218)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -10495,6 +10495,39 @@ async fn handle_frame(cmd: &Value, state: &mut DaemonState) -> Result<Value, Str
         }
     }
 
+    // A bare index, because that is what `frames` prints (`[0] top …`) and what
+    // the frame-boundary error tells the reader to pass. It used to fall
+    // through to CSS resolution and come back as a raw
+    // `SyntaxError: '0' is not a valid selector` — a documented recovery path
+    // that did not work when followed literally (issue #218).
+    if let Some(index) = cmd
+        .get("selector")
+        .and_then(|v| v.as_str())
+        .and_then(|sel| sel.trim().parse::<usize>().ok())
+    {
+        let frames = {
+            let mgr = state.browser.as_ref().ok_or("Browser not launched")?;
+            let session_id = mgr.active_session_id()?.to_string();
+            super::element::collect_all_frames_text(
+                &mgr.client,
+                &session_id,
+                &state.iframe_sessions,
+            )
+            .await?
+        };
+        let frame = frames.get(index).ok_or_else(|| {
+            format!(
+                "frame {index}: this page has {} frame(s), numbered 0..{}. Run `frames` for the list.",
+                frames.len(),
+                frames.len().saturating_sub(1)
+            )
+        })?;
+        // Index 0 is the top document — switching "into" it means leaving any
+        // frame, which is the useful reading of `frame 0`.
+        state.active_frame_id = (index != 0).then(|| frame.frame_id.clone());
+        return Ok(json!({ "frame": frame.frame_id, "index": index, "url": frame.url }));
+    }
+
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
     let session_id = mgr.active_session_id()?.to_string();
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3382,19 +3382,30 @@ Examples:
             r##"
 chrome-use frame - Switch frame context
 
-Usage: chrome-use frame <selector|main>
+Usage: chrome-use frame <index|frameId|selector|@ref|main>
 
 Switch to an iframe or back to the main frame.
 
 Arguments:
-  <selector>           CSS selector for iframe
+  <index>              The number `frames` prints in brackets ([2] …). 0 is the
+                       top document, i.e. the same as `main`
+  <frameId>            A frame id, e.g. from an observation's `newFrames`
+  <selector>           CSS selector for the iframe element
+  @ref                 An iframe element's ref from `snapshot -i`
   main                 Switch back to main frame
+
+A cross-origin overlay (a bank/branch picker, a payment field) is a separate
+frame: `snapshot -i` on the page will not show what is inside it. List frames
+with `frames`, switch in with `frame <index>`, then `snapshot -i` / `click` /
+`fill` act inside it. `eval --frame <f>` is the one-off form.
 
 Global Options:
   --json               Output as JSON
   --session <name>     Use specific session
 
 Examples:
+  chrome-use frames                        # [0] top … [1] accessory_layer …
+  chrome-use frame 1                       # switch into it by index
   chrome-use frame "#embed-iframe"
   chrome-use frame "iframe[name='content']"
   chrome-use frame main

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -467,10 +467,19 @@
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
           <span class="du-code-name">frame</span>
         </div>
-<pre><code><span class="du-prompt">$</span> chrome-use frame <span class="du-str">"#iframe"</span>     <span class="du-cmt"># 按 CSS 选择器切换到 iframe</span>
+<pre><code><span class="du-prompt">$</span> chrome-use frames              <span class="du-cmt"># [0] top … [1] accessory_layer …</span>
+<span class="du-prompt">$</span> chrome-use frame 1             <span class="du-cmt"># 按 frames 打印的序号切换（0 = 顶层文档）</span>
+<span class="du-prompt">$</span> chrome-use frame <span class="du-str">"#iframe"</span>     <span class="du-cmt"># 按 CSS 选择器切换到 iframe</span>
 <span class="du-prompt">$</span> chrome-use frame @e3           <span class="du-cmt"># 按元素 ref 切换到 iframe</span>
 <span class="du-prompt">$</span> chrome-use frame main          <span class="du-cmt"># 返回主框架</span></code></pre>
       </div>
+      <p>
+        <span class="mark">跨域浮层是独立的框架</span>——银行/分行选择器、支付字段这类，
+        页面上的 <code>snapshot -i</code> 看不到里面的东西，<code>focus</code> / <code>press</code>
+        也只会落在 iframe 元素本身。路径是 <code>frames</code> → <code>frame &lt;序号&gt;</code>
+        → 在里面 <code>snapshot -i</code> / <code>click</code> / <code>fill</code>；
+        只做一次的话用 <code>eval --frame &lt;f&gt;</code>。
+      </p>
       <p>
         <code>frame</code> 接受三种输入：<strong>元素 ref</strong>（<code>frame @e3</code>）、
         <strong>CSS 选择器</strong>（<code>frame "#payment-iframe"</code>）、以及

--- a/docs/en/commands.html
+++ b/docs/en/commands.html
@@ -482,10 +482,20 @@
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
           <span class="du-code-name">frame</span>
         </div>
-<pre><code><span class="du-prompt">$</span> chrome-use frame <span class="du-str">"#iframe"</span>     <span class="du-cmt"># switch to an iframe by CSS selector</span>
+<pre><code><span class="du-prompt">$</span> chrome-use frames              <span class="du-cmt"># [0] top … [1] accessory_layer …</span>
+<span class="du-prompt">$</span> chrome-use frame 1             <span class="du-cmt"># switch by the index frames prints (0 = top document)</span>
+<span class="du-prompt">$</span> chrome-use frame <span class="du-str">"#iframe"</span>     <span class="du-cmt"># switch to an iframe by CSS selector</span>
 <span class="du-prompt">$</span> chrome-use frame @e3           <span class="du-cmt"># switch to an iframe by element ref</span>
 <span class="du-prompt">$</span> chrome-use frame main          <span class="du-cmt"># return to the main frame</span></code></pre>
       </div>
+      <p>
+        <span class="mark">A cross-origin overlay is a separate frame</span> — a bank/branch
+        picker, a payment field. <code>snapshot -i</code> on the page shows nothing of what is
+        inside it, and <code>focus</code> / <code>press</code> land on the iframe element itself.
+        The path is <code>frames</code> → <code>frame &lt;index&gt;</code> → <code>snapshot -i</code>
+        / <code>click</code> / <code>fill</code> inside it; <code>eval --frame &lt;f&gt;</code> is
+        the one-off form.
+      </p>
       <p>
         <code>frame</code> accepts three kinds of input: an <strong>element ref</strong> (<code>frame @e3</code>),
         a <strong>CSS selector</strong> (<code>frame "#payment-iframe"</code>), and a

--- a/skill-data/core/references/commands.md
+++ b/skill-data/core/references/commands.md
@@ -382,6 +382,7 @@ version, update or reload ab-connect at `chrome://extensions`, then retry.
 ## Frames
 
 ```bash
+chrome-use frame 2             # Switch by the index `frames` prints ([2] …)
 chrome-use frame "#iframe"     # Switch to iframe by CSS selector
 chrome-use frame @e3           # Switch to iframe by element ref
 chrome-use frame main          # Back to main frame


### PR DESCRIPTION
Addresses #218 的 ask 1(部分) / 2(已存在) / 4。

## 发现的真 bug：我们自己写的恢复路径是断的

`frames` 打印 `[0] top …`，跨框架的错误信息让读者「用 `frame <id>` 进去」，而：

```
$ chrome-use frame 0
✗ Evaluation error: SyntaxError: Failed to execute 'querySelector' on 'Document':
  '0' is not a valid selector.
```

序号落进了 CSS 解析。issue 抱怨「`eval --frame` 是唯一可行的办法，而它不在任何排查路径里」—— 有一半是因为写在提示里的那条路径照着做不通。

现在 `frame <index>` 按 `frames` 的编号解析，`frame 0` = 回到顶层文档（与 `main` 同义）；越界给人话而不是 querySelector 原文：

```
✗ frame 5: this page has 2 frame(s), numbered 0..1. Run `frames` for the list.
```

## 文档（ask 4）

`frame --help`、skill、中英文档站都补上：跨域浮层（银行/分行选择器、支付字段）**是独立的框架**，页面上的 `snapshot -i` 看不到里面，`focus`/`press` 只会落在 iframe 元素本身；路径是 `frames` → `frame <序号>` → 在里面 `snapshot -i` / `click` / `fill`，一次性的用 `eval --frame`。

## 已经存在、不用做的

- **ask 2**（`focus`/`press` 落在 iframe 上应该报出来）：`frame_boundary_warning` 已经在做，而且原文就点名了「a cross-origin overlay (a bank/branch picker, a payment field) is always a separate frame like this」。
- **ask 3**（React 受控输入的原生 setter）：`fill` 已经走原生 value setter + 事件；配合 `frame <n>` 切进去即可，不需要单独的 `fill --frame`。

## 还开着的

**ask 1 的另一半**：点击后新出现的 OOPIF 主动提示（`note: a new cross-origin frame appeared`）。观察侧已有 `newFrames`，但把它接到 `snapshot -i` 的提示上是另一件事，留在 issue 里。

190 上 1306 通过。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf