### PR TITLE
fix: 插入超时的提示不再建议会损坏文本的分块办法，并说明插入没有被取消

### DIFF
--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -699,10 +699,16 @@ pub fn to_ai_friendly_error(error: &str) -> String {
         if lower.contains("input.inserttext") {
             return format!(
                 "{error}\nHint: this is a size limit, not a dead connection. `Input.insertText` \
-                 costs time per character (~0.45s/KB in a rich editor), and this payload needed \
-                 more than the budget. The connection is fine — do NOT reconnect. Insert less at \
-                 once (split the text and send it as separate `keyboard inserttext` calls, \
-                 re-reading the field between them), or use a smaller payload."
+                 costs time per character (~0.45-0.53s/KB in a rich editor), and this payload \
+                 needed more than the budget. The connection is fine — do NOT reconnect.\n\
+                 The insert was NOT cancelled. The page can keep working on it for minutes after \
+                 this error, so let the tab go quiet and re-read the field before sending anything \
+                 else — some or all of the text may have landed, and a command sent now hits a \
+                 renderer that is still busy (#315).\n\
+                 If you must send it in pieces, compare the field's CONTENT between pieces, never \
+                 just its length: a call returns when Chrome dispatched the insert, not when the \
+                 editor committed it, so the next piece can race the uncommitted tail and scramble \
+                 the text while preserving the total length (#301)."
             );
         }
         return format!(
@@ -4489,6 +4495,29 @@ mod tests {
             !out.contains("stale relay/service-worker"),
             "must not send the caller after a stale worker: {out}"
         );
+
+        // The command failing is not the page stopping: `withRelayTimeout` races
+        // a timer against a `sendCommand` promise that was already dispatched,
+        // and losing that race cancels nothing. The renderer was measured still
+        // working ~14 minutes after the caller got this error, so a command sent
+        // "right after the failure" lands on a busy tab (#315). Say so.
+        assert!(
+            out.contains("NOT cancelled"),
+            "must say the insert keeps running: {out}"
+        );
+
+        // The old wording told the caller to split into back-to-back
+        // `keyboard inserttext` calls — the exact thing #301 proved corrupts
+        // text at every boundary, because a call returns on dispatch and not on
+        // commit, and total length survives so a length check passes. If a
+        // split is mentioned at all, the content check must be mentioned with
+        // it; advising the split alone is the regression this pins.
+        if out.contains("pieces") || out.contains("split") {
+            assert!(
+                out.contains("CONTENT"),
+                "a split must be paired with a content comparison, not a length check: {out}"
+            );
+        }
 
         // An ordinary command running out its budget keeps the connection
         // diagnosis — that one really is the likely cause there.


### PR DESCRIPTION
修 #315 里指出的两处问题，都在同一段 hint 里（`cli/src/native/browser.rs` 的 `to_ai_friendly_error`）。

## 1. 它建议的做法，正是 #301 证明会损坏文本的那个

原文案：

> Insert less at once (**split the text and send it as separate `keyboard inserttext` calls**, re-reading the field between them)

而 `cli/src/commands.rs:1044-1053` 的注释写的是：

> Chunking a large insert into back-to-back `inserttext` calls **corrupts text at each boundary** … Total length is preserved, so a char-count check passes and **the scrambled text ships**. One insert removes the boundary entirely.

同一个仓库，两条现行指导互相打架。现在如果提到分块，必须同时说清要比对**内容**而不是长度。

## 2. 它没说这次插入其实没有被取消

`withRelayTimeout` 是 `Promise.race`，而 `deps.sendCommand(...)` 在进入 race 之前就已经派发了——输掉这场比赛不取消任何东西，CDP 也没有撤回已派发命令的原语。实测渲染器在调用方收到报错之后**还干了约 14 分钟**（RSS 持续增长，不是卡死），所以「失败后马上重试」会打在一个仍然忙碌的标签上。

新文案明说：插入没有被取消、让标签安静下来再重读字段、部分或全部文本可能已经落地。

顺带把 `~0.45s/KB` 更新为 `~0.45-0.53s/KB`（后者是 chatgpt.com 上的实测）。

## 测试

原来的测试只断言了 `size limit` 和 `do NOT reconnect`——**这两句我改写后照样在**，等于这次修复没有任何测试保护。补了两条把要点钉住：

- 必须说明插入未被取消
- 一旦提到分块，就必须同时提到比对内容（`CONTENT`），不能只说长度

行为无改动，只有面向调用方的文案 + 测试。

https://claude.ai/code/session_01YBrHUJnzXRfGbVZapEnCh5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated timeout guidance for text insertion to clarify that the operation may continue running after a timeout.
  * Added clearer instructions to wait for the page to become idle and re-read the field before continuing.
  * Improved guidance for splitting text input by recommending content comparisons between pieces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->