### PR TITLE
docs(site): 拆成 CLI 更新日志 + 插件更新日志（中/英）

### DIFF
--- a/docs/assets/docs/docs.js
+++ b/docs/assets/docs/docs.js
@@ -126,6 +126,8 @@
     { id: "ref", label: { zh: "参考", en: "Reference" }, items: [
       { slug: "commands",        ico: "📚", zh: "命令参考",   en: "Command Reference",  kw: "commands cli flags reference 命令 参考" },
       { slug: "troubleshooting", ico: "🩹", zh: "故障排查",   en: "Troubleshooting",    kw: "troubleshoot debug relay error 故障 排查" },
+      { slug: "changelog",           ico: "📝", zh: "CLI 更新日志",  en: "CLI Changelog",       kw: "changelog cli version release history 更新 版本 日志 发版" },
+      { slug: "extension-changelog", ico: "🧩", zh: "插件更新日志",  en: "Extension Changelog", kw: "changelog extension ab-connect plugin version 0.5 更新 扩展 插件 版本 日志" },
       { slug: "family",          ico: "🧩", zh: "*-use 家族", en: "The *-use Family",   kw: "family iphone-use cookie-use bitwarden 家族" },
       { slug: "lineage",         ico: "🌱", zh: "血统与上游", en: "Lineage & Upstream", kw: "fork upstream vercel agent-browser apache license attribution 上游 分叉 血统 许可证 出身" },
     ]},

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <title>更新日志 · chrome-use 文档</title>
+  <title>CLI 更新日志 · chrome-use 文档</title>
   <meta name="description" content="chrome-use 版本更新日志：会话生命周期路由修复、Nix 打包、Monaco 编辑器写入校验，以及近期版本要点。" />
 
   <!-- SEO / social -->
@@ -46,7 +46,7 @@
       <p class="du-eyebrow">参考 / Reference</p>
 
       <div class="du-title-row">
-        <h1>更新日志</h1>
+        <h1>CLI 更新日志</h1>
         <button class="du-copy-page" type="button" aria-label="复制页面">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
           <span class="du-copy-page-label">复制页面</span>
@@ -63,6 +63,13 @@
         <div class="du-callout-title">ℹ️ 逐条 commit diff：GitHub Releases</div>
         这一页按版本汇总了每次改动的要点。想看某个版本的完整 diff，去
         <a href="https://github.com/leeguooooo/chrome-use/releases">GitHub Releases</a>。
+      </div>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">🧩 找扩展（插件）的版本？</div>
+        这一页是 <strong>CLI</strong>（<code>chrome-use</code> 命令行）的版本历史。驱动真实 Chrome 的
+        <strong>ab-connect 扩展</strong>有它自己的版本号（<code>0.5.x</code>），单独一页：
+        <a href="/extension-changelog.html">插件更新日志</a>。
       </div>
 
       <hr class="du-divider" />

--- a/docs/en/changelog.html
+++ b/docs/en/changelog.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <title>Changelog · chrome-use docs</title>
+  <title>CLI Changelog · chrome-use docs</title>
   <meta name="description" content="chrome-use release notes: restored session lifecycle routing, Nix packaging, verified Monaco editor fills, and other recent highlights." />
 
   <!-- SEO / social -->
@@ -46,7 +46,7 @@
       <p class="du-eyebrow">Reference</p>
 
       <div class="du-title-row">
-        <h1>Changelog</h1>
+        <h1>CLI Changelog</h1>
         <button class="du-copy-page" type="button" aria-label="Copy page">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
           <span class="du-copy-page-label">Copy page</span>
@@ -64,6 +64,14 @@
         <div class="du-callout-title">ℹ️ Commit-level diffs: GitHub Releases</div>
         This page rolls up the highlights per version. For the full diff of any single release, see
         <a href="https://github.com/leeguooooo/chrome-use/releases">GitHub Releases</a>.
+      </div>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">🧩 Looking for the extension (plugin)?</div>
+        This page is the <strong>CLI</strong> (<code>chrome-use</code> command line) history. The
+        <strong>ab-connect extension</strong> that drives real Chrome has its own version numbers
+        (<code>0.5.x</code>) on a separate page:
+        <a href="/en/extension-changelog.html">Extension Changelog</a>.
       </div>
 
       <hr class="du-divider" />

