### PR TITLE
ci(ext): Chrome Web Store API 发布脚本 + 手动工作流

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,51 @@
+# Publish ab-connect to the Chrome Web Store from CI, so a release never depends
+# on someone being at a logged-in Mac. Manual trigger only (workflow_dispatch):
+# publishing is deliberate, never a side effect of a push.
+#
+# One-time: add three repository secrets (Settings → Secrets and variables →
+# Actions), the same values as .secrets/cws.env locally:
+#   CWS_CLIENT_ID  CWS_CLIENT_SECRET  CWS_REFRESH_TOKEN
+# See scripts/publish-extension.sh for how to obtain them.
+name: Publish extension (Chrome Web Store)
+
+on:
+  workflow_dispatch:
+    inputs:
+      draft:
+        description: "Upload only, do not submit for review"
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify the packaged zip matches the manifest version
+        run: |
+          python3 - <<'PY'
+          import json, zipfile
+          m = json.load(open("extensions/ab-connect/manifest.json"))["version"]
+          z = json.loads(zipfile.ZipFile("extensions/ab-connect.zip").read("manifest.json"))["version"]
+          assert m == z, f"manifest {m} != zip {z}; run scripts/pack-extension.sh and commit the zip"
+          assert "key" not in json.loads(zipfile.ZipFile("extensions/ab-connect.zip").read("manifest.json")), "zip must not contain manifest key"
+          print(f"ab-connect {z} ready to publish")
+          PY
+      - name: Publish
+        env:
+          CWS_CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
+        run: |
+          if [ -z "$CWS_CLIENT_ID" ]; then
+            echo "::error::CWS_CLIENT_ID / CWS_CLIENT_SECRET / CWS_REFRESH_TOKEN secrets are not set." >&2
+            exit 1
+          fi
+          if [ "${{ inputs.draft }}" = "true" ]; then
+            sh scripts/publish-extension.sh --draft
+          else
+            sh scripts/publish-extension.sh
+          fi

--- a/scripts/cws-get-refresh-token.sh
+++ b/scripts/cws-get-refresh-token.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# One-time: exchange a Google OAuth consent for a Chrome Web Store refresh token.
+# Run this once after creating a "Desktop app" OAuth client (see
+# scripts/publish-extension.sh header). The refresh token it prints goes into
+# .secrets/cws.env as CWS_REFRESH_TOKEN and is reused for every future publish.
+#
+#   sh scripts/cws-get-refresh-token.sh <CLIENT_ID> <CLIENT_SECRET>
+#
+# Uses a localhost loopback redirect (Google deprecated the old out-of-band
+# copy-paste flow). A Desktop-app OAuth client allows loopback automatically.
+# It opens the consent URL in your browser; you approve; the local listener
+# catches the code and exchanges it. The only value printed is the refresh
+# token; nothing is stored by this script.
+set -eu
+
+CLIENT_ID="${1:?usage: cws-get-refresh-token.sh <CLIENT_ID> <CLIENT_SECRET>}"
+CLIENT_SECRET="${2:?usage: cws-get-refresh-token.sh <CLIENT_ID> <CLIENT_SECRET>}"
+
+CWS_CLIENT_ID="$CLIENT_ID" CWS_CLIENT_SECRET="$CLIENT_SECRET" python3 - <<'PY'
+import http.server, os, secrets, urllib.parse, urllib.request, webbrowser, sys, json
+
+CLIENT_ID = os.environ["CWS_CLIENT_ID"]
+CLIENT_SECRET = os.environ["CWS_CLIENT_SECRET"]
+SCOPE = "https://www.googleapis.com/auth/chromewebstore"
+PORT = 8770
+REDIRECT = f"http://127.0.0.1:{PORT}"
+state = secrets.token_urlsafe(16)
+
+auth_url = "https://accounts.google.com/o/oauth2/auth?" + urllib.parse.urlencode({
+    "response_type": "code", "access_type": "offline", "prompt": "consent",
+    "client_id": CLIENT_ID, "redirect_uri": REDIRECT, "scope": SCOPE, "state": state,
+})
+
+code = {}
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        q = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+        self.send_response(200); self.send_header("Content-Type", "text/plain; charset=utf-8"); self.end_headers()
+        if q.get("state", [""])[0] == state and "code" in q:
+            code["v"] = q["code"][0]
+            self.wfile.write("Done — you can close this tab and return to the terminal.".encode())
+        else:
+            self.wfile.write(f"OAuth error: {q.get('error', ['unknown'])[0]}".encode())
+    def log_message(self, *a):
+        pass
+
+print("Opening the consent screen in your browser. Approve it there.")
+print(f"If it does not open, paste this URL yourself:\n\n  {auth_url}\n")
+try:
+    webbrowser.open(auth_url)
+except Exception:
+    pass
+
+srv = http.server.HTTPServer(("127.0.0.1", PORT), Handler)
+while "v" not in code:
+    srv.handle_request()
+
+resp = urllib.request.urlopen(urllib.request.Request(
+    "https://oauth2.googleapis.com/token",
+    data=urllib.parse.urlencode({
+        "client_id": CLIENT_ID, "client_secret": CLIENT_SECRET,
+        "code": code["v"], "grant_type": "authorization_code", "redirect_uri": REDIRECT,
+    }).encode(),
+))
+d = json.load(resp)
+rt = d.get("refresh_token")
+if not rt:
+    print("failed:", d, file=sys.stderr); sys.exit(1)
+print("\nCWS_REFRESH_TOKEN=" + rt)
+print("\nAdd that line (plus CWS_CLIENT_ID and CWS_CLIENT_SECRET) to .secrets/cws.env")
+PY

