### PR TITLE
ci: macOS 产物签名 + 公证（消除 adhoc 复制失效导致的 rc=137）

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -115,14 +115,16 @@ jobs:
       # Skipped, not failed, when the secrets are absent: a fork building a tag
       # has no certificate, and an unsigned build is still a usable build.
       - name: Sign and notarize (macOS)
-        if: startsWith(matrix.os, 'macos') && secrets.MACOS_CERT_P12 != ''
+        if: startsWith(matrix.os, 'macos') && secrets.APPLE_SIGNING_CERTIFICATE != ''
         env:
-          MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
-          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
-          ASC_KEY_P8: ${{ secrets.ASC_KEY_P8 }}
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          # Same secret names as leeguooooo/iphone-use, which already signs and
+          # notarizes this way — one convention across the repos, not two.
+          APPLE_SIGNING_CERTIFICATE: ${{ secrets.APPLE_SIGNING_CERTIFICATE }}
+          APPLE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
+          APPLE_SIGN_IDENTITY: ${{ secrets.APPLE_SIGN_IDENTITY }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
         shell: bash
         run: |
           set -euo pipefail
@@ -134,8 +136,8 @@ jobs:
           security create-keychain -p "$pw" "$kc"
           security set-keychain-settings -lut 21600 "$kc"
           security unlock-keychain -p "$pw" "$kc"
-          echo "$MACOS_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
-          security import "$RUNNER_TEMP/cert.p12" -k "$kc" -P "$MACOS_CERT_PASSWORD" \
+          echo "$APPLE_SIGNING_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$kc" -P "$APPLE_SIGNING_CERTIFICATE_PASSWORD" \
             -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$pw" "$kc" >/dev/null
           security list-keychain -d user -s "$kc" $(security list-keychains -d user | tr -d '"')
@@ -144,14 +146,14 @@ jobs:
           # `--options runtime` is required for notarization. Verified locally
           # that the daemon still starts and drives a browser under it.
           codesign --force --options runtime --timestamp \
-            -s "$MACOS_SIGN_IDENTITY" --keychain "$kc" "$bin"
+            -s "$APPLE_SIGN_IDENTITY" --keychain "$kc" "$bin"
           codesign --verify --strict --verbose=2 "$bin"
 
-          if [ -n "${ASC_KEY_P8:-}" ]; then
-            echo "$ASC_KEY_P8" | base64 --decode > "$RUNNER_TEMP/asc.p8"
+          if [ -n "${APPLE_API_KEY_P8:-}" ]; then
+            echo "$APPLE_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/asc.p8"
             ditto -c -k --keepParent "$bin" "$RUNNER_TEMP/notarize.zip"
             xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
-              --key "$RUNNER_TEMP/asc.p8" --key-id "$ASC_KEY_ID" --issuer "$ASC_ISSUER_ID" \
+              --key "$RUNNER_TEMP/asc.p8" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID" \
               --wait --timeout 30m
             rm -f "$RUNNER_TEMP/asc.p8" "$RUNNER_TEMP/notarize.zip"
             # A bare executable cannot carry a stapled ticket (only .app/.dmg/

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -105,6 +105,66 @@ jobs:
         if: '!matrix.use_zigbuild'
         run: cargo build --release --manifest-path cli/Cargo.toml --target ${{ matrix.target }}
 
+      # Sign and notarize the macOS binaries. Without this they ship ad-hoc
+      # signed, and an ad-hoc signature does not survive being copied: macOS
+      # then SIGKILLs the process the moment it spawns a thread, which shows up
+      # as a daemon that dies with rc=137 for no visible reason. Every install
+      # that moves the binary (a package manager, `cp` into ~/.local/bin) hits
+      # it. A Developer ID signature survives the copy.
+      #
+      # Skipped, not failed, when the secrets are absent: a fork building a tag
+      # has no certificate, and an unsigned build is still a usable build.
+      - name: Sign and notarize (macOS)
+        if: startsWith(matrix.os, 'macos') && secrets.MACOS_CERT_P12 != ''
+        env:
+          MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          ASC_KEY_P8: ${{ secrets.ASC_KEY_P8 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin="cli/target/${{ matrix.target }}/release/chrome-use"
+
+          # A throwaway keychain, so nothing is added to the runner's login one.
+          kc="$RUNNER_TEMP/signing.keychain-db"
+          pw="$(openssl rand -hex 20)"
+          security create-keychain -p "$pw" "$kc"
+          security set-keychain-settings -lut 21600 "$kc"
+          security unlock-keychain -p "$pw" "$kc"
+          echo "$MACOS_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$kc" -P "$MACOS_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$pw" "$kc" >/dev/null
+          security list-keychain -d user -s "$kc" $(security list-keychains -d user | tr -d '"')
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+          # `--options runtime` is required for notarization. Verified locally
+          # that the daemon still starts and drives a browser under it.
+          codesign --force --options runtime --timestamp \
+            -s "$MACOS_SIGN_IDENTITY" --keychain "$kc" "$bin"
+          codesign --verify --strict --verbose=2 "$bin"
+
+          if [ -n "${ASC_KEY_P8:-}" ]; then
+            echo "$ASC_KEY_P8" | base64 --decode > "$RUNNER_TEMP/asc.p8"
+            ditto -c -k --keepParent "$bin" "$RUNNER_TEMP/notarize.zip"
+            xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+              --key "$RUNNER_TEMP/asc.p8" --key-id "$ASC_KEY_ID" --issuer "$ASC_ISSUER_ID" \
+              --wait --timeout 30m
+            rm -f "$RUNNER_TEMP/asc.p8" "$RUNNER_TEMP/notarize.zip"
+            # A bare executable cannot carry a stapled ticket (only .app/.dmg/
+            # .pkg can), so there is nothing to staple — Gatekeeper checks the
+            # notarization online. Verified: `spctl -a` goes from `rejected` to
+            # `accepted / source=Notarized Developer ID`.
+            echo "notarized (no staple: bare executables cannot hold a ticket)"
+          else
+            echo "signed but NOT notarized (no App Store Connect key configured)"
+          fi
+
+          security delete-keychain "$kc" || true
+
       - name: Package (.tar.gz + .sha256)
         shell: bash
         run: |

--- a/scripts/sign-release-macos.sh
+++ b/scripts/sign-release-macos.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Sign + notarize the macOS binaries of a published release, in place.
+#
+# Why this exists alongside the CI step: signing in CI means putting the
+# Developer ID private key into GitHub's secret store. That is normal practice
+# and the workflow supports it — but it is not required. This script does the
+# same job from a machine that already holds the key, so the key never leaves
+# it.
+#
+# What signing buys (measured, not assumed): an ad-hoc signature does NOT
+# survive being copied — macOS then SIGKILLs the process as soon as it spawns a
+# thread, which surfaces as a daemon dying with rc=137. A Developer ID
+# signature survives. Notarization additionally flips `spctl -a` from
+# `rejected` to `accepted / source=Notarized Developer ID`, which is what a
+# browser-downloaded (quarantined) copy is checked against.
+#
+# Usage:
+#   scripts/sign-release-macos.sh v1.5.113                # sign + notarize + re-upload
+#   DRY_RUN=1 scripts/sign-release-macos.sh v1.5.113      # do everything except upload
+#
+# Requires: a `Developer ID Application` identity in the keychain, and a
+# notarytool keychain profile (default `chrome-use-notary`; create with
+# `xcrun notarytool store-credentials`).
+set -euo pipefail
+
+TAG="${1:-}"
+[ -n "$TAG" ] || { echo "usage: $0 <tag> (e.g. v1.5.113)" >&2; exit 2; }
+REPO="${REPO:-leeguooooo/chrome-use}"
+IDENTITY="${MACOS_SIGN_IDENTITY:-Developer ID Application: LI GUO (6ZPXG4KVVS)}"
+PROFILE="${NOTARY_PROFILE:-chrome-use-notary}"
+DRY_RUN="${DRY_RUN:-}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+for asset in chrome-use-darwin-arm64 chrome-use-darwin-x64; do
+  echo "── $asset"
+  ( cd "$work" && gh release download "$TAG" -R "$REPO" -p "$asset.tar.gz" --clobber )
+  mkdir -p "$work/$asset" && tar xzf "$work/$asset.tar.gz" -C "$work/$asset"
+  bin="$work/$asset/chrome-use"
+
+  before="$(codesign -dv "$bin" 2>&1 | grep -c 'Signature=adhoc' || true)"
+  codesign --force --options runtime --timestamp -s "$IDENTITY" "$bin"
+  codesign --verify --strict "$bin"
+  echo "   signed (was adhoc: $before)"
+
+  ditto -c -k --keepParent "$bin" "$work/$asset.notarize.zip"
+  xcrun notarytool submit "$work/$asset.notarize.zip" \
+    --keychain-profile "$PROFILE" --wait --timeout 30m
+  # A bare executable cannot hold a stapled ticket (only .app/.dmg/.pkg can);
+  # Gatekeeper verifies notarization online. Confirm the outcome rather than
+  # assuming the submission implies it.
+  spctl -a -vv -t install "$bin" 2>&1 | sed 's/^/   /'
+
+  ( cd "$work/$asset" && tar czf "../$asset.tar.gz" chrome-use LICENSE* )
+  ( cd "$work" && shasum -a 256 "$asset.tar.gz" > "$asset.tar.gz.sha256" )
+
+  if [ -n "$DRY_RUN" ]; then
+    echo "   DRY_RUN: not uploading. Rebuilt archive at $work/$asset.tar.gz"
+  else
+    gh release upload "$TAG" -R "$REPO" \
+      "$work/$asset.tar.gz" "$work/$asset.tar.gz.sha256" --clobber
+    echo "   uploaded (sha256 replaced too)"
+  fi
+done
+
+echo
+echo "Done. Anyone who already downloaded the old archive keeps a working but"
+echo "ad-hoc-signed binary; the checksum published now matches the signed one."


### PR DESCRIPTION
现在发布的 macOS 二进制是 `adhoc, linker-signed`、无团队标识，`spctl -a` 判 **rejected**。

## 主要收益不是 Gatekeeper，是「复制之后失效」

**adhoc 签名扛不住复制** —— 复制之后 macOS 会在进程创建线程的瞬间 SIGKILL 它，表现是 daemon 无缘无故 rc=137 死掉。任何把二进制搬个位置的安装方式都会踩到（包管理器、`cp` 进 `~/.local/bin`）。这就是仓库记忆里那条 `macos-adhoc-copy-sigkill`；**我在这一轮工作里自己踩了四次**，每次都得手动 `codesign --force -s -`。

## 本机实测的前后对照

```
签名前          Signature=adhoc, TeamIdentifier=not set,   spctl → rejected
签名+公证后      Developer ID Application: LI GUO (…),      spctl → accepted
                source=Notarized Developer ID
复制之后         签名保留，直接可执行
带 quarantine    可以运行（模拟浏览器下载）
硬化运行时       daemon 正常启动并驱动浏览器
```

公证是真跑的，不是照文档写的：提交 → `status: Accepted` → `spctl` 从 rejected 变 accepted。

## 实现

`release-binaries.yml` 在 macOS 两个 target 构建后签名 + 公证：

- 用一次性钥匙串（`$RUNNER_TEMP`），不碰 runner 的登录钥匙串，用完删除
- `--options runtime`（公证的前提）—— 已验证 daemon 在硬化运行时下能正常启动并驱动浏览器
- **没配 secrets 时是跳过而不是失败**：fork 打 tag 时没有证书，未签名的构建仍然是可用的构建

secret 名沿用 `leeguooooo/iphone-use` 已有的那套（`APPLE_SIGNING_CERTIFICATE` / `APPLE_API_KEY_P8` …）。`leeguooooo` 是个人账号不是组织，没有账号级 secrets，所以每个仓库各配一份 —— 七个已在 chrome-use 上配好。

## 一条边界，写在注释里免得下次被当成故障

裸可执行文件**不能钉公证票据**（只有 .app/.dmg/.pkg 能），`stapler` 报 Error 73 是预期的。公证记录在 Apple 侧，Gatekeeper 联网校验。

## 另一条路径也留着

`scripts/sign-release-macos.sh`：从已发布的 release 下载产物、就地签名公证、重传（sha256 一并更新），私钥不出本机，带 `DRY_RUN`。给不想走 CI 的情况，或给已经发出去的旧版本补签。

## 证书是怎么进 secret 的

钥匙串导出会把**全部四个身份**打成一包（含其他账号的开发证书）。那不该整包上传，所以拆开只留 Developer ID 那一对（证书 + 匹配的私钥），重建了一个只含单一身份的 .p12，并在隔离钥匙串里**实测能导入、能签名**之后才上传。本地明文 p12/pem/密码已删除。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - macOS release binaries are now signed with a Developer ID certificate and notarized when the required credentials are available.
  - Release archives include verified signatures and checksums after signing.

- **Bug Fixes**
  - Improved macOS compatibility by validating releases against Gatekeeper requirements, helping prevent security warnings when downloading and running official binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->