### PR TITLE
fix(ci): secrets 不能用在 step 的 if 里，整个工作流会被拒绝

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -48,6 +48,12 @@ jobs:
     needs: validate
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    # The `secrets` context is NOT allowed in a step-level `if:` — a workflow
+    # that uses it there is rejected wholesale, with no jobs and no log to read.
+    # Hoisting the check into a job-level env var is the supported form, and the
+    # one leeguooooo/iphone-use already uses.
+    env:
+      HAS_SIGNING: ${{ secrets.APPLE_SIGNING_CERTIFICATE != '' && secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD != '' && secrets.APPLE_SIGN_IDENTITY != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -115,7 +121,7 @@ jobs:
       # Skipped, not failed, when the secrets are absent: a fork building a tag
       # has no certificate, and an unsigned build is still a usable build.
       - name: Sign and notarize (macOS)
-        if: startsWith(matrix.os, 'macos') && secrets.APPLE_SIGNING_CERTIFICATE != ''
+        if: startsWith(matrix.os, 'macos') && env.HAS_SIGNING == 'true'
         env:
           # Same secret names as leeguooooo/iphone-use, which already signs and
           # notarizes this way — one convention across the repos, not two.


### PR DESCRIPTION
v1.5.114 的发布跑挂了，症状很特别：run 里**一个 job 都没有**，`gh run view --log-failed` 说 `log not found`，run 的 `name` 是文件路径而不是工作流名。那是「工作流文件本身无效」的样子，不是某一步失败。

原因：**`secrets` 上下文在 step 级 `if:` 里不被允许**。GitHub 不是忽略这个表达式，而是拒绝整个文件。

`leeguooooo/iphone-use` 早就用对了模式 —— job 级 `env` 先算好布尔值，`if` 再读 `env`。我照抄了它的 secret 命名，却没照抄这一处。**抄一半比不抄危险**：命名一致让它看起来是同一套做法，而关键的那处不是。

改成：

```yaml
env:
  HAS_SIGNING: ${{ secrets.APPLE_SIGNING_CERTIFICATE != '' && … }}
...
        if: startsWith(matrix.os, 'macos') && env.HAS_SIGNING == 'true'
```

合并后重新触发 `v1.5.114` 的发布构建。