--- a/scripts/publish-extension.sh
+++ b/scripts/publish-extension.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# Publish extensions/ab-connect.zip to the Chrome Web Store through its REST API.
+# No browser, no clicking — the whole point is that this runs the same from a
+# laptop or from CI, so 0.5.26, 0.5.27 … are one command, never a manual upload.
+#
+# Chrome forbids CDP on the Web Store gallery, so chrome-use itself cannot drive
+# the developer console. This API path is the supported alternative.
+#
+# ── One-time setup (does NOT repeat per release) ─────────────────────────────
+#   1. https://console.cloud.google.com → create/pick a project.
+#   2. APIs & Services → Library → enable "Chrome Web Store API".
+#   3. APIs & Services → OAuth consent screen → External, add yourself as a test
+#      user (the app can stay in "testing"; a test-user refresh token does not
+#      expire for this use).
+#   4. Credentials → Create credentials → OAuth client ID → type "Desktop app".
+#      Note the client ID and client secret.
+#   5. Get a refresh token once:  sh scripts/cws-get-refresh-token.sh
+#   6. Save all three to .secrets/cws.env (gitignored):
+#        CWS_CLIENT_ID=...
+#        CWS_CLIENT_SECRET=...
+#        CWS_REFRESH_TOKEN=...
+#
+# ── Every release ────────────────────────────────────────────────────────────
+#        sh scripts/pack-extension.sh          # build the 0.5.x zip
+#        sh scripts/publish-extension.sh       # upload + submit for review
+#   Add --draft to upload without submitting (leaves it as a draft in the console).
+#
+# Credentials come from .secrets/cws.env or the environment (so CI can supply
+# them as secrets). Nothing is ever printed.
+set -eu
+
+cd "$(dirname "$0")/.."
+ITEM_ID="knfcmbamhjmaonkfnjhldjedeobeafmk"   # the published (store) extension id
+ZIP="extensions/ab-connect.zip"
+ENV_FILE=".secrets/cws.env"
+DRAFT=0
+[ "${1:-}" = "--draft" ] && DRAFT=1
+
+[ -f "$ZIP" ] || { echo "error: $ZIP not found — run scripts/pack-extension.sh first" >&2; exit 1; }
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+fi
+: "${CWS_CLIENT_ID:?set CWS_CLIENT_ID (see the setup notes at the top of this script)}"
+: "${CWS_CLIENT_SECRET:?set CWS_CLIENT_SECRET}"
+: "${CWS_REFRESH_TOKEN:?set CWS_REFRESH_TOKEN}"
+
+VER=$(python3 -c "import json;print(json.load(open('extensions/ab-connect/manifest.json'))['version'])")
+echo "→ publishing ab-connect $VER ($(wc -c <"$ZIP" | tr -d ' ') bytes) to item $ITEM_ID"
+
+# 1. refresh token → short-lived access token (never printed)
+ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+  -d "client_id=$CWS_CLIENT_ID" \
+  -d "client_secret=$CWS_CLIENT_SECRET" \
+  -d "refresh_token=$CWS_REFRESH_TOKEN" \
+  -d "grant_type=refresh_token" \
+  | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('access_token') or '')")
+[ -n "$ACCESS_TOKEN" ] || { echo "error: token refresh failed — check the three CWS_* values" >&2; exit 1; }
+
+# 2. upload the new package
+echo "→ uploading package…"
+UP=$(curl -s -X PUT \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "x-goog-api-version: 2" \
+  -T "$ZIP" \
+  "https://www.googleapis.com/upload/chromewebstore/v1.1/items/$ITEM_ID?uploadType=media")
+echo "$UP" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+state=d.get('uploadState')
+print('   uploadState:', state)
+if state not in ('SUCCESS',):
+    for e in d.get('itemError',[]) or []:
+        print('   error:', e.get('error_code'), e.get('error_detail'))
+    sys.exit(1)
+"
+
+if [ "$DRAFT" = 1 ]; then
+  echo "✓ uploaded as a draft (not submitted). Review and publish in the developer console."
+  exit 0
+fi
+
+# 3. submit for review / publish
+echo "→ submitting for review…"
+PUB=$(curl -s -X POST \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "x-goog-api-version: 2" \
+  -H "Content-Length: 0" \
+  "https://www.googleapis.com/chromewebstore/v1.1/items/$ITEM_ID/publish")
+echo "$PUB" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+st=d.get('status') or []
+print('   status:', ', '.join(st) if st else d)
+detail=d.get('statusDetail') or []
+for s in detail: print('   ', s)
+# OK / ITEM_PENDING_REVIEW are both success; anything else is a real failure.
+ok={'OK','ITEM_PENDING_REVIEW'}
+sys.exit(0 if (set(st) & ok) else 1)
+"
+echo "✓ ab-connect $VER submitted for Chrome Web Store review."


