### PR TITLE
feat(observe): 观察结果带上目标身份 (#237 第 3 条)

### DIFF
--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -2030,6 +2030,26 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                 )),
             );
         }
+        // Name the target this observation came from. Without it a caller
+        // cannot tell a delta on the page they meant from a delta on a page
+        // they were silently moved to — after a rebinding, a cross-process
+        // navigation, or a tab switch — and reuses refs across the boundary
+        // (issue #237). Ids only: no account email, no query string beyond the
+        // url the page itself reports.
+        if let Some((tab_id, target_id, url)) =
+            state.browser.as_ref().and_then(|mgr| mgr.observed_target())
+        {
+            observed.insert(
+                "target".into(),
+                json!({
+                    "session": state.session_id,
+                    "tabId": tab_id,
+                    "targetId": target_id,
+                    "url": url,
+                }),
+            );
+        }
+
         if let Some(obj) = resp.as_object_mut() {
             let data = obj
                 .entry("data")

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -2523,6 +2523,22 @@ impl BrowserManager {
         Some((format_tab_id(page.tab_id), page.url.clone()))
     }
 
+    /// Which tab this observation is about: `(tabId, targetId, url)`.
+    ///
+    /// Deliberately no account or profile email. The point is only "is this
+    /// still the same target as last time" — a caller that cannot tell reuses
+    /// refs from one page against another, which is how a rebinding or a
+    /// navigation turns into a mis-click (issue #237).
+    pub fn observed_target(&self) -> Option<(String, String, String)> {
+        let i = self.resolved_active_index();
+        let page = self.pages.get(i)?;
+        Some((
+            format_tab_id(page.tab_id),
+            page.target_id.clone(),
+            page.url.clone(),
+        ))
+    }
+
     pub fn tab_list(&self) -> Vec<Value> {
         let active = self.resolved_active_index();
         let pinned = self.active_target_id.as_deref();


### PR DESCRIPTION
Addresses #237 第 3 条（短字段标明目标身份）。

## 问题

`--observe` 之前只有 before/after 的 URL。调用方分不出「我要的那个页面的变化」和「我被悄悄换到别的页面之后的变化」—— 重绑定、跨进程导航、标签切换之后都会发生，而分不出的后果是把上一页的 `@ref` 用在下一页上。

## 改动

`observed.target` 加四个字段：

```json
"target": {
  "session": "cu-…",
  "tabId": "t3",
  "targetId": "8A1F…",
  "url": "https://app.example.com/checkout"
}
```

**只有 id，没有账号邮箱。** issue 的验收里写了「默认不必暴露账户邮箱或 URL 中的敏感参数」，而这里要回答的问题只是「还是不是同一个目标」——不需要知道是谁。

## 其余六条的状态

在 issue 里留了逐条对照（#237 的评论）：1/2/5/6 已随 #242 / #243 / #246 / #236 落地；4（无变化时的按需诊断）和 7（脱敏失败诊断包）还开着，且都是新功能而非修 bug。

190 上 1309 通过，clippy 干净。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf