### PR TITLE
fix: 扩展版本按 profile 记录，别再报成另一个 profile 的（#319）

### DIFF
--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -3260,6 +3260,11 @@ async fn nm_host_main() {
     if let Some(id) = &bound_profile_id {
         let _ = std::fs::remove_file(relay_url_path_for(id));
         let _ = std::fs::remove_file(relay_ext_profile_path_for(id));
+        // The version sidecar belongs to this set too. Leaving it behind is the
+        // same shape as the bug this fix is about: a per-profile file added
+        // without being added to the group that gets written, read and cleaned
+        // together.
+        let _ = std::fs::remove_file(relay_ext_version_path_for(id));
     }
 }
 

--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -2748,7 +2748,11 @@ fn relay_ext_profile_path() -> PathBuf {
 /// Read one version sidecar, treating blank as absent.
 fn read_ext_version_file(path: PathBuf) -> Option<String> {
     let s = std::fs::read_to_string(path).ok()?.trim().to_string();
-    if s.is_empty() { None } else { Some(s) }
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
 }
 
 /// The extension version of the profile the relay is actually DRIVING.
@@ -3646,11 +3650,14 @@ mod tests {
         );
         // A path separator in a profile id must never escape the directory.
         assert!(
-            !version.file_name().and_then(|n| n.to_str()).unwrap().contains('/'),
+            !version
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap()
+                .contains('/'),
             "a sanitised id must not reintroduce a path separator"
         );
     }