--- a/docs/en/extension-changelog.html
+++ b/docs/en/extension-changelog.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Extension Changelog · chrome-use docs</title>
+  <meta name="description" content="Version history of the ab-connect extension (the browser plugin that drives real Chrome): from 0.5.25's generic ABExt.call door back through self-update, attached-tab reporting, and the no-debugger-banner work, newest first." />
+  <meta name="theme-color" content="#fcfbf4" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="chrome-use docs" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=ZCOOL+KuaiLe&family=Permanent+Marker&family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/docs/docs.css" />
+</head>
+
+<body data-page="extension-changelog" data-lang="en">
+  <div id="du-topbar"></div>
+  <div class="du-shell">
+    <nav id="du-sidebar"></nav>
+    <main class="du-main">
+
+      <p class="du-eyebrow">Reference</p>
+      <div class="du-title-row">
+        <h1>Extension Changelog</h1>
+        <button class="du-copy-page" type="button" aria-label="Copy page">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
+          <span class="du-copy-page-label">Copy page</span>
+        </button>
+      </div>
+
+      <p class="du-lede">
+        <strong>ab-connect</strong> is the browser extension that drives your real Chrome, talking to the
+        CLI over native messaging. It has <span class="mark">its own version numbers</span>
+        (<code>0.5.x</code>), separate from the CLI. <code>chrome-use extension status</code> shows which
+        version is installed and which the store serves. Since 0.5.23 the extension asks Chrome to check
+        for updates itself, so most users never update it by hand.
+      </p>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">📝 Looking for the CLI?</div>
+        This page is the <strong>extension</strong> history. The <code>chrome-use</code> command line's own
+        versions (<code>1.5.x</code>) are on the <a href="/en/changelog.html">CLI Changelog</a>. The two ship
+        independently: the extension through the Chrome Web Store, the CLI through GitHub Releases.
+      </div>
+
+      <hr class="du-divider" />
+
+      <h2>0.5.x</h2>
+      <ul class="du-changelog">
+        <li><strong>0.5.25</strong> (2026-09-10): one generic door, <code>ABExt.call</code> — a CLI feature
+          that only needs an allow-listed <code>chrome.tabs / tabGroups / windows / downloads / webNavigation</code>
+          method no longer needs a new extension release. Mutating calls are allowed only on tabs the agent
+          created (adopted tabs stay read-only, <code>windows.create/remove</code> are refused, and
+          <code>debugger / identity / storage / runtime / management</code> are never reachable this way). New
+          <code>ABExt.state</code> returns everything the extension holds, owns and is configured to in one call.
+          Permissions unchanged, so the update installs without re-approval (#294).</li>
+        <li><strong>0.5.24</strong> (2026-09-09): <code>tabs</code> reports the tab the relay is
+          <strong>actually attached to</strong>, not only the one the session requested, and speaks up when the two
+          disagree — so a dropped relay tab no longer reads like a permissions bug (#279).</li>
+        <li><strong>0.5.23</strong> (2026-09-09): <strong>self-update</strong> — the extension asks Chrome to
+          check the store instead of waiting for its own multi-hour schedule, and applies a downloaded update the
+          moment no tab is attached. No new permission; an update that never finds a quiet moment is applied by
+          Chrome when the worker stops (#272).</li>
+        <li><strong>0.5.22</strong> (2026-09-09): raised the trustworthiness of relay recovery, observations, and
+          connection status.</li>
+        <li><strong>0.5.21</strong> (2026-09-08): tab-group naming for <code>session name</code> — name the session
+          at the start of a task, before opening tabs (#236).</li>
+        <li><strong>0.5.20</strong> (2026-09-04): fixed a batch of upload, select, idle and relay regressions (#212).</li>
+        <li><strong>0.5.19</strong> (2026-09-02): fixed #201–#206 (idle detach, press/xpath, CJK read-back, click
+          focus, cwd session, shadow-DOM snapshot).</li>
+        <li><strong>0.5.18</strong> (2026-08-30): converged relay, ref and macOS leak issues; an explicit
+          <code>open</code>/<code>navigate</code> now recovers a renderer-scoped <code>Page.navigate</code> timeout
+          through Chrome's browser-level tab API, keeping the same session and tab (#198).</li>
+        <li><strong>0.5.17</strong> (2026-08-24): store package, permission notes completed.</li>
+        <li><strong>0.5.16</strong> (2026-07-31): fixed recording, snapshot, find and frozen-tab issues; the
+          <code>tab inspect</code> probe channel dates from here (#151 #154–#157).</li>
+        <li><strong>0.5.14 – 0.5.15</strong> (2026-07-28): fixed open-relay, dialog, status and site-adapter issues,
+          plus release-review follow-ups.</li>
+        <li><strong>0.5.13</strong> (2026-07-24): native downloads and a versioned local HTTP API (#132).</li>
+        <li><strong>0.5.12</strong> (2026-07-16): agent tabs open in a <strong>dedicated window</strong> by default,
+          plus a smarter default profile choice (#120).</li>
+        <li><strong>0.5.10</strong> (2026-07-06): traffic links in the popup footer; silenced the native-host lastError.</li>
+        <li><strong>0.5.9</strong> (2026-07-02): added <code>identity</code> / <code>identity.email</code> so the hello
+          carries the profile's account email.</li>
+        <li><strong>0.5.8</strong> (2026-06-30): pierced the OAuth GSI sign-in iframe (OOPIF) and early-attached login popups.</li>
+        <li><strong>0.5.7</strong> (2026-06-29): reconnect the relay on wake-from-sleep via <code>chrome.idle</code> (#72).</li>
+        <li><strong>0.5.6</strong> (2026-06-29): stopped persisting adopted tabs, clearing a stuck "debugging this browser" banner (#71).</li>
+        <li><strong>0.5.5</strong> (2026-06-28): <strong>attach only the agent's own tabs</strong> — no debugger banner on user pages (#68).</li>
+        <li><strong>0.5.4</strong> (2026-06-27): stopped the reattach retry storm on permanently-unattachable tabs (#64).</li>
+        <li><strong>0.5.3</strong> (2026-06-26): the hello reports which Chrome profile the relay is driving (#60).</li>
+        <li><strong>0.5.2</strong> (2026-06-26): a proactive 20s heartbeat so the MV3 worker never idle-drops the relay (#59).</li>
+        <li><strong>0.5.0 – 0.5.1</strong> (2026-06-24): icon and UX overhaul (friendly icon, polished popup, options page, agent cursor); rounded transparent icon.</li>
+      </ul>
+
+      <hr class="du-divider" />
+
+      <h2>0.4.x and earlier (early history)</h2>
+      <p>
+        The 0.4 series is where the relay was made reliable: a stable per-tab session id, auto-reconnect after a
+        cross-process detach, recovery of a churned-tabId session by its stable CDP <code>targetId</code>, loud
+        failure on a stale sessionId instead of routing to a random tab, plus <code>adopt</code> for pre-existing
+        tabs, group-scoped <code>Target.getTargets</code>, and default idle-shutdown with <code>keep</code>.
+        Before that, <code>0.1.0 – 0.3.0</code> (2026-06-09) laid the foundation: the MV3 connect extension adapted
+        from openclaw-browser-relay, the zero-token native-messaging transport, and force-install through a Chrome
+        config profile (no Load-unpacked).
+      </p>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ Per-commit diffs: GitHub</div>
+        This page summarizes each version. For the full diff of any extension version, see
+        <a href="https://github.com/leeguooooo/chrome-use/commits/main/extensions/ab-connect">ab-connect's commit history on GitHub</a>.
+      </div>
+
+    </main>
+    <aside id="du-toc"></aside>
+  </div>
+  <script src="/assets/docs/docs.js" defer></script>
+</body>
+</html>

--- a/docs/extension-changelog.html
+++ b/docs/extension-changelog.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>插件更新日志 · chrome-use 文档</title>
+  <meta name="description" content="ab-connect 扩展（驱动真实 Chrome 的浏览器插件）的版本历史：从 0.5.25 的通用直通 ABExt.call，到自更新、附着标签上报、无调试横幅等，按版本号新到旧排列。" />
+  <meta name="theme-color" content="#fcfbf4" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="chrome-use 文档" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=ZCOOL+KuaiLe&family=Permanent+Marker&family=Noto+Sans+SC:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/docs/docs.css" />
+</head>
+
+<body data-page="extension-changelog" data-lang="zh">
+  <div id="du-topbar"></div>
+  <div class="du-shell">
+    <nav id="du-sidebar"></nav>
+    <main class="du-main">
+
+      <p class="du-eyebrow">参考 / Reference</p>
+      <div class="du-title-row">
+        <h1>插件更新日志</h1>
+        <button class="du-copy-page" type="button" aria-label="复制页面">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3.5A1.5 1.5 0 009.5 2h-6A1.5 1.5 0 002 3.5v6A1.5 1.5 0 003.5 11H5"/></svg>
+          <span class="du-copy-page-label">复制页面</span>
+        </button>
+      </div>
+
+      <p class="du-lede">
+        <strong>ab-connect</strong> 是驱动你真实 Chrome 的浏览器扩展，通过原生消息和 CLI 通信。
+        它有<span class="mark">独立于 CLI 的版本号</span>（<code>0.5.x</code>）。
+        <code>chrome-use extension status</code> 会告诉你装的是哪个版本、商店发的是哪个版本。
+        0.5.23 起扩展会自己催 Chrome 检查更新，所以大多数用户无需手动升级。
+      </p>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">📝 找 CLI 的版本？</div>
+        这一页是<strong>扩展</strong>的历史。<code>chrome-use</code> 命令行本身的版本（<code>1.5.x</code>）在
+        <a href="/changelog.html">CLI 更新日志</a>。两者独立发布：扩展走 Chrome Web Store，CLI 走 GitHub Releases。
+      </div>
+
+      <hr class="du-divider" />
+
+      <h2>0.5.x</h2>
+      <ul class="du-changelog">
+        <li><strong>0.5.25</strong>（2026-09-10）：一扇通用的门 <code>ABExt.call</code> —— CLI 想调
+          <code>chrome.tabs / tabGroups / windows / downloads / webNavigation</code> 的白名单方法时，不再需要发一个新扩展版本。
+          改动类调用只允许作用在 agent 自己创建的标签上（adopted 标签只读、<code>windows.create/remove</code> 不开、
+          <code>debugger / identity / storage / runtime / management</code> 永远不经这扇门）。新增 <code>ABExt.state</code>，
+          一次返回扩展持有、拥有与配置的全部状态。权限不变，升级不触发重新授权（#294）。</li>
+        <li><strong>0.5.24</strong>（2026-09-09）：<code>tabs</code> 报出中继<strong>实际附着</strong>的标签，而不只是会话请求的那个；
+          两者不一致时明确出声，避免把中继掉标签的情况误读成权限问题（#279）。</li>
+        <li><strong>0.5.23</strong>（2026-09-09）：<strong>自更新</strong> —— 扩展主动请 Chrome 去商店查更新，
+          而不是等它自己的多小时排期；下载好的更新在没有标签附着时就地应用。不需要新权限；
+          一直找不到空隙的更新，会在 worker 停止时由 Chrome 应用（#272）。</li>
+        <li><strong>0.5.22</strong>（2026-09-09）：提高中继恢复、观察结果与连接状态的可信度。</li>
+        <li><strong>0.5.21</strong>（2026-09-08）：配合 <code>session name</code> 的标签组命名，任务开始、开标签之前先给会话起名（#236）。</li>
+        <li><strong>0.5.20</strong>（2026-09-04）：修复上传、select、idle 与中继的一批回归（#212）。</li>
+        <li><strong>0.5.19</strong>（2026-09-02）：修复 #201–#206（idle 分离、press/xpath、中文读回、点击移焦、cwd 会话、shadow-DOM 快照）。</li>
+        <li><strong>0.5.18</strong>（2026-08-30）：收敛中继、ref 与 macOS 泄漏问题；显式 <code>open</code>/<code>navigate</code> 遇到渲染器级
+          <code>Page.navigate</code> 超时时，通过浏览器级标签 API 恢复，保住同一会话和标签（#198）。</li>
+        <li><strong>0.5.17</strong>（2026-08-24）：上架包，权限说明补齐。</li>
+        <li><strong>0.5.16</strong>（2026-07-31）：修复录像、快照、find 与冻结标签的问题；<code>tab inspect</code> 的探测通道自此可用（#151 #154–#157）。</li>
+        <li><strong>0.5.14 – 0.5.15</strong>（2026-07-28）：修复开启中继、对话框、status 与站点适配器的问题，以及发版评审的跟进。</li>
+        <li><strong>0.5.13</strong>（2026-07-24）：原生下载与带版本的本地 HTTP API（#132）。</li>
+        <li><strong>0.5.12</strong>（2026-07-16）：默认把 agent 标签开在<strong>独立窗口</strong>里，加上更聪明的默认 profile 选择（#120）。</li>
+        <li><strong>0.5.10</strong>（2026-07-06）：popup 底部流量链接，静默原生宿主的 lastError。</li>
+        <li><strong>0.5.9</strong>（2026-07-02）：加 <code>identity</code> / <code>identity.email</code> 权限，让 hello 带上该 profile 的账号邮箱。</li>
+        <li><strong>0.5.8</strong>（2026-06-30）：穿透 OAuth GSI 登录 iframe（OOPIF），提前附着登录弹窗。</li>
+        <li><strong>0.5.7</strong>（2026-06-29）：通过 <code>chrome.idle</code> 在睡眠唤醒后重连中继（#72）。</li>
+        <li><strong>0.5.6</strong>（2026-06-29）：不再持久化 adopted 标签，清掉卡住的「正在调试此浏览器」横幅（#71）。</li>
+        <li><strong>0.5.5</strong>（2026-06-28）：<strong>只附着 agent 自己的标签</strong>，用户页面上不再出现调试横幅（#68）。</li>
+        <li><strong>0.5.4</strong>（2026-06-27）：对永远无法附着的标签停止重连风暴（#64）。</li>
+        <li><strong>0.5.3</strong>（2026-06-26）：hello 里报出中继正在驱动哪个 Chrome profile（#60）。</li>
+        <li><strong>0.5.2</strong>（2026-06-26）：主动 20 秒心跳，MV3 worker 不再空闲掉线中继（#59）。</li>
+        <li><strong>0.5.0 – 0.5.1</strong>（2026-06-24）：图标与 UX 翻新（友好图标、打磨的 popup、options 页、agent 光标），圆角透明图标。</li>
+      </ul>
+
+      <hr class="du-divider" />
+
+      <h2>0.4.x 与更早（早期历史）</h2>
+      <p>
+        0.4 系列是把中继做稳的一段：稳定的 per-tab 会话 id、跨进程分离后自动重连、
+        用稳定的 CDP <code>targetId</code> 恢复被换了 tabId 的会话、stale sessionId 时响亮失败而不是路由到随机标签、
+        以及 <code>adopt</code> 读取已有标签、按标签组 scope 的 <code>Target.getTargets</code>、默认空闲关闭 + <code>keep</code>。
+        再往前，<code>0.1.0 – 0.3.0</code>（2026-06-09）是奠基：从 openclaw-browser-relay 改写的 MV3 连接扩展、
+        零 token 的原生消息传输、以及通过 Chrome 配置 profile 强制安装（无需 Load-unpacked）。
+      </p>
+
+      <div class="du-callout note">
+        <div class="du-callout-title">ℹ️ 逐条 commit diff：GitHub</div>
+        这一页按版本汇总要点。想看某个扩展版本的完整 diff，去
+        <a href="https://github.com/leeguooooo/chrome-use/commits/main/extensions/ab-connect">GitHub 上 ab-connect 的提交历史</a>。
+      </div>
+
+    </main>
+    <aside id="du-toc"></aside>
+  </div>
+  <script src="/assets/docs/docs.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
文档站原来只有一个 changelog（CLI 的，1.5.x）。扩展版本（0.5.x）只在 CLI 条目里顺带提到，没有单独的历史。现在拆成两个：

- **CLI 更新日志**（原页改标题）：`chrome-use` 命令行的 1.5.x 历史，走 GitHub Releases。
- **插件更新日志**（新页 `/extension-changelog.html` + `/en/`）：ab-connect 扩展的 0.5.x 全量历史，走 Chrome Web Store。近几版详述（0.5.25 通用直通、0.5.23 自更新、0.5.5 无横幅等），0.4.x 及更早收进「早期历史」段，逐条 diff 指向 GitHub 上 ab-connect 的提交历史。

导航「参考」组加了两个条目；两页顶部互相交叉链接，并说明二者独立发布。本地在真实 Chrome 渲染过四个页面：标题、侧栏高亮、交叉链接都正确，`node -c docs.js` 通过。合并后需手动触发 Pages。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated CLI and browser extension changelog pages in English and Chinese.
  - Added navigation links and search keywords for both changelog pages.
  - Documented extension release history, versioning, automatic updates, and related resources.

- **Documentation**
  - Clarified that CLI and browser extension releases use separate version histories.
  - Updated existing changelog titles and headings to identify them specifically as CLI changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->