### PR TITLE
fix(ci): 扩展自动发布只把决定写进 GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -61,12 +61,19 @@ jobs:
           CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
           MANUAL: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          python3 - <<'PY'
           import json, os, urllib.parse, urllib.request, zipfile
           ITEM = "knfcmbamhjmaonkfnjhldjedeobeafmk"
           zver = json.loads(zipfile.ZipFile("extensions/ab-connect.zip").read("manifest.json"))["version"]
+          def decide(value):
+              # Only this line belongs in GITHUB_OUTPUT. Redirecting the whole
+              # script there made the ::notice:: line parse as an output
+              # assignment and failed the step ("Invalid format").
+              with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                  fh.write(f"publish={value}\n")
+
           if os.environ.get("MANUAL") == "true":
-              print("publish=true"); raise SystemExit
+              decide("true"); raise SystemExit
           tok = json.load(urllib.request.urlopen(urllib.request.Request(
               "https://oauth2.googleapis.com/token",
               data=urllib.parse.urlencode({
@@ -79,7 +86,7 @@ jobs:
               headers={"Authorization": f"Bearer {tok}", "x-goog-api-version": "2"})
           cur = json.load(urllib.request.urlopen(req)).get("crxVersion")
           print(f"::notice::store draft version {cur}, packaged {zver}")
-          print("publish=" + ("false" if cur == zver else "true"))
+          decide("false" if cur == zver else "true")
           PY
       - name: Publish
         if: steps.decide.outputs.publish == 'true'


### PR DESCRIPTION
自动发布工作流首次真实触发（0.5.26 的 zip 进 main）就失败了：

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '::notice::store draft version 0.5.25, packaged 0.5.26'
```

**判定逻辑本身是对的** —— 它正确读到商店草稿是 0.5.25、打包的是 0.5.26，会决定 `publish=true`。坏的是管线：我把整段 python 的 stdout 重定向进了 `$GITHUB_OUTPUT`，于是那行 `::notice::` 也被当成 `key=value` 输出赋值去解析。

改成在 python 里显式把 `publish=<v>` 追加进 `GITHUB_OUTPUT`，notice 留在 stdout。合并后 0.5.26 会自动提交审核（守卫会看到商店草稿 0.5.25 ≠ 打包 0.5.26，决定发布）。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf