### PR TITLE
feat(snapshot): 重名控件补区分上下文 (#281)；受管理安装下不再指向不存在的 Update 按钮

### DIFF
--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -1666,6 +1666,16 @@ impl PolicyState {
 /// Read the forcelist Chrome sees from macOS managed preferences (user scope,
 /// then device scope). `defaults read` fails when the key is absent, which maps
 /// to `Absent`; corporate forcelists for OTHER extensions are ignored.
+/// Whether this Chrome has our extension force-installed by policy.
+///
+/// It changes what the user can DO about a stale extension: a policy install
+/// has no per-row update control and no Remove button, so "open
+/// chrome://extensions and hit Update" is advice they cannot follow on the
+/// extension itself. Reported by users as "chrome-use 管理之后就没法手动升级了".
+pub fn extension_is_policy_installed() -> bool {
+    matches!(managed_policy_state(), PolicyState::Active)
+}
+
 fn managed_policy_state() -> PolicyState {
     if !cfg!(target_os = "macos") {
         return PolicyState::Unknown;
@@ -1846,6 +1856,27 @@ pub fn cached_store_extension_version() -> Option<String> {
     fetched
 }
 
+/// How to actually pull an extension update on THIS machine.
+///
+/// A policy install has no update control on the extension's own row and no
+/// Remove button — telling those users to "hit Update" points at a button that
+/// is not there. The toolbar-level Update still works, and so does restarting
+/// Chrome.
+pub fn update_instruction() -> String {
+    if extension_is_policy_installed() {
+        "this profile has the extension installed by policy, so its own row has no update or \
+         remove control. Use chrome://extensions → enable Developer mode → the **Update** \
+         button in the toolbar (not the extension row), or restart Chrome. Chrome also updates \
+         policy-installed extensions on its own schedule and grants new permissions without \
+         asking."
+            .to_string()
+    } else {
+        "chrome://extensions → Developer mode → Update (a reload is enough for an unpacked \
+         build, which never updates itself)."
+            .to_string()
+    }
+}
+
 /// One line naming the installed and published extension versions, when the
 /// installed one is genuinely behind something the user can install today.
 ///
@@ -1862,8 +1893,8 @@ pub fn outdated_extension_note() -> Option<String> {
         ExtVersionVerdict::BehindStore { store } => Some(format!(
             "\nThe ab-connect extension driving this browser is {live}; the Web Store serves \
              {store}. Relay failures like this one are what those builds keep fixing, so update \
-             before digging further: chrome://extensions → Developer mode → Update (a reload is \
-             enough for an unpacked build, which never updates itself)."
+             before digging further: {}",
+            update_instruction()
         )),
         _ => None,
     }
@@ -3843,5 +3874,31 @@ mod tests {
             classify_ext_version("0.5.20", "0.5.22", None),
             ExtVersionVerdict::BehindStore { .. }
         ));
+    }
+
+    /// A policy install has no update control on the extension's own row, so
+    /// the two audiences need different instructions. Sending a managed user
+    /// to a button that is not there is what got reported as "chrome-use
+    /// 管理之后就没法手动升级了".
+    #[test]
+    fn the_update_instruction_names_a_control_that_exists() {
+        let managed = "this profile has the extension installed by policy";
+        let plain = "chrome://extensions → Developer mode → Update";
+        let text = update_instruction();
+        // Whichever branch this machine is on, the text must name a real path
+        // and never claim the row-level control on a policy install.
+        assert!(
+            text.contains("chrome://extensions") || text.contains("restart Chrome"),
+            "{text}"
+        );
+        if text.starts_with(managed) {
+            assert!(
+                text.contains("toolbar"),
+                "must point at the toolbar button: {text}"
+            );
+            assert!(text.contains("restart Chrome"), "{text}");
+        } else {
+            assert!(text.starts_with(plain), "{text}");
+        }
     }
 }

--- a/cli/src/doctor/versions.rs
+++ b/cli/src/doctor/versions.rs
@@ -53,11 +53,14 @@ pub(super) fn check(checks: &mut Vec<Check>) {
                         Status::Warn,
                         format!("extension {ext} is behind the published {store}"),
                     )
-                    .with_fix(
-                        "update ab-connect in Chrome: chrome://extensions \u{2192} \
-                         Developer mode \u{2192} Update (or reload the unpacked build)"
-                            .to_string(),
-                    ),
+                    // Advice a policy-installed user cannot follow is worse
+                    // than none: their extension row has no update control at
+                    // all, which reads as "chrome-use took my ability to
+                    // upgrade away".
+                    .with_fix(format!(
+                        "update ab-connect: {}",
+                        connect::update_instruction()
+                    )),
                 ),
                 connect::ExtVersionVerdict::NewestPublished { store } => checks.push(Check::new(
                     "versions.extension",

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -2035,6 +2035,107 @@ fn build_tree(nodes: &[AXNode]) -> (Vec<TreeNode>, Vec<usize>) {
 /// Recover short, local text lost by interactive filtering without changing
 /// accessible names or ref identity. Never cross a nested item boundary or
 /// walk an unbounded subtree merely to annotate one control.
+/// Context for a control whose name is not unique on the page.
+///
+/// [`control_context`] only speaks for containers it can vouch for — a semantic
+/// `article`/`listitem`/`row`, one with a heading, or a linked product card.
+/// A card header that is just a title and a button matches none of those, so
+/// three cards produced three identical `button "进入"` lines with nothing to
+/// tell them apart, and the caller had to walk the DOM by hand (issue #281).
+///
+/// Duplication is exactly when the risk of adding noise is worth taking: a
+/// unique name needs no help, and an ambiguous one is unusable without it. So
+/// this runs only for repeated (role, name) pairs, and accepts a looser
+/// container — text plus this one control.
+///
+/// The result must actually separate them. If a sibling duplicate would get
+/// the same words, the context has told the reader nothing and is dropped:
+/// a second identical line is worse than a short one.
+fn disambiguating_context(nodes: &[TreeNode], idx: usize) -> Option<String> {
+    let me = &nodes[idx];
+    if me.ref_id.is_none() || me.name.trim().is_empty() || !is_interactive_role(&me.role) {
+        return None;
+    }
+    let twins: Vec<usize> = nodes
+        .iter()
+        .enumerate()
+        .filter(|(j, n)| *j != idx && n.ref_id.is_some() && n.role == me.role && n.name == me.name)
+        .map(|(j, _)| j)
+        .collect();
+    if twins.is_empty() {
+        return None;
+    }
+    let mine = nearest_labelling_text(nodes, idx)?;
+    if twins
+        .iter()
+        .any(|&j| nearest_labelling_text(nodes, j).as_deref() == Some(mine.as_str()))
+    {
+        return None;
+    }
+    Some(mine)
+}
+
+/// Text from the nearest ancestor that holds this control and nothing else
+/// interactive — a card header, a table cell, a labelled row.
+///
+/// Stops at the first such ancestor rather than climbing to the widest one:
+/// the outer grid holds every card, and its text describes all of them equally.
+fn nearest_labelling_text(nodes: &[TreeNode], idx: usize) -> Option<String> {
+    let mut parent = nodes[idx].parent_idx;
+    for _ in 0..4 {
+        let root = parent?;
+        let node = &nodes[root];
+        if matches!(
+            node.role.as_str(),
+            "RootWebArea" | "WebArea" | "dialog" | "document"
+        ) {
+            return None;
+        }
+        parent = node.parent_idx;
+
+        let mut pending: Vec<usize> = node.children.iter().rev().copied().collect();
+        let mut visited = 0;
+        let mut controls = 0;
+        let mut text: Vec<String> = Vec::new();
+        while let Some(child) = pending.pop() {
+            visited += 1;
+            if visited > 64 {
+                return None;
+            }
+            let n = &nodes[child];
+            if is_interactive_role(&n.role) || n.cursor_info.is_some() {
+                controls += 1;
+                // More than this one control means the ancestor covers
+                // several actions, so its text does not belong to ours.
+                if controls > 1 {
+                    break;
+                }
+                continue;
+            }
+            if matches!(n.role.as_str(), "heading" | "StaticText") && !n.name.trim().is_empty() {
+                let value = n.name.split_whitespace().collect::<Vec<_>>().join(" ");
+                // The control's own name is not context for itself.
+                if value != nodes[idx].name && !text.contains(&value) {
+                    text.push(value);
+                }
+            } else {
+                pending.extend(n.children.iter().rev().copied());
+            }
+        }
+        if controls > 1 || text.is_empty() {
+            continue;
+        }
+        let joined = text.join(" | ");
+        let trimmed: String = joined.chars().take(120).collect();
+        return Some(if trimmed.len() < joined.len() {
+            format!("{trimmed} [truncated]")
+        } else {
+            trimmed
+        });
+    }
+    None
+}
+
 fn control_context(nodes: &[TreeNode], idx: usize) -> Option<String> {
     if !is_interactive_role(&nodes[idx].role) {
         return None;
@@ -2294,7 +2395,9 @@ fn render_tree(
     }
 
     if options.interactive {
-        if let Some(context) = control_context(nodes, idx) {
+        if let Some(context) =
+            control_context(nodes, idx).or_else(|| disambiguating_context(nodes, idx))
+        {
             if let Ok(encoded) = serde_json::to_string(&context) {
                 attrs.push(format!("context={}", encoded));
             }
@@ -3015,6 +3118,98 @@ mod tests {
         nodes[1].name = "字".repeat(600);
         let summary = status_summary(&nodes, 0);
         assert!(summary.len() <= 524 && summary.ends_with(" [truncated]"));
+    }
+
+    /// The real shape from #281: a card grid where every card header is just a
+    /// title and one button. `control_context` vouches for none of these
+    /// containers, so three cards rendered three identical `button "进入"`.
+    #[test]
+    fn duplicate_button_names_get_the_text_that_separates_them() {
+        let mut nodes = vec![
+            make_node("RootWebArea", "", None),
+            make_node("generic", "", Some(0)), // grid
+            make_node("generic", "", Some(1)), // card header A
+            make_node("StaticText", "飞行棋", Some(2)),
+            make_node("button", "进入", Some(2)),
+            make_node("generic", "", Some(1)), // card header B
+            make_node("StaticText", "H5 Games", Some(5)),
+            make_node("button", "进入", Some(5)),
+        ];
+        nodes[0].children = vec![1];
+        nodes[1].children = vec![2, 5];
+        nodes[2].children = vec![3, 4];
+        nodes[5].children = vec![6, 7];
+        nodes[4].ref_id = Some("e1".to_string());
+        nodes[7].ref_id = Some("e2".to_string());
+
+        assert_eq!(
+            control_context(&nodes, 4),
+            None,
+            "the plain shape is unchanged"
+        );
+        assert_eq!(disambiguating_context(&nodes, 4).as_deref(), Some("飞行棋"));
+        assert_eq!(
+            disambiguating_context(&nodes, 7).as_deref(),
+            Some("H5 Games")
+        );
+    }
+
+    /// A unique name needs no help — adding context there is pure noise, which
+    /// is why this is gated on duplication rather than applied everywhere.
+    #[test]
+    fn a_unique_name_gets_no_disambiguating_context() {
+        let mut nodes = vec![
+            make_node("RootWebArea", "", None),
+            make_node("generic", "", Some(0)),
+            make_node("StaticText", "飞行棋", Some(1)),
+            make_node("button", "进入", Some(1)),
+        ];
+        nodes[0].children = vec![1];
+        nodes[1].children = vec![2, 3];
+        nodes[3].ref_id = Some("e1".to_string());
+        assert_eq!(disambiguating_context(&nodes, 3), None);
+    }
+
+    /// Context that does not separate them is worse than none: it makes each
+    /// line longer while leaving the reader exactly as stuck.
+    #[test]
+    fn context_that_does_not_distinguish_is_dropped() {
+        let mut nodes = vec![
+            make_node("RootWebArea", "", None),
+            make_node("generic", "", Some(0)),
+            make_node("generic", "", Some(1)),
+            make_node("StaticText", "操作", Some(2)),
+            make_node("button", "删除", Some(2)),
+            make_node("generic", "", Some(1)),
+            make_node("StaticText", "操作", Some(5)),
+            make_node("button", "删除", Some(5)),
+        ];
+        nodes[0].children = vec![1];
+        nodes[1].children = vec![2, 5];
+        nodes[2].children = vec![3, 4];
+        nodes[5].children = vec![6, 7];
+        nodes[4].ref_id = Some("e1".to_string());
+        nodes[7].ref_id = Some("e2".to_string());
+        assert_eq!(disambiguating_context(&nodes, 4), None);
+        assert_eq!(disambiguating_context(&nodes, 7), None);
+    }
+
+    /// An ancestor holding several controls describes all of them equally, so
+    /// its text is not this control's label — climb no further.
+    #[test]
+    fn a_container_with_several_controls_is_not_a_label() {
+        let mut nodes = vec![
+            make_node("RootWebArea", "", None),
+            make_node("generic", "", Some(0)),
+            make_node("StaticText", "工具栏", Some(1)),
+            make_node("button", "保存", Some(1)),
+            make_node("button", "保存", Some(1)),
+        ];
+        nodes[0].children = vec![1];
+        nodes[1].children = vec![2, 3, 4];
+        nodes[3].ref_id = Some("e1".to_string());
+        nodes[4].ref_id = Some("e2".to_string());
+        assert_eq!(disambiguating_context(&nodes, 3), None);
     }
 
     #[test]

--- a/cli/src/native/snapshot.rs
+++ b/cli/src/native/snapshot.rs
@@ -3139,6 +3139,13 @@ mod tests {
         nodes[1].children = vec![2, 5];
         nodes[2].children = vec![3, 4];
         nodes[5].children = vec![6, 7];
+        nodes[1].parent_idx = Some(0);
+        nodes[2].parent_idx = Some(1);
+        nodes[3].parent_idx = Some(2);
+        nodes[4].parent_idx = Some(2);
+        nodes[5].parent_idx = Some(1);
+        nodes[6].parent_idx = Some(5);
+        nodes[7].parent_idx = Some(5);
         nodes[4].ref_id = Some("e1".to_string());
         nodes[7].ref_id = Some("e2".to_string());
 
@@ -3166,6 +3173,9 @@ mod tests {
         ];
         nodes[0].children = vec![1];
         nodes[1].children = vec![2, 3];
+        nodes[1].parent_idx = Some(0);
+        nodes[2].parent_idx = Some(1);
+        nodes[3].parent_idx = Some(1);
         nodes[3].ref_id = Some("e1".to_string());
         assert_eq!(disambiguating_context(&nodes, 3), None);
     }
@@ -3188,6 +3198,13 @@ mod tests {
         nodes[1].children = vec![2, 5];
         nodes[2].children = vec![3, 4];
         nodes[5].children = vec![6, 7];
+        nodes[1].parent_idx = Some(0);
+        nodes[2].parent_idx = Some(1);
+        nodes[3].parent_idx = Some(2);
+        nodes[4].parent_idx = Some(2);
+        nodes[5].parent_idx = Some(1);
+        nodes[6].parent_idx = Some(5);
+        nodes[7].parent_idx = Some(5);
         nodes[4].ref_id = Some("e1".to_string());
         nodes[7].ref_id = Some("e2".to_string());
         assert_eq!(disambiguating_context(&nodes, 4), None);
@@ -3207,6 +3224,10 @@ mod tests {
         ];
         nodes[0].children = vec![1];
         nodes[1].children = vec![2, 3, 4];
+        nodes[1].parent_idx = Some(0);
+        nodes[2].parent_idx = Some(1);
+        nodes[3].parent_idx = Some(1);
+        nodes[4].parent_idx = Some(1);
         nodes[3].ref_id = Some("e1".to_string());
         nodes[4].ref_id = Some("e2".to_string());
         assert_eq!(disambiguating_context(&nodes, 3), None);


### PR DESCRIPTION
Closes #281。顺带修了用户反馈的「chrome-use 被管理后无法手动升级」。

## #281：重名控件补一段能区分彼此的上下文

真实页面上三个 `button "进入"` 一模一样，而游戏名就在 DOM 往上两跳的 `.card-header` 里。调用方只能自己 `eval` 爬 DOM —— 那正是 @ref 体系该替它做的事。

`control_context`（#246）只为它能担保的容器说话：语义化的 `article`/`listitem`/`row`、带 heading 的、或「一个链接 + 一个控件」的商品卡。卡头是「一个标题 + 一个按钮」，三条都不满足，于是跳过。

补的这条**只在重名时生效** —— 名字唯一时不需要帮助，名字重复时不给就等于让调用方去猜。容器判据相应放宽：文本 + 这一个控件；祖先里控件多于一个就停下（它的文本对每个控件都成立，不属于其中任何一个）。

**最后一条约束是重点：补出来的上下文必须真的把它们分开。** 同名兄弟拿到同样的文字时整条丢弃 —— 每行变长而读者一样卡住，比短一行更糟。

### 真实页面前后对照

```
修复前   - button "进入" [ref=e10]
        - button "进入" [ref=e11]
        - button "进入" [ref=e12]

修复后   - button "进入" [ref=e8,  context="Win In Future"]
        - button "进入" [ref=e9,  context="H5 Games"]
        - button "进入" [ref=e10, context="飞行棋"]
```

四条单测：真实的卡片网格形状、名字唯一时不补、补了还一样时丢弃、祖先含多个控件时不算标签。

## 顺带：受管理安装下别再让人去点一个不存在的按钮

用户反馈「chrome-use 被你管理后，无法手动升级了」。**属实，而且刚发的两处提示正在加剧它** —— doctor 和中继失败提示都写着「chrome://extensions → Developer mode → Update」，而策略强装的扩展**在它自己那一行上根本没有更新和移除控件**。让人去点一个不存在的按钮，比不给建议更糟：读起来就是「这个工具把我的升级能力拿走了」。

代码里早有受管理分支（`stale_extension_hint` 带 `managed_install`），但只有 `extension status` 用了；doctor 和我新加的提示各自硬编码了那句话。抽成 `update_instruction()` 三处共用：策略安装时说明要用**工具栏上**的 Update 按钮（不是扩展行），或重启 Chrome，并说明 Chrome 会按自己的节奏更新且不弹权限确认。

## 一处自查

#281 的四个测试一开始全挂：`make_node` 的第三个参数是 `backend_node_id` 不是 `parent_idx`，我按位置传了父节点索引，于是 `parent_idx` 全是 `None`。**测试挂在自己的脚手架上，不是被测逻辑** —— 值得记一笔，因为一个「测试红了」的第一反应通常是去改实现。

190 上 1321 通过，clippy 干净。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidance for updating outdated browser extensions, including tailored instructions for policy-managed installations.
  * Updated diagnostics to provide the appropriate extension update steps.
  * Improved accessibility context for duplicated interactive controls by displaying nearby distinguishing labels when available.
  * Added coverage to verify extension update guidance and control disambiguation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->