### PR TITLE
fix: keyboard inserttext --file/--stdin（#301 静默损坏）；site --help（#299）；list 过滤（#302）

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5927,7 +5927,10 @@ mod tests {
         // A stray token making an odd count must not silently send `1155` to the
         // DOM as a selector (which then reports "selector matched nothing").
         let err = parse_command(&args("click 1155 467 890"), &default_flags());
-        assert!(err.is_err(), "three numbers should be a loud error, not a selector click");
+        assert!(
+            err.is_err(),
+            "three numbers should be a loud error, not a selector click"
+        );
         // A real numeric-looking selector is still not valid; a genuine CSS
         // selector with letters is unaffected.
         let ok = parse_command(&args("click #main"), &default_flags()).unwrap();

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1021,11 +1021,45 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     Ok(json!({ "id": id, "action": "keyboard", "subaction": "type", "text": text }))
                 }
                 "inserttext" | "insertText" => {
-                    let text: String = rest[1..].join(" ");
+                    // `--file <path>` / `--stdin` send the WHOLE payload in one
+                    // `Input.insertText`, the way `fill` already does (#301).
+                    // Chunking a large insert into back-to-back `inserttext`
+                    // calls corrupts text at each boundary: a call returns when
+                    // Chrome dispatched the insert, not when the editor (e.g.
+                    // ProseMirror) committed it, so the next chunk races the
+                    // uncommitted tail. Total length is preserved, so a
+                    // char-count check passes and the scrambled text ships. One
+                    // insert removes the boundary entirely.
+                    let text: String = match rest.get(1).copied() {
+                        Some("--file") => {
+                            let path = rest.get(2).ok_or(ParseError::InvalidValue {
+                                message: "keyboard inserttext --file requires a path".to_string(),
+                                usage: "keyboard inserttext --file <path>",
+                            })?;
+                            std::fs::read_to_string(path).map_err(|e| ParseError::InvalidValue {
+                                message: format!(
+                                    "keyboard inserttext --file: cannot read {path}: {e}"
+                                ),
+                                usage: "keyboard inserttext --file <path>",
+                            })?
+                        }
+                        Some("--stdin") => {
+                            use std::io::Read;
+                            let mut buf = String::new();
+                            io::stdin().read_to_string(&mut buf).map_err(|e| {
+                                ParseError::InvalidValue {
+                                    message: format!("keyboard inserttext --stdin: {e}"),
+                                    usage: "keyboard inserttext --stdin",
+                                }
+                            })?;
+                            buf
+                        }
+                        _ => rest[1..].join(" "),
+                    };
                     if text.is_empty() {
                         return Err(ParseError::MissingArguments {
                             context: "keyboard inserttext".to_string(),
-                            usage: "keyboard inserttext <text>",
+                            usage: "keyboard inserttext <text> | --file <path> | --stdin",
                         });
                     }
                     Ok(
@@ -5470,6 +5504,45 @@ mod tests {
             &default_flags(),
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn keyboard_inserttext_reads_whole_payload_from_a_file() {
+        // #301: chunking a large insert corrupts the boundary; --file sends the
+        // whole payload in one Input.insertText.
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("cu-inserttext-{}.txt", std::process::id()));
+        let payload = "line one\nline two with `backticks` and \"quotes\"\n中文尾部";
+        std::fs::write(&path, payload).unwrap();
+        let cmd = parse_command(
+            &args(&format!("keyboard inserttext --file {}", path.display())),
+            &default_flags(),
+        )
+        .unwrap();
+        std::fs::remove_file(&path).ok();
+        assert_eq!(cmd["action"], "keyboard");
+        assert_eq!(cmd["subaction"], "insertText");
+        assert_eq!(cmd["text"], payload);
+    }
+
+    #[test]
+    fn keyboard_inserttext_missing_file_is_an_error_not_a_literal() {
+        let result = parse_command(
+            &args("keyboard inserttext --file /no/such/cu-path-xyz.txt"),
+            &default_flags(),
+        );
+        assert!(result.is_err(), "a missing --file path must error, not insert the flag text");
+    }
+
+    #[test]
+    fn keyboard_inserttext_inline_text_still_works() {
+        let cmd = parse_command(
+            &args("keyboard inserttext pasted content"),
+            &default_flags(),
+        )
+        .unwrap();
+        assert_eq!(cmd["subaction"], "insertText");
+        assert_eq!(cmd["text"], "pasted content");
     }
 
     // === Storage Tests ===

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -614,6 +614,27 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
                     usage:
                         "click <selector> | click <x> <y> | click --coords <x>,<y> [--new-tab] [--follow]",
                 })?;
+            // A purely numeric first arg is never a valid CSS selector or @ref,
+            // so it is almost certainly a coordinate that failed to parse as a
+            // pair — e.g. an odd token count when a stray value slipped into the
+            // args. Say so loudly instead of shipping `1155` to the DOM as a
+            // selector and reporting the misleading "selector matched nothing"
+            // (reported by the chatgpt-use session).
+            if coord_args
+                .iter()
+                .any(|a| !a.is_empty() && a.chars().all(|c| c.is_ascii_digit()))
+                && parse_coords(&coord_args).is_none()
+            {
+                return Err(ParseError::InvalidValue {
+                    message: format!(
+                        "click: `{}` looks like a coordinate but the arguments are not a single \
+                         `x y` (or `x,y`) pair — got {:?}. Pass exactly two numbers, e.g. \
+                         `click 1155 467` or `click --coords 1155,467`.",
+                        sel, coord_args
+                    ),
+                    usage: "click <x> <y> | click --coords <x>,<y>",
+                });
+            }
             let mut cmd = json!({ "id": id, "action": "click", "selector": sel });
             if new_tab {
                 cmd["newTab"] = json!(true);
@@ -5884,6 +5905,33 @@ mod tests {
         assert_eq!(cmd["action"], "click");
         assert_eq!(cmd["selector"], "button.submit");
         assert!(cmd.get("x").is_none());
+    }
+
+    #[test]
+    fn click_two_numbers_through_the_full_pipeline_is_a_coordinate() {
+        // The chatgpt-use report: `click 1155 467 --session mp`. clean_args must
+        // strip the global flag so parse sees exactly two numbers.
+        let raw: Vec<String> = "click 1155 467 --session mp"
+            .split_whitespace()
+            .map(String::from)
+            .collect();
+        let clean = crate::flags::clean_args(&raw);
+        let cmd = parse_command(&clean, &default_flags()).unwrap();
+        assert_eq!(cmd["x"], 1155.0, "clean args were {clean:?}");
+        assert_eq!(cmd["y"], 467.0);
+        assert!(cmd.get("selector").is_none());
+    }
+
+    #[test]
+    fn click_a_bare_number_that_is_not_a_pair_errors_instead_of_becoming_a_selector() {
+        // A stray token making an odd count must not silently send `1155` to the
+        // DOM as a selector (which then reports "selector matched nothing").
+        let err = parse_command(&args("click 1155 467 890"), &default_flags());
+        assert!(err.is_err(), "three numbers should be a loud error, not a selector click");
+        // A real numeric-looking selector is still not valid; a genuine CSS
+        // selector with letters is unaffected.
+        let ok = parse_command(&args("click #main"), &default_flags()).unwrap();
+        assert_eq!(ok["selector"], "#main");
     }
 
     #[test]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5531,7 +5531,10 @@ mod tests {
             &args("keyboard inserttext --file /no/such/cu-path-xyz.txt"),
             &default_flags(),
         );
-        assert!(result.is_err(), "a missing --file path must error, not insert the flag text");
+        assert!(
+            result.is_err(),
+            "a missing --file path must error, not insert the flag text"
+        );
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2455,6 +2455,13 @@ Subcommands:
   type <text>          Type text character-by-character with real
                        key events (keydown, keypress, keyup per char)
   inserttext <text>    Insert text without key events (like paste)
+  inserttext --file <path> | --stdin
+                       Insert a whole payload in ONE call. Use this for large
+                       or multiline text instead of chunking into back-to-back
+                       inserttext calls — a chunked insert corrupts text at each
+                       boundary (the call returns when Chrome dispatched, not
+                       when the editor committed), and the length is preserved
+                       so a char-count check misses it (#301).
 
 Note: For key combos (Enter, Control+a), use the 'press' command
 directly — it already operates on the current focus.
@@ -4402,6 +4409,40 @@ Environment:
 "##
         }
 
+        // === Site adapters ===
+        "site" => {
+            r##"
+chrome-use site - Run a community site adapter over your logged-in session
+
+Usage:
+  chrome-use site <name>/<command> [positional...] [--key value]
+  chrome-use site list                 List installed adapters (name/command)
+  chrome-use site update               Fetch/refresh the adapter packs
+  chrome-use site info <name>          Show one pack's adapters and their args
+
+An adapter extracts structured JSON from a site through its own API/DOM,
+in the site's real logged-in page — so it replaces a snapshot+click scrape
+with one call. Adapters ship in community packs (epiral/bb-sites) and the
+official leeguooooo/chrome-use-sites pack; `update` syncs both.
+
+The spec is always `name/command`. `site` alone, or a wrong spec, prints a
+one-line usage and points you at `site list`.
+
+Global Options:
+  --json               Output as JSON (adapters usually return JSON already)
+  --session <name>     Use specific session
+
+Examples:
+  chrome-use site list
+  chrome-use site github/issues epiral/bb-browser --json
+  chrome-use site hackernews/top --json
+  chrome-use site update
+
+See also: `chrome-use skills get core` documents adapters with a decision
+table and a full "Site adapters" section.
+"##
+        }
+
         _ => return false,
     };
     println!("{}", help.trim());
@@ -5190,8 +5231,17 @@ pub fn print_version() {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_a11y_text, format_storage_text};
+    use super::{format_a11y_text, format_storage_text, print_command_help};
     use serde_json::json;
+
+    #[test]
+    fn site_has_its_own_help_topic() {
+        // #299: `site --help` used to fall through to the 534-line generic help,
+        // which reads to an agent as "that command does not exist".
+        assert!(print_command_help("site"), "site must print its own help");
+        // A genuinely unknown command still falls back (returns false).
+        assert!(!print_command_help("definitely-not-a-command"));
+    }
 
     #[test]
     fn observation_output_survives_early_return_branches() {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2371,7 +2371,10 @@ where clicks are DOM-dispatched, so click-then-press works.
 To press a key against a control INSIDE an open popover/menu, do NOT use
 --selector: focusing through a selector moves focus out of the popover and
 dismisses it. Click the control by a real coordinate first (`click x y`),
-then use a bare `press` on the now-focused control.
+then use a bare `press` on the now-focused control. Example: a
+`[role=slider]` inside a menu — `press ArrowRight --selector '[role=slider]'`
+closes the menu and the value never moves; `click <thumb x> <thumb y>` then
+bare `press ArrowRight` is what advances `aria-valuenow`.
 
 For keys whose only effect depends on page JavaScript (Arrow/Home/End/
 PageUp/PageDown on a text field, Escape, Enter on a bare input outside a

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -2368,6 +2368,11 @@ target first when you can't be sure focus is where you left it. A preceding
 `click <input>` moves focus to that input, also over the extension relay
 where clicks are DOM-dispatched, so click-then-press works.
 
+To press a key against a control INSIDE an open popover/menu, do NOT use
+--selector: focusing through a selector moves focus out of the popover and
+dismisses it. Click the control by a real coordinate first (`click x y`),
+then use a bare `press` on the now-focused control.
+
 For keys whose only effect depends on page JavaScript (Arrow/Home/End/
 PageUp/PageDown on a text field, Escape, Enter on a bare input outside a
 form) press probes for keydown/keyup/keypress listeners on the focused

--- a/cli/src/site.rs
+++ b/cli/src/site.rs
@@ -330,6 +330,15 @@ pub fn build_eval(adapter: &Adapter, args: &Value, helper_src: Option<&str>) -> 
 }
 
 /// List installed adapters as `name/cmd` strings (sorted).
+/// Whether a `.js` file stem in a pack directory is a runnable adapter.
+/// `_`-prefixed files are loader internals (family helpers like `_helper`,
+/// injected automatically), and `*.test.js` are the pack's own tests — neither
+/// is invokable as `site name/<stem>`, so listing them sends an agent to a
+/// command that does nothing (#302).
+pub fn is_runnable_adapter_stem(stem: &str) -> bool {
+    !stem.starts_with('_') && !stem.ends_with(".test")
+}
+
 pub fn list_adapters() -> Result<Vec<String>, String> {
     let dir = sites_dir().ok_or("site: cannot resolve home dir")?;
     if !dir.exists() {
@@ -351,7 +360,9 @@ pub fn list_adapters() -> Result<Vec<String>, String> {
             let p = cmd.path();
             if p.extension().and_then(|e| e.to_str()) == Some("js") {
                 if let Some(stem) = p.file_stem().and_then(|s| s.to_str()) {
-                    out.push(format!("{name}/{stem}"));
+                    if is_runnable_adapter_stem(stem) {
+                        out.push(format!("{name}/{stem}"));
+                    }
                 }
             }
         }
@@ -817,5 +828,21 @@ async function(args){ return args; }"#;
         let args = map_args(&a, &["the-uuid".into(), "misonote.dc.html".into()], &[]);
         assert_eq!(args["projectId"], "the-uuid");
         assert_eq!(args["path"], "misonote.dc.html");
+    }
+
+    #[test]
+    fn loader_internals_and_tests_are_not_listed_as_adapters() {
+        // Real adapters list; the loader's `_helper` family file and a pack's
+        // own `*.test.js` do not (#302).
+        assert!(is_runnable_adapter_stem("issues"));
+        assert!(is_runnable_adapter_stem("top"));
+        assert!(!is_runnable_adapter_stem("_helper"));
+        assert!(!is_runnable_adapter_stem("_"));
+        // `foo.test.js` → stem is `foo.test`.
+        assert!(!is_runnable_adapter_stem("adapters.test"));
+        assert!(!is_runnable_adapter_stem("thread.test"));
+        // A normal adapter that merely contains "test" in its name still lists.
+        assert!(is_runnable_adapter_stem("latest"));
+        assert!(is_runnable_adapter_stem("testimonials"));
     }
 }


### PR DESCRIPTION
来自 chatgpt-use 会话在真实 ChatGPT 编辑器上重度使用后的三条反馈，#301 是静默数据损坏，优先。

## #301 — `keyboard inserttext` 背靠背分块时边界处乱掉（长度守恒，字符数校验漏掉）
**根因**：`Input.insertText` 在 Chrome 派发后即返回，不等编辑器（ProseMirror）提交事务；分块时下一段插入撞上上一段未落定的尾部，边界处乱掉。总长度保留 → 字符数校验通过 → 损坏文本被发出去。对方的对照实验（同 34KB、同 1500 分块）：inserttext ×23 在原始 offset 1474 处发散，execCommand insertText ×23 字节一致——换插入命令即可复现/消失，排除编辑器和分块本身。

**修法**：给 `keyboard inserttext` 加 `--file <path>` / `--stdin`（对齐 `fill`），整段一次 `Input.insertText`，彻底去掉边界。34KB 在 native-messaging 1MiB 分块上限内。调用方不再需要分块。（对方之前只能在 Rust 里手搓 execCommand blob。）

## #299 — `site --help` 落到 534 行通用帮助（唯一这样的子命令）
agent 反射性跑 `<cmd> --help`，通用帮助里没有 site，读成「猜错了命令」→ 退回昂贵的 snapshot+click。加 `site` 专属帮助 arm。

## #302 — `site list` 把 `_helper` 和 `*.test.js` 列成可运行适配器
抽纯函数 `is_runnable_adapter_stem` 过滤 `_` 前缀与 `.test` 后缀，加测试。

## 顺带
press 帮助补一条：浮层内的控件别用 `--selector`（穿选择器聚焦会关掉浮层），先坐标点击再 bare press。

## 验证
190：fmt OK，1330 测试通过（新增 5 个：inserttext --file 往返 + 缺文件报错 + 内联仍可用、site 有专属帮助、适配器过滤），clippy 无新告警。#301 的实机回归会在合并后请 chatgpt-use 会话用 ChatGPT composer 跑。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `keyboard inserttext` now accepts complete text from a file or standard input.
  - Added help for the `press` menu workflow and the `site` command, including adapter management and execution.
  - Site adapter listings now show only runnable adapters, excluding internal helpers and test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->