### PR TITLE
docs(readme): 修正 Codex 说明块的闭合围栏

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ npx skills add leeguooooo/chrome-use -g
 >
 > ```text
 > Use the `chrome-use` CLI from the shell for every browser task; start with `chrome-use skills get core`. Do not use the built-in Chrome plugin for browser work here.
-> ```text
+> ```
 
 Either way the agent gets the right usage patterns and pre-approved bash permissions for `chrome-use` and `abs`; the skill self-heals a missing binary by re-running the `install.sh` one-liner above. Specialized guides (`electron`, `slack`, `agentcore`, …) are served by the binary itself via `chrome-use skills get <name>`, so instructions always match the installed version.
 


### PR DESCRIPTION
#291 里 sed 把开合两处围栏都改成了 ```text，amend 时又漏了 -a。一行修正。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf