### PR TITLE
fix: 统一「在驱动哪个 profile」的口径——v1.5.122 的修复不生效（#319）

### DIFF
--- a/cli/src/connect.rs
+++ b/cli/src/connect.rs
@@ -84,8 +84,10 @@ const OLD_PROFILE_IDS: &[&str] = &[
 /// with `--browser <id|email>` (issue #60). Local; no daemon.
 pub fn run_browsers(json: bool) {
     let profiles = list_relay_profiles();
-    // The generic (last-writer) default the relay binds to without `--browser`.
-    let default = relay_ext_profile().map(|(id, _)| id);
+    // The profile the CLI drives without `--browser`. Must match what actually
+    // gets bound, not the last `hello` writer — marking the wrong row `default`
+    // was the third symptom of #319.
+    let default = driving_profile().map(|(id, _)| id);
     if json {
         let arr: Vec<_> = profiles
             .iter()
@@ -201,7 +203,7 @@ pub fn run_connect(args: &[String], json: bool) {
     // THAT profile rather than whichever worker last wrote the generic sidecar.
     let live_extension_version = relay_ext_version_driving();
     let expected_extension_version = env!("AB_CONNECT_VERSION");
-    let driving_profile = relay_ext_profile();
+    let driving_profile = driving_profile();
     let profiles = chrome_profiles();
     let policy = managed_policy_state();
     let (_, old_ids) = approved_config_profiles();
@@ -2755,6 +2757,40 @@ fn read_ext_version_file(path: PathBuf) -> Option<String> {
     }
 }
 
+/// Choose between the two notions of "driving": the focus-based winner (same
+/// source the endpoint selection uses) and the generic last-`hello` sidecar.
+///
+/// Pure, so the preference is testable without touching the filesystem.
+/// `most_recently_focused_profile` deliberately returns `None` when the choice
+/// is not clean — fewer than two profiles, any profile whose extension is too
+/// old to report focus, or a tie — and in exactly those cases the generic
+/// sidecar is the best answer available, so it is the fallback, not the
+/// primary.
+fn prefer_focused_profile(
+    focused: Option<(String, Option<String>)>,
+    generic: Option<(String, Option<String>)>,
+) -> Option<(String, Option<String>)> {
+    focused.or(generic)
+}
+
+/// The profile the CLI is actually driving, for anything that REPORTS it.
+///
+/// There used to be two answers in this codebase. The header line and the
+/// endpoint selection used `most_recently_focused_profile()`; the `profile:`
+/// line, `drivingProfileId`, `browsers`' default column, doctor, and the
+/// version resolver used `relay_ext_profile()` — the generic sidecar, which
+/// belongs to whoever sent `hello` last. With two profiles connected those
+/// disagree, which is what #319 actually was: `status` printed
+/// `driving 27ade1bc…` above `profile: 696d9cb7…`. Fixing the version's
+/// per-profile storage (v1.5.122) did not help, because the lookup still used
+/// the wrong id. One answer, used everywhere that reports it.
+pub fn driving_profile() -> Option<(String, Option<String>)> {
+    prefer_focused_profile(
+        most_recently_focused_profile().map(|(id, email, _)| (id, email)),
+        relay_ext_profile(),
+    )
+}
+
 /// The extension version of the profile the relay is actually DRIVING.
 ///
 /// Use this wherever a version is shown next to a profile. Falls back to the
@@ -2763,7 +2799,7 @@ fn read_ext_version_file(path: PathBuf) -> Option<String> {
 /// one, and reporting "unknown" for those would be a regression dressed up as
 /// a fix.
 pub fn relay_ext_version_driving() -> Option<String> {
-    if let Some((id, _)) = relay_ext_profile() {
+    if let Some((id, _)) = driving_profile() {
         if let Some(version) = read_ext_version_file(relay_ext_version_path_for(&id)) {
             return Some(version);
         }
@@ -3629,6 +3665,28 @@ mod tests {
         assert_eq!(profile_label("uuid", None), "uuid");
         assert_eq!(profile_label("uuid", Some("")), "uuid");
     }
+    #[test]
+    fn the_reported_driving_profile_prefers_focus_over_the_last_hello_writer() {
+        let focused = || Some(("focused".to_string(), Some("f@x".to_string())));
+        let generic = || Some(("last-hello".to_string(), None));
+
+        // The whole point: when the two disagree, focus wins — that is the one
+        // the endpoint selection actually binds (#319).
+        assert_eq!(
+            super::prefer_focused_profile(focused(), generic()).map(|(id, _)| id),
+            Some("focused".to_string())
+        );
+        // `most_recently_focused_profile` returns None whenever the choice is
+        // not clean (one profile, an extension too old to report focus, a tie).
+        // Those are exactly the cases where the generic sidecar is right, so it
+        // must still be used rather than reporting nothing.
+        assert_eq!(
+            super::prefer_focused_profile(None, generic()).map(|(id, _)| id),
+            Some("last-hello".to_string())
+        );
+        assert_eq!(super::prefer_focused_profile(None, None), None);
+    }
+
     #[test]
     fn the_per_profile_version_sidecar_is_named_like_its_endpoint_sibling() {
         // This bug was exactly "the endpoint got per-profile treatment, the

--- a/cli/src/doctor/versions.rs
+++ b/cli/src/doctor/versions.rs
@@ -125,7 +125,7 @@ pub(super) fn check(checks: &mut Vec<Check>) {
     // Driving Chrome profile — with many profiles, the relay binds to whichever
     // profile's extension worker connected; naming it disambiguates a "logged
     // out" result (wrong profile vs. genuinely not logged in) (issue #60).
-    match connect::relay_ext_profile() {
+    match connect::driving_profile() {
         Some((id, Some(email))) => checks.push(Check::new(
             "relay.profile",
             category,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -948,7 +948,7 @@ fn run_status(session: &str, json_mode: bool) {
     // Printed next to the driving profile below, so it must be that profile's
     // version, not the last `hello` writer's (#319).
     let extension_version = connect::relay_ext_version_driving();
-    let profile = connect::relay_ext_profile();
+    let profile = connect::driving_profile();
     let current = inventory.sessions.iter().find(|item| item.name == session);
 
     if json_mode {


### PR DESCRIPTION
**这个 PR 修的是我自己上一个修复的失败。** v1.5.122 我声称修好了 #319,那是错的。

## 现场

升级到 1.5.122 后只跑一次 `status`(两个 profile 都连着):

```
driving … (27ade1bc-8275-4308-ac97-cca1b4fbc04f) (most recently used)
  extension: live 0.5.26, expected 0.5.26
  profile:  … (696d9cb7-5dcd-4f9f-975f-ef6ce90929fe)
```

`profile:` 行仍然指向**另一个** profile,和修复前一模一样。

## 我的诊断错在哪

#319 我诊断成「版本号缺 profile 维度」。这句没错,但**不完整**。真正的缺陷是:代码里「driving」有**两个不同的实现**。

| 用哪个 | 消费者 |
|---|---|
| `most_recently_focused_profile()`(焦点时间戳) | 标题行 `driving X (most recently used)`、**以及真正的端点选择** |
| `relay_ext_profile()`(通用侧车 = 最后一个发 `hello` 的) | `profile:` 行、`drivingProfileId`、`browsers` 的 default 列、doctor,**以及我在 v1.5.122 新写的版本解析器** |

所以 v1.5.122 把版本挪进了按 profile 的文件,**却仍然拿着错误的 id 去查它**:

```rust
if let Some((id, _)) = relay_ext_profile() {   // ← 最后一个 hello，不是在驱动的那个
    read_ext_version_file(relay_ext_version_path_for(&id))
}
```

同一个错误换了个位置引入,症状原样保留。PR #323 里那句「呈现版本的地方读当前驱动的那个 profile 的副本」**不成立**。

## 改动

一个 `driving_profile()`,所有**报告** driving 的地方都用它:优先焦点口径(与端点选择同源),取不到再回退通用侧车。

**回退不是将就。** `most_recently_focused_profile()` 只在三种情况返回 `None`——少于两个 profile、有 profile 的扩展太老报不出焦点、平局——而那些情况下通用侧车恰恰是唯一可得且正确的答案。所以它是 fallback,不是 primary。

顺带修掉同一缺陷的**第三个症状**:`chrome-use browsers` 的 default 列也标错了。它的注释还写着「relay 不带 `--browser` 时绑定的默认」,而实际绑定早就按焦点选了。

## 验证,以及它证明不了什么

构建机(游离 HEAD):`cargo fmt --check` 干净、`cargo build` 无错误、全量 **1343 + 2 + 2 + 7 通过 / 0 失败**。

**但这套验证证明不了修复有效——#323 就是反例。** 那次同样全绿(单元测试 + 编译 + 针眼验证),而修复无效。针眼只能证明代码进了二进制,单元测试只能证明纯函数的偏好逻辑对。

本次新增的测试(`prefer_focused_profile` 的偏好与回退)**同样不能替代双 profile 实机验证**。那个缺口仍然存在,只是现在被写下来了而不是被忽略。现场报告者已停止一切实机操作(用户已禁止),所以这次也不能靠他们复现。

## 仍未确认

现场那次两个 profile 都是 0.5.26,所以那份输出**无法判断版本行本身是否已经正确**;已确认的只有 `profile:` 行错配。#319 里那些 `open` 之后立刻失败的问题,归因依旧未确立,本 PR 不声称修了它们。

现场数据来自 chatgpt-use 会话,代码侧确认在本 PR 内。

https://claude.ai/code/session_01YBrHUJnzXRfGbVZapEnCh5