### PR TITLE
feat(keep): 区分「交付物」和「下回合接着用」，并给出撤销路径（#290）

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1867,7 +1867,51 @@ fn parse_command_inner(args: &[String], flags: &Flags) -> Result<Value, ParseErr
 
         // `keep`: leave the active tab for the user — exempt it from the daemon's
         // auto-close/idle cleanup and remove it from the session's tab group.
-        "keep" => Ok(json!({ "id": id, "action": "keep" })),
+        //
+        // `--as <reason>` records WHY it was left, because keeping works by
+        // dropping ownership and that erases the only record: afterwards a kept
+        // tab is indistinguishable from one we never touched, so `tab list`
+        // cannot answer "why is this still open?". Two reasons, from the tab
+        // model this mirrors: `deliverable` (the tab IS the result — an edited
+        // doc, a checkout page) and `handoff` (next turn resumes here — waiting
+        // on a login, an approval, a code). Bare `keep` stays `deliverable`, so
+        // every existing caller keeps its current meaning.
+        "keep" => {
+            const REASONS: [&str; 2] = ["deliverable", "handoff"];
+            const USAGE: &str = "keep [--as deliverable|handoff] | keep --release";
+            match rest.first().copied() {
+                None => Ok(json!({ "id": id, "action": "keep", "reason": "deliverable" })),
+                Some("--release") => {
+                    if let Some(extra) = rest.get(1) {
+                        return Err(ParseError::InvalidValue {
+                            message: format!("keep --release takes no arguments (got `{extra}`)"),
+                            usage: USAGE,
+                        });
+                    }
+                    Ok(json!({ "id": id, "action": "keep", "release": true }))
+                }
+                Some("--as") => {
+                    let reason = rest.get(1).copied().ok_or(ParseError::InvalidValue {
+                        message: "keep --as requires a reason".to_string(),
+                        usage: USAGE,
+                    })?;
+                    if !REASONS.contains(&reason) {
+                        return Err(ParseError::InvalidValue {
+                            message: format!(
+                                "`{reason}` is not a keep reason. Use `deliverable` (the tab is \
+                                 the result) or `handoff` (next turn resumes here)."
+                            ),
+                            usage: USAGE,
+                        });
+                    }
+                    Ok(json!({ "id": id, "action": "keep", "reason": reason }))
+                }
+                Some(other) => Err(ParseError::InvalidValue {
+                    message: format!("unknown option `{other}` for keep"),
+                    usage: USAGE,
+                }),
+            }
+        }
 
         // === Stealth self-check ===
         "stealth" => {
@@ -4952,6 +4996,37 @@ pub fn shell_words_split(s: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn keep_defaults_to_deliverable_and_validates_its_reason() {
+        let flags = default_flags();
+        let parse = |args: &[&str]| {
+            let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+            parse_command(&owned, &flags)
+        };
+
+        // Bare `keep` must keep meaning exactly what it meant before the flags
+        // existed, or every existing caller changes behaviour on upgrade.
+        let bare = parse(&["keep"]).expect("bare keep parses");
+        assert_eq!(bare["action"], "keep");
+        assert_eq!(bare["reason"], "deliverable");
+        assert!(bare.get("release").is_none());
+
+        let handoff = parse(&["keep", "--as", "handoff"]).expect("--as handoff parses");
+        assert_eq!(handoff["reason"], "handoff");
+
+        let released = parse(&["keep", "--release"]).expect("--release parses");
+        assert_eq!(released["release"], true);
+        // `--release` carries no reason: it is the undo, not another way to keep.
+        assert!(released.get("reason").is_none());
+
+        // An unknown reason is refused rather than silently recorded, otherwise
+        // `tab list` would show a label nothing else understands.
+        assert!(parse(&["keep", "--as", "important"]).is_err());
+        assert!(parse(&["keep", "--as"]).is_err());
+        assert!(parse(&["keep", "--unknown"]).is_err());
+        assert!(parse(&["keep", "--release", "extra"]).is_err());
+    }
 
     fn default_flags() -> Flags {
         Flags {

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -340,6 +340,67 @@ pub fn created_target_count(session: &str) -> usize {
 /// open; only the session's claim on them is forgotten.
 pub fn forget_created_targets(session: &str) -> Result<(), String> {
     write_created_targets(session, "", &HashSet::new())
+}
+
+/// Why a `keep` tab was left behind, recorded per session.
+///
+/// `keep` works by DROPPING ownership: the target leaves `created_targets` and
+/// the sidecar, which is what exempts it from the shutdown sweep. That erases
+/// the only record we had, so a kept tab is afterwards indistinguishable from a
+/// tab we never touched — `tab list` renders it `foreign` and cannot say why it
+/// is still open. This store is the missing half: the REASON, kept separately.
+///
+/// **It grants no rights.** Deletion rights come only from
+/// `<session>.created-targets.json`; nothing here is ever consulted to decide
+/// whether a tab may be closed. Keeping the two apart is deliberate — a second
+/// source of deletion rights is exactly the v1.5.95 shape. This file is
+/// presentation and bookkeeping, so it needs no endpoint guard and fails open:
+/// an unreadable or malformed file means "no reason recorded", never "closable".
+fn get_kept_tabs_path(session: &str) -> PathBuf {
+    get_socket_dir().join(format!("{}.kept-tabs.json", session))
+}
+
+/// Read the recorded reasons as `target_id -> reason`. Missing or malformed
+/// reads as empty: a lost reason costs a label, never a tab.
+pub fn read_kept_tabs(session: &str) -> BTreeMap<String, String> {
+    fs::read_to_string(get_kept_tabs_path(session))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<BTreeMap<String, String>>(&raw).ok())
+        .unwrap_or_default()
+}
+
+/// Replace the whole map. An empty map removes the file rather than leaving
+/// `{}` behind, so "no kept tabs" has one representation, not two.
+pub fn write_kept_tabs(session: &str, kept: &BTreeMap<String, String>) -> Result<(), String> {
+    let path = get_kept_tabs_path(session);
+    if kept.is_empty() {
+        return match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.to_string()),
+        };
+    }
+    fs::create_dir_all(get_socket_dir()).map_err(|error| error.to_string())?;
+    let encoded = serde_json::to_vec(kept).map_err(|error| error.to_string())?;
+    fs::write(&path, encoded).map_err(|error| error.to_string())
+}
+
+/// Record one tab's reason. Returns the reason it replaced, if any.
+pub fn set_kept_tab(session: &str, target_id: &str, reason: &str) -> Result<Option<String>, String> {
+    let mut kept = read_kept_tabs(session);
+    let previous = kept.insert(target_id.to_string(), reason.to_string());
+    write_kept_tabs(session, &kept)?;
+    Ok(previous)
+}
+
+/// Forget one tab's reason. Returns the reason that was recorded, if any.
+pub fn clear_kept_tab(session: &str, target_id: &str) -> Result<Option<String>, String> {
+    let mut kept = read_kept_tabs(session);
+    let previous = kept.remove(target_id);
+    if previous.is_some() {
+        write_kept_tabs(session, &kept)?;
+    }
+    Ok(previous)
 }
 
 pub fn has_created_targets(session: &str) -> bool {
@@ -1459,6 +1520,67 @@ fn send_command_once(cmd: &Value, session: &str) -> Result<Response, String> {
 mod tests {
     use super::{client_read_budget, daemon_cdp_budget};
     use serde_json::json;
+
+    #[test]
+    fn a_kept_reason_round_trips_and_an_empty_map_removes_the_file() {
+        let guard = crate::test_utils::EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR"]);
+        let dir = tempfile::tempdir().expect("tempdir");
+        guard.set("AGENT_BROWSER_SOCKET_DIR", dir.path().to_str().expect("utf-8"));
+        let session = "kept-round-trip";
+
+        assert!(super::read_kept_tabs(session).is_empty(), "starts empty");
+        assert_eq!(
+            super::set_kept_tab(session, "TARGET-A", "handoff").expect("set"),
+            None,
+            "first write replaces nothing"
+        );
+        assert_eq!(
+            super::read_kept_tabs(session).get("TARGET-A").map(String::as_str),
+            Some("handoff")
+        );
+        // Re-keeping the same tab reports what it replaced, so a caller can say
+        // "was handoff, now deliverable" instead of silently overwriting.
+        assert_eq!(
+            super::set_kept_tab(session, "TARGET-A", "deliverable").expect("re-set"),
+            Some("handoff".to_string())
+        );
+
+        assert_eq!(
+            super::clear_kept_tab(session, "TARGET-A").expect("clear"),
+            Some("deliverable".to_string())
+        );
+        // Emptying removes the file rather than leaving `{}` behind: "no kept
+        // tabs" must have one representation, not two.
+        assert!(
+            !dir.path().join(format!("{session}.kept-tabs.json")).exists(),
+            "an empty map must remove the file"
+        );
+        assert_eq!(
+            super::clear_kept_tab(session, "TARGET-A").expect("clear again"),
+            None,
+            "clearing an absent tab is not an error"
+        );
+    }
+
+    #[test]
+    fn a_malformed_kept_tabs_file_reads_as_empty_not_as_an_error() {
+        let guard = crate::test_utils::EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR"]);
+        let dir = tempfile::tempdir().expect("tempdir");
+        guard.set("AGENT_BROWSER_SOCKET_DIR", dir.path().to_str().expect("utf-8"));
+        let session = "kept-malformed";
+        std::fs::write(
+            dir.path().join(format!("{session}.kept-tabs.json")),
+            b"{ not json",
+        )
+        .expect("write garbage");
+
+        // This store is labels, never rights: a lost reason costs a label, and
+        // must never be able to fail a command or imply a tab is closable.
+        assert!(
+            super::read_kept_tabs(session).is_empty(),
+            "a malformed file reads as 'no reason recorded'"
+        );
+    }
 
     #[test]
     fn the_client_read_budget_always_outlasts_the_daemon_budget() {

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -386,7 +386,11 @@ pub fn write_kept_tabs(session: &str, kept: &BTreeMap<String, String>) -> Result
 }
 
 /// Record one tab's reason. Returns the reason it replaced, if any.
-pub fn set_kept_tab(session: &str, target_id: &str, reason: &str) -> Result<Option<String>, String> {
+pub fn set_kept_tab(
+    session: &str,
+    target_id: &str,
+    reason: &str,
+) -> Result<Option<String>, String> {
     let mut kept = read_kept_tabs(session);
     let previous = kept.insert(target_id.to_string(), reason.to_string());
     write_kept_tabs(session, &kept)?;
@@ -1525,7 +1529,10 @@ mod tests {
     fn a_kept_reason_round_trips_and_an_empty_map_removes_the_file() {
         let guard = crate::test_utils::EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR"]);
         let dir = tempfile::tempdir().expect("tempdir");
-        guard.set("AGENT_BROWSER_SOCKET_DIR", dir.path().to_str().expect("utf-8"));
+        guard.set(
+            "AGENT_BROWSER_SOCKET_DIR",
+            dir.path().to_str().expect("utf-8"),
+        );
         let session = "kept-round-trip";
 
         assert!(super::read_kept_tabs(session).is_empty(), "starts empty");
@@ -1535,7 +1542,9 @@ mod tests {
             "first write replaces nothing"
         );
         assert_eq!(
-            super::read_kept_tabs(session).get("TARGET-A").map(String::as_str),
+            super::read_kept_tabs(session)
+                .get("TARGET-A")
+                .map(String::as_str),
             Some("handoff")
         );
         // Re-keeping the same tab reports what it replaced, so a caller can say
@@ -1552,7 +1561,9 @@ mod tests {
         // Emptying removes the file rather than leaving `{}` behind: "no kept
         // tabs" must have one representation, not two.
         assert!(
-            !dir.path().join(format!("{session}.kept-tabs.json")).exists(),
+            !dir.path()
+                .join(format!("{session}.kept-tabs.json"))
+                .exists(),
             "an empty map must remove the file"
         );
         assert_eq!(
@@ -1566,7 +1577,10 @@ mod tests {
     fn a_malformed_kept_tabs_file_reads_as_empty_not_as_an_error() {
         let guard = crate::test_utils::EnvGuard::new(&["AGENT_BROWSER_SOCKET_DIR"]);
         let dir = tempfile::tempdir().expect("tempdir");
-        guard.set("AGENT_BROWSER_SOCKET_DIR", dir.path().to_str().expect("utf-8"));
+        guard.set(
+            "AGENT_BROWSER_SOCKET_DIR",
+            dir.path().to_str().expect("utf-8"),
+        );
         let session = "kept-malformed";
         std::fs::write(
             dir.path().join(format!("{session}.kept-tabs.json")),

--- a/cli/src/native/actions.rs
+++ b/cli/src/native/actions.rs
@@ -1705,7 +1705,7 @@ pub async fn execute_command(cmd: &Value, state: &mut DaemonState) -> Value {
             "site" => handle_site(cmd, state).await,
             "script" => super::script::handle_script(cmd, state).await,
             "close" => handle_close(state).await,
-            "keep" => handle_keep(state).await,
+            "keep" => handle_keep(cmd, state).await,
             "stealth_status" => handle_stealth_status(state).await,
             "snapshot" => handle_snapshot(cmd, state).await,
             "select_text" => handle_select_text(cmd, state).await,
@@ -3984,10 +3984,53 @@ async fn handle_stealth_status(state: &DaemonState) -> Result<Value, String> {
 /// user" half of the auto-close-on-idle cleanup: scratch tabs get closed, tabs
 /// the agent explicitly `keep`s stay. (Adopted user tabs are never owned, so
 /// they're already safe.)
-async fn handle_keep(state: &mut DaemonState) -> Result<Value, String> {
+async fn handle_keep(cmd: &Value, state: &mut DaemonState) -> Result<Value, String> {
+    let release = cmd
+        .get("release")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let reason = cmd
+        .get("reason")
+        .and_then(|value| value.as_str())
+        .unwrap_or("deliverable");
+    let session = super::browser::DAEMON_SESSION.get().cloned();
     let mgr = state.browser.as_mut().ok_or("Browser not launched")?;
     let target_id = mgr.active_target_id()?.to_string();
     let session_id = mgr.active_session_id()?.to_string();
+
+    if release {
+        // Only a recorded keep can be undone. The record is written solely for a
+        // tab that was owned when it was kept, so restoring ownership from it
+        // gives back a right we held — it never mints one. Releasing "whatever
+        // is active" would do exactly that, over the user's own tab.
+        let recorded = session
+            .as_deref()
+            .map(crate::connection::read_kept_tabs)
+            .unwrap_or_default();
+        let Some(was_kept_as) = recorded.get(&target_id).cloned() else {
+            return Err(format!(
+                "keep --release: this session has no `keep` record for the active tab ({target_id}). \
+                 Only a tab this session created and then kept can be taken back — otherwise the \
+                 command would claim the right to close a tab it never opened. Run `tab list` to \
+                 see which tabs are marked kept."
+            ));
+        };
+        let reowned = mgr.reown_target(&target_id)?;
+        if let Some(session) = session.as_deref() {
+            crate::connection::clear_kept_tab(session, &target_id)?;
+        }
+        return Ok(json!({
+            "released": target_id,
+            "wasKeptAs": was_kept_as,
+            "reowned": reowned,
+            // Say what did NOT happen: the tab is not back in the session's tab
+            // group. Ungrouping is a one-way door today — the extension exposes
+            // `ABExt.ungroupTab` but no re-group command — and implying the
+            // group was restored would be a second false statement.
+            "note": "ownership restored — this tab closes with the session again.                      It is NOT back in the session's tab group; the extension has no re-group                      command, so it stays ungrouped.",
+        }));
+    }
+
     let was_owned = mgr.unown_target(&target_id)?;
     // Best-effort: ask the extension to ungroup the tab (relay only; no-ops on a
     // launched browser or an older extension that doesn't know ABExt.ungroupTab).
@@ -3999,10 +4042,27 @@ async fn handle_keep(state: &mut DaemonState) -> Result<Value, String> {
             None,
         )
         .await;
+    // Record the reason ONLY when we actually owned the tab. `keep` on a tab we
+    // merely adopted is a no-op for ownership, and writing a record for it would
+    // let `--release` later claim deletion rights over the user's own tab.
+    let previously = if was_owned {
+        match session.as_deref() {
+            Some(session) => crate::connection::set_kept_tab(session, &target_id, reason)?,
+            None => None,
+        }
+    } else {
+        None
+    };
     Ok(json!({
         "kept": target_id,
         "wasOwned": was_owned,
-        "note": "tab left for the user — exempt from auto-close, removed from the session tab group",
+        "as": if was_owned { Some(reason) } else { None },
+        "previously": previously,
+        "note": if was_owned {
+            "tab left for the user — exempt from auto-close, removed from the session tab group"
+        } else {
+            "this session did not create this tab, so there was nothing to release: it was already              exempt from auto-close. No keep reason was recorded."
+        },
     }))
 }
 
@@ -8064,6 +8124,28 @@ async fn handle_tab_list(cmd: &Value, state: &mut DaemonState) -> Result<Value, 
             let is_attached = attached.contains(tid);
             if let Some(obj) = tab.as_object_mut() {
                 obj.insert("relayAttached".to_string(), json!(is_attached));
+            }
+        }
+    }
+    // Why a tab is still open, for tabs this session deliberately left behind.
+    // `keep` exempts a tab by DROPPING ownership, which erases the only record —
+    // so without this the row renders `foreign` and `tab list` cannot answer
+    // "why is this one still here?". Read here rather than in `tab_list()` so
+    // the manager stays free of filesystem access. Absent record = say nothing.
+    let kept = super::browser::DAEMON_SESSION
+        .get()
+        .map(|session| crate::connection::read_kept_tabs(session))
+        .unwrap_or_default();
+    if !kept.is_empty() {
+        for tab in tabs.iter_mut() {
+            let Some(target_id) = tab.get("targetId").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(reason) = kept.get(target_id).cloned() else {
+                continue;
+            };
+            if let Some(object) = tab.as_object_mut() {
+                object.insert("keptAs".to_string(), json!(reason));
             }
         }
     }

--- a/cli/src/native/browser.rs
+++ b/cli/src/native/browser.rs
@@ -2436,6 +2436,28 @@ impl BrowserManager {
         self.forget_created_target(target_id)
     }
 
+    /// Re-take a tab this session created and later released with `keep`.
+    ///
+    /// The caller MUST establish that we created it — `handle_keep` does that by
+    /// requiring a `kept-tabs` record, which is only ever written for a target
+    /// that was owned at the time it was kept. Re-owning on any other basis
+    /// would mint deletion rights over a tab we never created, which is the
+    /// v1.5.95 shape: rights must be restored from a record, never inferred
+    /// from the fact that a tab happens to be active right now.
+    ///
+    /// Returns whether this call changed anything (false = already owned).
+    pub fn reown_target(&mut self, target_id: &str) -> Result<bool, String> {
+        if self.created_targets.contains(target_id) {
+            return Ok(false);
+        }
+        self.created_targets.insert(target_id.to_string());
+        if let Err(error) = self.persist_created_targets() {
+            self.created_targets.remove(target_id);
+            return Err(error);
+        }
+        Ok(true)
+    }
+
     /// Returns true if this manager was connected via CDP (as opposed to local launch).
     pub fn is_cdp_connection(&self) -> bool {
         self.browser_process.is_none()

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1102,6 +1102,14 @@ fn print_response_body(resp: &Response, action: Option<&str>, opts: &OutputOptio
                 // invent a second false statement.
                 let pinned_but_detached =
                     active && tab.get("relayAttached").and_then(|v| v.as_bool()) == Some(false);
+                // Why this tab is still open, when the session deliberately
+                // left it. Only present for tabs `keep` recorded, so an
+                // ordinary row gains nothing and the common case stays quiet.
+                let kept_marker = tab
+                    .get("keptAs")
+                    .and_then(|v| v.as_str())
+                    .map(|reason| format!(" [kept: {}]", reason))
+                    .unwrap_or_default();
                 let marker = if pinned_but_detached {
                     color::warning_indicator().to_string()
                 } else if active {
@@ -1111,13 +1119,13 @@ fn print_response_body(resp: &Response, action: Option<&str>, opts: &OutputOptio
                 };
                 if let Some(label) = tab_label {
                     println!(
-                        "{} [{}]{} {} {} - {}",
-                        marker, tab_id, ownership_marker, label, title, url
+                        "{} [{}]{}{} {} {} - {}",
+                        marker, tab_id, ownership_marker, kept_marker, label, title, url
                     );
                 } else {
                     println!(
-                        "{} [{}]{} {} - {}",
-                        marker, tab_id, ownership_marker, title, url
+                        "{} [{}]{}{} {} - {}",
+                        marker, tab_id, ownership_marker, kept_marker, title, url
                     );
                 }
                 // `--full` also surfaces the stable cross-session CDP targetId so
@@ -4418,6 +4426,47 @@ Environment:
         }
 
         // === Site adapters ===
+        "keep" => {
+            r##"
+chrome-use keep - Leave the active tab for the user
+
+Usage: chrome-use keep [--as deliverable|handoff]
+       chrome-use keep --release
+
+Exempts the active tab from the daemon's auto-close and removes it from the
+session's tab group, so it survives after the session ends.
+
+Keeping works by dropping ownership: the tab leaves the session's created-tab
+record, which is what exempts it. That erases the only trace we had, so
+`--as` records WHY it was left — otherwise `tab list` shows it as `foreign`
+and cannot answer "why is this still open?".
+
+  --as deliverable   (default) the tab IS the result: an edited document, a
+                     checkout page, something the user asked to keep open.
+  --as handoff       the next turn resumes here: waiting on a login, an
+                     approval, a payment, a code.
+
+`tab list` marks them `[kept: deliverable]` / `[kept: handoff]`.
+
+Bare `keep` means `--as deliverable`, so existing callers are unchanged.
+
+  --release          take the tab back: ownership is restored and it closes
+                     with the session again.
+
+`--release` only works on a tab THIS session created and then kept — the
+recorded keep is the proof. Without that record the command would claim the
+right to close a tab it never opened, so it refuses instead. Note the tab does
+NOT rejoin the session's tab group: ungrouping is one-way today.
+
+Do NOT keep research, search results, sources, intermediate steps, duplicates,
+blank tabs, error pages, or routine navigation. Keeping everything makes the
+mark meaningless and leaves the user's window full of the agent's scratch work.
+
+Global Options:
+  --json               Output as JSON
+  --session <name>     Use specific session
+"##
+        }
         "site" => {
             r##"
 chrome-use site - Run a community site adapter over your logged-in session
@@ -5247,6 +5296,9 @@ mod tests {
         // #299: `site --help` used to fall through to the 534-line generic help,
         // which reads to an agent as "that command does not exist".
         assert!(print_command_help("site"), "site must print its own help");
+        // `keep` grew flags (`--as`, `--release`); without its own topic help it
+        // falls back to the 534-line top-level help, which is how #299 looked.
+        assert!(print_command_help("keep"), "keep must print its own help");
         // A genuinely unknown command still falls back (returns false).
         assert!(!print_command_help("definitely-not-a-command"));
     }

--- a/skill-data/core/references/behaviour.md
+++ b/skill-data/core/references/behaviour.md
@@ -89,11 +89,20 @@ next task.
 
 - Name the session before opening anything: `session name "🔎 short task
   name"`. The user sees it as the tab group label.
-- Your tabs are scratch. The daemon closes them when it goes idle. Use `keep`
-  only for a tab that is itself the deliverable (a document you edited, a
-  checkout the user must finish, a page they asked to see) or that a later
-  turn must continue from. Never `keep` research, search, source, duplicate,
-  blank, or error tabs.
+- Your tabs are scratch. The daemon closes them when it goes idle. `keep`
+  exempts one, and it takes the reason: `keep --as deliverable` for a tab that
+  IS the result (a document you edited, a checkout the user must finish, a page
+  they asked to see), `keep --as handoff` for one a later turn resumes from
+  (waiting on a login, an approval, a payment, a code). Bare `keep` means
+  `deliverable`. `tab list` shows them as `[kept: deliverable]` /
+  `[kept: handoff]`, which is how the user finds out why a tab is still open —
+  so a wrong reason is worse than none. Never `keep` research, search, source,
+  intermediate, duplicate, blank, or error tabs: if everything is kept, the
+  mark means nothing and the user's window fills with your scratch work.
+- Changed your mind? `keep --release` takes the tab back, so it closes with the
+  session again. It works only on a tab you kept earlier — that record is the
+  proof you opened it. The tab does not rejoin your tab group; ungrouping is
+  one-way.
 - An empty `tab list`, a tab that went stale, or one command that timed out is
   not a disconnected browser. Keep the session, `open` the URL you need, and
   carry on. Do not restart the daemon, re-run setup, or re-read this skill for


### PR DESCRIPTION
关闭 #290。

## 问题

`keep` 靠**丢弃所有权**来豁免自动关闭(`unown_target` 就是 `forget_created_target`),而那恰恰抹掉了唯一的记录。之后这个标签和我们从没碰过的标签**无法区分**——`tab list` 只能把它显示成 `foreign`,回答不了「它为什么还开着」。

## 改动

- **`keep --as deliverable|handoff`** 记录原因。`deliverable` = 标签本身就是结果(编辑好的文档、要用户完成的结账页);`handoff` = 下回合从这里接着走(等登录/审批/支付/验证码)。**裸 `keep` 仍等于 `deliverable`**,现有调用方语义不变。
- **新侧车 `<session>.kept-tabs.json`** 存 `targetId -> reason`。
- **`tab list` 渲染 `[kept: deliverable]` / `[kept: handoff]`**,只在有记录时出现,普通行不受影响。
- **`keep --release`** 撤销:恢复所有权,标签重新随会话关闭。

## 两条刻意的约束

**1. 这个侧车不授予任何删除权。** 它照 `session_title` 的「非所有权」形态写,不是 `created-targets` 的形态:无 endpoint 守卫、读失败一律当作「没有记录」。删除权只能有一个来源(`created-targets.json`),第二个来源正是 v1.5.95 那个形状。注释里写死了这一点。

**2. `--release` 只对本会话创建过、且被 `keep` 记录过的标签生效。** 这一条是写的过程中拦下来的:`keep` 对 adopted/foreign 标签本来就是空操作(`was_owned == false`),如果照样写记录,`--release` 之后就会**凭空取得一个我们从未创建的标签的删除权**。所以只在 `was_owned` 时才写记录,`reown_target` 的文档注释也把这条写死:权利只能从记录里恢复,不能从「这个标签恰好是当前活动标签」推断出来。没有记录时 `--release` 直接报错并说明原因。

## 诚实地说清没做到的

**`--release` 不会把标签放回会话标签组。** 扩展只有 `ABExt.ungroupTab`,没有对外的重新分组命令(`groupTabInto` 是内部函数),所以取消分组今天是**单向门**。提示里明说这一点,而不是让人以为分组也一并恢复了。

## 顺带

`keep` 此前**没有专属帮助**,和 #299 一样会掉回 534 行顶层帮助——而我正在给它加 flag,不补等于新 flag 没有文档。补上了,并加断言钉住,防止再次静默回退。skill 的 `behaviour.md` 也同步点出了 flag 名,否则 agent 读到的指导和能用的命令对不上。

## 验证

构建机(游离 HEAD,不重置任何具名分支):`cargo fmt --check` 干净,`cargo build` 无错误,全量测试 **1341 + 2 + 2 + 7 通过 / 0 失败**(比改动前多 3 条,即 2 个侧车测试 + 1 个解析测试)。

新测试钉住的是这次的要点:原因能往返、空映射**删文件**而不是留 `{}`、**文件损坏读作「没有记录」而不是报错**(标签丢了只该少一个标签,绝不能让命令失败或暗示标签可关)、裸 `keep` 仍是 `deliverable`、非法原因被拒。

clippy 有一条 `for loop on unbounded range` 警告,**main 上同样存在**(main `browser.rs:5744` / 本分支 `5766`,差 22 行正是 `reown_target` 的行数),不是本 PR 引入,未在此处理。

https://claude.ai/code/session_01YBrHUJnzXRfGbVZapEnCh5