### PR TITLE
feat(relay): 中继失败时，扩展落后于商店就在错误里说出来

### DIFF
--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -1818,6 +1818,57 @@ pub fn store_extension_version() -> Option<String> {
     parse_store_update_version(&String::from_utf8_lossy(&out.stdout))
 }
 
+/// The published version, from a cache that expires after twelve hours.
+///
+/// [`store_extension_version`] shells out to `curl` with a 4s budget. That is
+/// fine for `doctor`, which the user ran on purpose, and far too expensive for
+/// anything on a command's path — so callers that want the fact opportunistically
+/// use this. A miss still pays the fetch once; everything for the next twelve
+/// hours is a small file read.
+pub fn cached_store_extension_version() -> Option<String> {
+    let path = relay_url_path().with_file_name("store-ext-version");
+    const TTL: std::time::Duration = std::time::Duration::from_secs(12 * 60 * 60);
+    if let Ok(meta) = std::fs::metadata(&path) {
+        if meta
+            .modified()
+            .ok()
+            .and_then(|m| m.elapsed().ok())
+            .is_some_and(|age| age < TTL)
+        {
+            let cached = std::fs::read_to_string(&path).ok()?.trim().to_string();
+            // An empty file is a remembered "the lookup failed" — honour the TTL
+            // rather than retrying the network on every failing command.
+            return (!cached.is_empty()).then_some(cached);
+        }
+    }
+    let fetched = store_extension_version();
+    let _ = std::fs::write(&path, fetched.as_deref().unwrap_or(""));
+    fetched
+}
+
+/// One line naming the installed and published extension versions, when the
+/// installed one is genuinely behind something the user can install today.
+///
+/// `None` in every other case, including "we could not ask the store" — being
+/// behind the version this CLI bundles is the normal state for Web Store users
+/// and not a problem to report (#186).
+pub fn outdated_extension_note() -> Option<String> {
+    let live = relay_ext_version()?;
+    let bundled = env!("AB_CONNECT_VERSION");
+    if !crate::upgrade::version_is_newer(bundled, &live) {
+        return None;
+    }
+    match classify_ext_version(&live, bundled, cached_store_extension_version().as_deref()) {
+        ExtVersionVerdict::BehindStore { store } => Some(format!(
+            "\nThe ab-connect extension driving this browser is {live}; the Web Store serves \
+             {store}. Relay failures like this one are what those builds keep fixing, so update \
+             before digging further: chrome://extensions → Developer mode → Update (a reload is \
+             enough for an unpacked build, which never updates itself)."
+        )),
+        _ => None,
+    }
+}
+
 /// Pull `version="x.y.z"` out of the update service's XML response. The
 /// `updatecheck` element carries it; `status="noupdate"`/error responses don't,
 /// and yield `None`.
@@ -3770,5 +3821,27 @@ mod tests {
 
         assert_eq!(status.version.as_deref(), Some("0.5.1"));
         assert_eq!(status.disable_reasons, vec!["4", "permissions_increase"]);
+    }
+
+    /// Only "a newer build exists in the store" is actionable. Being behind the
+    /// bundled build while sitting on the newest published one is the normal
+    /// state for Web Store users, and nagging about it sends people to an
+    /// Update button that does nothing (#186).
+    #[test]
+    fn the_outdated_note_only_fires_when_something_installable_is_newer() {
+        assert!(matches!(
+            classify_ext_version("0.5.20", "0.5.22", Some("0.5.21")),
+            ExtVersionVerdict::BehindStore { .. }
+        ));
+        assert!(!matches!(
+            classify_ext_version("0.5.21", "0.5.22", Some("0.5.21")),
+            ExtVersionVerdict::BehindStore { .. }
+        ));
+        // Store unreachable: we do not know that anything is installable, so
+        // there is nothing honest to say.
+        assert!(!matches!(
+            classify_ext_version("0.5.20", "0.5.22", None),
+            ExtVersionVerdict::BehindStore { .. }
+        ));
     }
 }

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1953,6 +1953,20 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
                     msg.push_str(&note);
                 }
             }
+            // A relay failure on an extension the store has already moved past
+            // is worth saying out loud right here. `doctor` reports it, but the
+            // people it matters to are exactly the ones who never run `doctor`
+            // and never open chrome://extensions — and an unpacked build never
+            // updates itself at all. Only on the failure path: the lookup is
+            // cached for twelve hours and the command has already failed, so it
+            // costs nothing anyone is waiting on.
+            if super::browser::is_debugger_access_denied(&e)
+                || super::browser::is_stale_target_error(&e)
+            {
+                if let Some(note) = crate::connect::outdated_extension_note() {
+                    msg.push_str(&note);
+                }
+            }
             // Say which page the failure was about. Without it a blocked
             // debugger access is indistinguishable from a permissions problem
             // and the reader has nothing to check (#217).


### PR DESCRIPTION
扩展版本落后现在只在 `doctor` 里报。而真正受影响的人恰恰是**从不跑 doctor、也从不打开 `chrome://extensions`** 的那批 —— 手动装 unpacked 的更是永远不会自动更新。本机现在连的就是 0.5.20，商店已经是 0.5.21。

## 只挂在失败路径上

命令因 `debugger_access_denied` 或 stale target 失败时，才追加一句：

```
✗ debugger_access_denied: … Original error: …

The ab-connect extension driving this browser is 0.5.20; the Web Store serves 0.5.21.
Relay failures like this one are what those builds keep fixing, so update before digging
further: chrome://extensions → Developer mode → Update (a reload is enough for an unpacked
build, which never updates itself).
```

两个理由：这两类失败正好是新扩展改的地方，提示出现得最相关；命令已经失败了，这时候的开销没人在等。

## 缓存

`store_extension_version()` 会 curl（4 秒超时），**绝不能放上热路径**。新增 `cached_store_extension_version()`：12 小时 TTL 的文件缓存，**查失败也缓存**（写空文件）—— 否则一串失败命令会每条都重新走网络。

## 只在真有更新时才说

落后于本 CLI 捆绑的版本、但已经是最新已发布版本，是商店用户的**常态**；为此让人去点 Update 是死路（#186 的教训）。单测锁住三种情况：商店更新 → 说；已是最新 → 不说；**查不到商店版本 → 不说**（不知道有什么可装，就没有诚实的话可讲）。

190 上 1310 通过，clippy 干净。纯 CLI，不碰扩展、不进商店、无审核风险。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a notice when the connected browser extension is older than the latest published version.
  - The notice appears alongside relevant connection and debugging errors to help identify outdated extensions.
  - Version information is checked periodically and remains available during temporary Store lookup failures.

- **Bug Fixes**
  - Avoided showing outdated-extension warnings when the installed version is unpublished or when current Store version information cannot be confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->