-
 
     #[test]
     fn parse_ext_profile_reads_id_and_optional_email() {

--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -197,7 +197,9 @@ pub fn run_connect(args: &[String], json: bool) {
     let installed = !manifests.is_empty();
     let extension_status = chrome_extension_status();
     let relay_url = relay_url();
-    let live_extension_version = relay_ext_version();
+    // Emitted and printed right next to `drivingProfileId`, so it must describe
+    // THAT profile rather than whichever worker last wrote the generic sidecar.
+    let live_extension_version = relay_ext_version_driving();
     let expected_extension_version = env!("AB_CONNECT_VERSION");
     let driving_profile = relay_ext_profile();
     let profiles = chrome_profiles();
@@ -2743,6 +2745,28 @@ fn relay_ext_profile_path() -> PathBuf {
     relay_url_path().with_file_name("relay-ext-profile")
 }
 
+/// Read one version sidecar, treating blank as absent.
+fn read_ext_version_file(path: PathBuf) -> Option<String> {
+    let s = std::fs::read_to_string(path).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+/// The extension version of the profile the relay is actually DRIVING.
+///
+/// Use this wherever a version is shown next to a profile. Falls back to the
+/// generic sidecar when the driving profile is unknown or has no per-profile
+/// file: an extension too old to report `profileId` writes only the generic
+/// one, and reporting "unknown" for those would be a regression dressed up as
+/// a fix.
+pub fn relay_ext_version_driving() -> Option<String> {
+    if let Some((id, _)) = relay_ext_profile() {
+        if let Some(version) = read_ext_version_file(relay_ext_version_path_for(&id)) {
+            return Some(version);
+        }
+    }
+    relay_ext_version()
+}
+
 /// The Chrome profile the relay is currently driving, as `(id, email)` learned
 /// from the extension's `hello`. `id` is a stable per-profile UUID (always
 /// present on a new-enough extension); `email` is the signed-in account, only
@@ -2811,6 +2835,18 @@ fn relay_url_path_for(id: &str) -> PathBuf {
 
 fn relay_ext_profile_path_for(id: &str) -> PathBuf {
     relay_url_path().with_file_name(format!("relay-ext-profile-{}", sanitize_profile_id(id)))
+}
+
+/// The extension version reported by ONE profile's worker.
+///
+/// The generic `relay-ext-version` is written by whichever worker sent `hello`
+/// last, so with several profiles connected it can describe a profile other
+/// than the one being driven — `status` printed "live 0.5.21" next to a driving
+/// profile that was on 0.5.26 (#319). The endpoint already had this per-profile
+/// treatment (`relay_url_path_for`); the version did not. Same naming and same
+/// sanitiser, so the pair stays findable together on disk.
+fn relay_ext_version_path_for(id: &str) -> PathBuf {
+    relay_url_path().with_file_name(format!("relay-ext-version-{}", sanitize_profile_id(id)))
 }
 
 /// Every profile whose extension worker is currently connected: `(id, email,
@@ -3128,7 +3164,8 @@ async fn nm_host_main() {
                 .flatten()
                 .filter_map(|x| x.as_str().map(ToString::to_string));
             state.lock().await.set_extension_capabilities(capabilities);
-            if let Some(ver) = v.get("version").and_then(|x| x.as_str()) {
+            let reported_version = v.get("version").and_then(|x| x.as_str());
+            if let Some(ver) = reported_version {
                 let _ = std::fs::write(relay_ext_version_path(), ver);
             }
             // Record which profile is driving (issue #60), if the extension
@@ -3140,6 +3177,14 @@ async fn nm_host_main() {
                 // Stable per-profile endpoint so `--browser <id>` can pin to THIS
                 // profile regardless of who last clobbered the generic file.
                 let _ = std::fs::write(relay_url_path_for(id), &url);
+                // ...and the version alongside it, for the same reason: the
+                // generic file belongs to whoever said `hello` last, which is
+                // not necessarily the profile we drive (#319). Only here — the
+                // `focus` ping below carries no version, so it must not write
+                // one and blank out a good value.
+                if let Some(ver) = reported_version {
+                    let _ = std::fs::write(relay_ext_version_path_for(id), ver);
+                }
                 // The per-profile record also carries a focus timestamp (host
                 // clock, so it's comparable across profiles) — baseline it at
                 // connect and refresh it on `focus` pings. Lets the CLI default to
@@ -3575,6 +3620,37 @@ mod tests {
         assert_eq!(profile_label("uuid", None), "uuid");
         assert_eq!(profile_label("uuid", Some("")), "uuid");
     }
+    #[test]
+    fn the_per_profile_version_sidecar_is_named_like_its_endpoint_sibling() {
+        // This bug was exactly "the endpoint got per-profile treatment, the
+        // version did not" (#319). Pin the pair so they cannot drift apart
+        // again: same directory, same sanitiser, matching prefixes.
+        let id = "27ade1bc-9f/00 XX";
+        let endpoint = super::relay_url_path_for(id);
+        let version = super::relay_ext_version_path_for(id);
+        let profile = super::relay_ext_profile_path_for(id);
+
+        assert_eq!(
+            endpoint.parent(),
+            version.parent(),
+            "the version sidecar must sit next to the endpoint it describes"
+        );
+        assert_eq!(
+            version.file_name().and_then(|n| n.to_str()),
+            Some("relay-ext-version-27ade1bc-9f_00_XX"),
+            "unexpected name — the id must be sanitised the same way as the siblings"
+        );
+        assert_eq!(
+            profile.file_name().and_then(|n| n.to_str()),
+            Some("relay-ext-profile-27ade1bc-9f_00_XX")
+        );
+        // A path separator in a profile id must never escape the directory.
+        assert!(
+            !version.file_name().and_then(|n| n.to_str()).unwrap().contains('/'),
+            "a sanitised id must not reintroduce a path separator"
+        );
+    }
+
 
     #[test]
     fn parse_ext_profile_reads_id_and_optional_email() {

--- a/cli/src/doctor/versions.rs
+++ b/cli/src/doctor/versions.rs
@@ -38,7 +38,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
     // Extension — the build this CLI shipped alongside (embedded at compile time
     // from the extension manifest) is what we expect to be running.
     let expected_ext = env!("AB_CONNECT_VERSION");
-    match connect::relay_ext_version() {
+    match connect::relay_ext_version_driving() {
         // Behind the bundled build is only a WARNING when a newer build is
         // actually published — the bundled version routinely runs ahead of the
         // Web Store, and telling people to hit Update for a build that isn't

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -945,7 +945,9 @@ fn run_status(session: &str, json_mode: bool) {
     let host_installed = !host_report.manifests.is_empty();
     let host_healthy = host_report.is_healthy();
     let relay_up = connect::relay_url().is_some();
-    let extension_version = connect::relay_ext_version();
+    // Printed next to the driving profile below, so it must be that profile's
+    // version, not the last `hello` writer's (#319).
+    let extension_version = connect::relay_ext_version_driving();
     let profile = connect::relay_ext_profile();
     let current = inventory.sessions.iter().find(|item| item.name == session);
 


### PR DESCRIPTION
关闭 #319。

## 问题

`status` 会同时打印这两句:

```
2 Chrome profiles connected — driving 27ade1bc-… (most recently used)
  extension: live 0.5.21, expected 0.5.26
```

而那个 `0.5.21` 是**另一个** profile(`696d9cb7-…`)上的版本。

原因不是竞态,是**缺一个维度**:`relay-ext-version` 是通用侧车,由**最后一个发 `hello` 的 worker** 写入;而「在驱动谁」走的是另一套口径(每 profile 记录里的焦点时间戳)。两个 profile 都连着时,这两行必然可能各说各话。

#60 早就意识到通用文件会被后来者覆盖,并为**端点**做了按 profile 隔离——`relay_url_path_for` 的注释原话是 *"regardless of who last clobbered the generic file"*。**版本号没跟上。**

对端做的分 profile 对照是直接证据:`--browser 27ade1bc-… status` 和 `--browser 696d9cb7-… status` **打印完全相同**,说明这两行根本不看 `--browser`。

## 改动

- 新增 `relay-ext-version-<profileId>` 侧车,在 `hello` 里和按 profile 的端点**一起**写。
- **只写在 `hello`**:`focus` 心跳不带 `version`,若照写会把一个好值清空。这一条在代码注释里写死了,因为那两处写按 profile 记录的代码长得几乎一样(我下锚时就先撞上了这个重复,查证后才确定分工)。
- 新增 `relay_ext_version_driving()`:按当前驱动的 profile 取,取不到**回退通用文件**。旧扩展不上报 `profileId`、只写通用文件,把它们报成 `unknown` 会是拿回归当修复。
- **只切换三处「版本与 profile 并排呈现」的地方**:`status` 的文本与 JSON(`liveExtensionVersion` 就挨着 `drivingProfileId`,机器可读那份错配影响最大)、`main.rs` 的 status 行、`doctor`。

其余七处保持读通用文件——它们问的是「有没有扩展连上」,不是「哪个 profile 的版本」。这七处我是**逐条列出来核对**的,不是估的。

## 测试

新测试钉住命名成对:这次的 bug 本质就是「端点隔离了而版本没有」,所以断言两个侧车**同目录、同 sanitiser、前缀对应**,并且 profile id 里的路径分隔符不会逃逸出目录(`27ade1bc-9f/00 XX` → `relay-ext-version-27ade1bc-9f_00_XX`)。

## 验证

构建机(游离 HEAD,不重置任何具名分支):`cargo fmt --check` 干净、`cargo build` 无错误、新测试单独通过、全量 **1342 + 2 + 2 + 7 通过 / 0 失败**(比改动前多 1 条,即新增的那个)。

## 范围

**只动 CLI 侧**,不需要发扩展、不走商店审核——`hello` 里本来就带着 `profileId`,宿主多写一个文件即可。

## 未涵盖

#319 里那些 `open` 之后立刻 unresponsive 的失败,**归因仍未确立**,本 PR 不声称修了它们。已确认的只有版本行缺 profile 维度这一件。另一个候选解释(其中一个 profile 跑着旧扩展)也没有被排除。

https://claude.ai/code/session_01YBrHUJnzXRfGbVZapEnCh5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Extension version checks now reflect the version installed in the currently active Chrome profile.
  - Status and diagnostic information now report the driving profile’s extension version, improving accuracy when multiple profiles are connected.
  - Older extensions continue to be supported through a fallback version source.
  - Version information is preserved correctly when focus changes occur.
  - Disconnecting a profile now clears its stored version information, preventing stale versions from appearing later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->