### PR DESCRIPTION
Chrome 禁止对 `chrome.google.com/webstore` 做 CDP（实测：relay 报 `The extensions gallery cannot be scripted`），所以 chrome-use 自己驱动不了开发者控制台。官方 REST API 是支持的替代：没有浏览器、没有点击，笔记本和 CI 一样一条命令。以后 0.5.26 / 0.5.27 不再手工上传。

- `scripts/publish-extension.sh`：refresh token → 上传 `extensions/ab-connect.zip` → 提交审核。凭证从 `.secrets/cws.env`（已 gitignore）或环境变量读，任何值都不打印。`--draft` 只上传不提交。
- `scripts/cws-get-refresh-token.sh`：一次性拿 refresh token，用 localhost 回环（Google 已废弃 OOB 复制粘贴流），只打印 token。
- `.github/workflows/publish-extension.yml`：`workflow_dispatch` 手动触发，先校验 zip 版本与 manifest 一致且不含 `key`，再发布；凭证走仓库 secrets。

一次性设置（Google Cloud 建项目、开 Chrome Web Store API、建 Desktop OAuth 客户端、取 token）写在 `publish-extension.sh` 头部。本地已验证脚本语法、缺凭证时干净报错、坏 token 时干净报错；真正发布要等作者提供凭证。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf