### PR TITLE
fix: 大载荷插入超时不再谎报「连接失效」

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -4480,7 +4480,10 @@ mod tests {
         // caller to reconnect sent them after a stale service worker that was
         // not there (#301).
         let out = to_ai_friendly_error("CDP command timed out after 180s: Input.insertText");
-        assert!(out.contains("size limit, not a dead connection"), "got: {out}");
+        assert!(
+            out.contains("size limit, not a dead connection"),
+            "got: {out}"
+        );
         assert!(out.contains("do NOT reconnect"), "got: {out}");
         assert!(
             !out.contains("stale relay/service-worker"),

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -691,6 +691,20 @@ pub fn to_ai_friendly_error(error: &str) -> String {
     // `sessions` still reports the daemon alive (issue #117). Keep the concrete
     // failing method and spell out recovery instead of leaving a bare timeout.
     if lower.contains("timed out") {
+        // A payload-sized command that ran out its (payload-scaled) budget is a
+        // different situation: the connection is fine, the command legitimately
+        // needed longer than we allowed. Sending that caller to `connect` or to
+        // hunt a stale service worker is the wrong direction — reported from
+        // live use after a 150 KB insert hit the daemon budget (#301).
+        if lower.contains("input.inserttext") {
+            return format!(
+                "{error}\nHint: this is a size limit, not a dead connection. `Input.insertText` \
+                 costs time per character (~0.45s/KB in a rich editor), and this payload needed \
+                 more than the budget. The connection is fine — do NOT reconnect. Insert less at \
+                 once (split the text and send it as separate `keyboard inserttext` calls, \
+                 re-reading the field between them), or use a smaller payload."
+            );
+        }
         return format!(
             "{error}\nHint: the session's browser connection is unresponsive (likely a stale \
              relay/service-worker mid-session). Reconnect with `connect`, or close the session \
@@ -4457,6 +4471,29 @@ async fn resolve_cdp_url(input: &str) -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
+    use super::to_ai_friendly_error;
+
+    #[test]
+    fn a_payload_sized_timeout_is_not_reported_as_a_dead_connection() {
+        // 150KB into a rich editor ran out the daemon budget. The connection was
+        // healthy; the command simply needed longer than we allowed. Telling the
+        // caller to reconnect sent them after a stale service worker that was
+        // not there (#301).
+        let out = to_ai_friendly_error("CDP command timed out after 180s: Input.insertText");
+        assert!(out.contains("size limit, not a dead connection"), "got: {out}");
+        assert!(out.contains("do NOT reconnect"), "got: {out}");
+        assert!(
+            !out.contains("stale relay/service-worker"),
+            "must not send the caller after a stale worker: {out}"
+        );
+
+        // An ordinary command running out its budget keeps the connection
+        // diagnosis — that one really is the likely cause there.
+        let other = to_ai_friendly_error("CDP command timed out after 30s: Runtime.evaluate");
+        assert!(other.contains("stale relay/service-worker"), "got: {other}");
+        assert!(!other.contains("size limit"), "got: {other}");
+    }
+
     use super::*;
     use tokio::time::sleep;
 


### PR DESCRIPTION
chatgpt-use 在 1.5.117 上实测 150KB 单次插入，拿到的是：

```
✗ CDP command timed out: Input.insertText
Hint: the session's browser connection is unresponsive (likely a stale
      relay/service-worker mid-session). Reconnect with `connect`, or close
      the session and reopen it.
real 30.170s
```

连接好得很。这条命令按 ~0.45s/KB 本来就要跑 68 秒，是**尺寸上限**，不是死连接。那句 hint 会让人去 `connect` 重连、去查 service worker——方向完全反了，和 #301 里「selector matched nothing」把人带去查 shadow root 是同一类错误。

`Input.insertText` 的超时改为说明这是尺寸上限而非死连接、明确「不要重连」、给出可行做法。**其他命令的超时保持原诊断**（那里连接失效确实是首要嫌疑），两条分支各有断言。

190：fmt OK，1336 个测试全过。

> 注：#305 的 daemon 侧 `command_timeout` 没进 v1.5.117——发布产物在 #305 合并前 36 秒就出来了，所以 1.5.117 上仍是硬编码 30 秒（实测 30.170s 一秒不差）。合并本 PR 后会切 1.5.118 把两半一起发出去。

https://claude.ai/code/session_01H44Z8bdnh1UEgj7DcvezUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidance for text input commands that exceed payload-size limits.
  * Users are now advised to split large inputs without reconnecting.
  * Other command timeouts continue to provide stale-connection guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->