### PR TITLE
fix(type/fill): 单参数 type 是用法错误；fill 的恢复焦点不再被 onFocus 重置吃掉 (#280)

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -730,10 +730,24 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     "commitEnter": commit_enter, "clear": clear, "delay": delay,
                 }));
             }
-            let sel = rest.first().ok_or_else(|| ParseError::MissingArguments {
-                context: "type".to_string(),
-                usage: type_usage,
-            })?;
+            // A lone argument used to become the SELECTOR with empty text, so
+            // `type "12491249"` went looking for an element called `12491249`
+            // and failed with "selector matched nothing in the page DOM" — a
+            // hint that sends the reader hunting for a label instead of telling
+            // them the command shape is wrong (issue #280). Both parts are
+            // required; typing nothing into something is not a thing to do.
+            if rest.len() < 2 {
+                return Err(ParseError::MissingArguments {
+                    context: match rest.first() {
+                        Some(only) => format!(
+                            "type: got one argument ('{only}') but needs a target AND the text.                              If '{only}' is the text you want typed, name where it goes                              (`type <selector|@ref> \"{only}\"`) or type into the focused                              element (`type --focused \"{only}\"`)"
+                        ),
+                        None => "type".to_string(),
+                    },
+                    usage: type_usage,
+                });
+            }
+            let sel = rest[0];
             Ok(
                 json!({ "id": id, "action": "type", "selector": sel, "text": rest[1..].join(" "), "keyEvents": key_events, "commitEnter": commit_enter, "clear": clear, "delay": delay }),
             )
@@ -8460,5 +8474,33 @@ mod tests {
         let cmd = parse_command(&args("wait 500"), &default_flags()).unwrap();
         assert_eq!(cmd["timeout"], 500);
         assert!(cmd.get("selector").is_none());
+    }
+
+    /// A lone argument used to become the selector with empty text, so
+    /// `type "12491249"` reported "selector matched nothing" and sent the
+    /// reader hunting for a label that never existed (#280).
+    #[test]
+    fn type_with_only_one_argument_is_a_usage_error_not_a_selector_miss() {
+        let err = parse_command(&["type".into(), "12491249".into()], &default_flags())
+            .expect_err("one argument cannot be both target and text");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("12491249"), "{msg}");
+        assert!(
+            msg.contains("--focused"),
+            "must offer the no-selector form: {msg}"
+        );
+        assert!(!msg.contains("matched nothing"), "{msg}");
+    }
+
+    /// Two arguments stay the ordinary shape.
+    #[test]
+    fn type_with_a_target_and_text_still_parses() {
+        let cmd = parse_command(
+            &["type".into(), "#q".into(), "hello".into()],
+            &default_flags(),
+        )
+        .expect("selector + text");
+        assert_eq!(cmd["selector"], "#q");
+        assert_eq!(cmd["text"], "hello");
     }
 }

--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -1010,9 +1010,90 @@ pub async fn fill(
         }
     }
 
-    verify_fill_value(client, &effective_session_id, &object_id, value, &engine).await?;
+    // A control whose `onFocus` resets its own state wipes what we just wrote.
+    // The fill path deliberately blurs (so blur-triggered validation and
+    // lookups run) and then restores focus (#167) — and that restore is what
+    // re-fires `onFocus`. On a hand-rolled combobox that clears its query on
+    // focus, the value is gone by the time we read it back (issue #280).
+    //
+    // So: one re-apply, without touching focus, and then the SAME verification.
+    // Nothing is reported as filled that the field does not actually hold.
+    if let Err(first) =
+        verify_fill_value(client, &effective_session_id, &object_id, value, &engine).await
+    {
+        if !value.is_empty() && first.contains("read back an empty value") {
+            let reapplied = reapply_value_without_focus_change(
+                client,
+                &effective_session_id,
+                &object_id,
+                value,
+            )
+            .await
+            .is_ok();
+            if !reapplied {
+                return Err(first);
+            }
+            verify_fill_value(client, &effective_session_id, &object_id, value, &engine).await?;
+            // Say which path produced the value: a control that needed this is
+            // one whose focus handler fights writes, and the caller may need to
+            // know that before pressing Enter into it.
+            return Ok(format!("{engine}+refocus-reset"));
+        }
+        return Err(first);
+    }
 
     Ok(engine)
+}
+
+/// Write the value once more with the native setter, firing `input`/`change`
+/// and leaving focus exactly where it is.
+///
+/// Deliberately no blur and no focus restore: those already ran once, and
+/// repeating them is what erased the value in the first place.
+async fn reapply_value_without_focus_change(
+    client: &CdpClient,
+    session_id: &str,
+    object_id: &str,
+    value: &str,
+) -> Result<(), String> {
+    let js = format!(
+        r#"function() {{
+            const el = this;
+            const v = {v};
+            const tag = el.tagName;
+            if (tag !== 'INPUT' && tag !== 'TEXTAREA') {{
+                el.textContent = v;
+                el.dispatchEvent(new Event('input', {{ bubbles: true }}));
+                return true;
+            }}
+            const proto = tag === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype
+                                             : window.HTMLInputElement.prototype;
+            const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+            if (desc && desc.set) {{ desc.set.call(el, v); }} else {{ el.value = v; }}
+            el.dispatchEvent(new Event('input', {{ bubbles: true }}));
+            el.dispatchEvent(new Event('change', {{ bubbles: true }}));
+            return true;
+        }}"#,
+        v = serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string()),
+    );
+    let result: EvaluateResult = client
+        .send_command_typed(
+            "Runtime.callFunctionOn",
+            &CallFunctionOnParams {
+                function_declaration: js,
+                object_id: Some(object_id.to_string()),
+                arguments: None,
+                return_by_value: Some(true),
+                await_promise: Some(false),
+            },
+            Some(session_id),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    if let Some(ex) = result.exception_details {
+        return Err(ex.text);
+    }
+    Ok(())
 }
 
 async fn fill_monaco_via_clipboard(


### PR DESCRIPTION
Closes #280 的第 1、2 条（第 3 条在真实页面上不成立，见 issue 里的说明；顺路发现的另一个缺口开成了 #281）。

## 第 2 条：`type` 单参数

`type "12491249"` 的一个参数被当成**选择器**、文本为空，于是去找一个叫 `12491249` 的元素，报「selector matched nothing in the page DOM」—— 把读者送去找一个根本不存在的标签。

现在直接说清楚是用法问题，并给两条出路：

```
✗ type: got one argument ('12491249') but needs a target AND the text. If '12491249' is the
  text you want typed, name where it goes (`type <selector|@ref> "12491249"`) or type into
  the focused element (`type --focused "12491249"`)
```

## 第 1 条：`fill` 在 React 手写 combobox 上读回为空

**issue 的猜测（「回退到原生 setter」）落不到实处 —— `fill` 一直在用原生 setter。**

真正的原因是它之后那段 `blur()` + `focusout` → **恢复焦点**（#167 加的：blur 后 activeElement 落到 `<body>`，紧接着的 `press Enter` 会打到文档上）。而这个 combobox 的 `onFocus` 会重置查询。

在用户的真实控件上逐步测出来的：

```
写入后      "7777"
blur 后     "7777"      ← blur 不是凶手
+50ms       "7777"
重新聚焦后   ""          ← 就是这一下
```

改法：读回为空且写的非空时，**不改动焦点**地重写一次值（原生 setter + `input`/`change`），然后跑**同一个校验**。校验不放宽 —— 字段里没有的东西不会被报成填好了。成功时 engine 报 `input+refocus-reset`，因为「这控件的焦点处理会跟写入打架」是按 Enter 之前该知道的事。

## 真实页面上的前后对照

同一个控件、同一条命令：

```
1.5.113          ✗ fill verification failed for input: read back an empty value after writing "1249"
本分支            ✓ Done
```

`✓` 之后单独读了一次 DOM 确认 `"1249"` 真在字段里。

## 一处记录

查这条时我判断错过一次：第一次探测 `blur(); focus();` 之后**同步**读值，看到值还在就说「机制判断错了」。同步读不是反证 —— React 的状态更新还没落地，加两帧 rAF 才看到真相。和「截图/AX 树是采样不是状态」是同一个形状。

190 上 1316 通过，clippy 干净。