### PR TITLE
feat(report): 报告自己说清包含什么、排除什么，并带上扩展与中继状态 (#275)

### DIFF
--- a/cli/src/friction.rs
+++ b/cli/src/friction.rs
@@ -231,17 +231,69 @@ fn report_markdown(agg: &Value) -> String {
     };
     format!(
         "## What happened\n<!-- what you were doing, the exact command, expected vs actual -->\n\n\
-         ## Environment\n- chrome-use: {ver}\n- platform: {os}/{arch}\n<!-- run `chrome-use doctor` and paste its output here if the issue is about connect/send -->\n\n\
-         ## Local friction summary\n_{total} failed command(s) recorded locally (de-identified: command + error category + host only, never full URLs)._\n\n\
-         **By command**\n{by_cmd}\n\n**By category**\n{by_cat}\n\n**By host**\n{by_host}\n",
-        ver = env!("CARGO_PKG_VERSION"),
-        os = std::env::consts::OS,
-        arch = std::env::consts::ARCH,
+         ## Environment\n{env}\n\n\
+         ## Local friction summary\n_{total} failed command(s) recorded locally._\n\n\
+         **By command**\n{by_cmd}\n\n**By category**\n{by_cat}\n\n**By host**\n{by_host}\n\n\
+         ---\n{scope}\n",
+        env = environment_block(),
         total = total,
         by_cmd = list("byCommand"),
         by_cat = list("byCategory"),
         by_host = list("byHost"),
+        scope = REPORT_SCOPE,
     )
+}
+
+/// What the report contains and what it deliberately leaves out.
+///
+/// Stating the boundary is the point, not politeness: a person deciding
+/// whether to paste this into a public issue cannot verify it line by line,
+/// and "de-identified" on its own is a claim they have to take on faith. The
+/// last line is the one that matters most — text redaction says nothing about
+/// pixels, and assuming otherwise is how a token ends up in a screenshot
+/// attached to a public issue (issue #275).
+pub const REPORT_SCOPE: &str = "\
+_Included: chrome-use and extension versions, platform, and per-command failure counts \
+grouped by error category and **host name only**._\n\n\
+_Excluded: full URLs and query strings, page content, form input, cookies, tokens, \
+credentials, and anything about tabs other than the ones that failed. The local log this \
+is built from (`~/.chrome-use/friction.jsonl`) never records them either._\n\n\
+_**Screenshots are not included, and are a separate decision.** If you attach one, nothing \
+above redacts it — check the image yourself for logged-in pages, tokens in the address bar, \
+and other tabs._";
+
+/// Version and connection facts, gathered without touching a page.
+///
+/// The extension version and whether the relay is up are the two things that
+/// explain most reports, and both are already sitting in sidecar files — asking
+/// the user to run `doctor` separately and paste it was one step that mostly
+/// did not happen.
+fn environment_block() -> String {
+    let mut out = format!(
+        "- chrome-use: {}\n- platform: {}/{}",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+    );
+    match crate::connect::relay_ext_version() {
+        Some(v) => out.push_str(&format!(
+            "\n- ab-connect: {v} (bundled with this CLI: {})",
+            env!("AB_CONNECT_VERSION")
+        )),
+        None => out.push_str(&format!(
+            "\n- ab-connect: not connected (this CLI bundles {})",
+            env!("AB_CONNECT_VERSION")
+        )),
+    }
+    out.push_str(&format!(
+        "\n- extension relay: {}",
+        if crate::connect::relay_url().is_some() {
+            "up"
+        } else {
+            "down"
+        }
+    ));
+    out
 }
 
 /// `chrome-use report [--open] [--json]` — OPT-IN. Packages the local friction
@@ -267,7 +319,10 @@ pub fn run_report(args: &[String], json_out: bool) {
     println!("{}", body);
     println!("─────────────────────────────────────────────");
     println!("Copy the block above into a new issue: {ISSUES_NEW_URL}");
-    println!("(Nothing was uploaded. `--open` opens the new-issue page in your browser.)");
+    println!(
+        "(Nothing was uploaded, and `--open` only opens the empty new-issue page — \
+         what gets posted is whatever you paste.)"
+    );
 
     if args.iter().any(|a| a == "--open") {
         let opener = if cfg!(target_os = "macos") {
@@ -284,6 +339,36 @@ pub fn run_report(args: &[String], json_out: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The boundary has to be stated, and the screenshot line has to be its
+    /// own sentence: text redaction says nothing about pixels (#275).
+    #[test]
+    fn the_report_states_what_it_leaves_out() {
+        for excluded in [
+            "full URLs",
+            "cookies",
+            "tokens",
+            "credentials",
+            "form input",
+        ] {
+            assert!(REPORT_SCOPE.contains(excluded), "missing: {excluded}");
+        }
+        assert!(REPORT_SCOPE.contains("Screenshots are not included"));
+        assert!(
+            REPORT_SCOPE.contains("nothing \nabove redacts it")
+                || REPORT_SCOPE.contains("nothing above redacts it")
+        );
+    }
+
+    /// The two facts that explain most reports have to be in the block itself,
+    /// not behind "please also run doctor and paste it".
+    #[test]
+    fn the_environment_block_carries_the_extension_and_relay_state() {
+        let env = environment_block();
+        assert!(env.contains("chrome-use:"), "{env}");
+        assert!(env.contains("ab-connect:"), "{env}");
+        assert!(env.contains("extension relay:"), "{env}");
+    }
 
     #[test]
     fn test_categorize() {


### PR DESCRIPTION
Closes #275。

`chrome-use report` 已经存在（从 friction 日志出 markdown、明说没有上传）。补两处。

## 一、把边界写出来

原来只有一句「de-identified: command + error category + host only」。要决定「这段能不能贴进公开 issue」的人**没法逐行核对**，只能选择相信。现在明列：

- **包含**：版本、平台、按错误类别和**仅主机名**分组的失败计数
- **排除**：完整 URL 和查询串、页面内容、表单输入、Cookie、Token、凭据，以及失败之外的标签；本地日志 `friction.jsonl` 本身也不记这些
- **截图不包含在内，且是一个独立的决定；上面任何脱敏都管不到图片**

最后一条是 issue 的原话要求（「截图单独选择，不能假定文本脱敏覆盖截图」）。**刻意没有加「附带截图」的选项** —— 文本脱敏对像素什么都没做，加一个选项等于鼓励一个我们无法脱敏的动作。改成在报告里说清它是独立决定，并提醒去检查登录态页面、地址栏里的 token、以及别的标签。

## 二、环境块自己去取

原来写的是「如果问题和连接有关，请另外跑 `doctor` 并把输出贴过来」。那一步大多没人做，而**扩展版本和 relay 是否在跑恰恰能解释大多数报告** —— 两者都躺在侧车文件里，直接读就是了：

```
## Environment
- chrome-use: 1.5.113
- platform: macos/aarch64
- ab-connect: 0.5.22 (bundled with this CLI: 0.5.23)
- extension relay: up
```

顺带把 footer 说准：`--open` 只打开空白的新建 issue 页，贴什么完全由用户决定。

190 上 1312 通过，clippy 干净。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub issue reports now include detailed environment information, including version, platform, connection status, and extension relay state.
  * Added clear documentation describing report scope and noting that screenshots are not redacted.

* **Bug Fixes**
  * Replaced outdated hardcoded version and platform details with current environment information.

* **Documentation**
  * Improved the report footer messaging and scope guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->