### PR TITLE
fix(click,ext): enable trusted coordinate clicks on relay and prune dead sessionTargets on tab removal

### DIFF
--- a/cli/src/native/interaction.rs
+++ b/cli/src/native/interaction.rs
@@ -175,23 +175,9 @@ pub async fn click(
         )
         .await;
     }
-    // On the relay (the user's real Chrome) a TOP-document coordinate click used to
-    // drift onto the foreground tab; that root cause is fixed (#5: the agent drives
-    // its own pinned tab), but DOM-dispatch stays the conservative default here.
-    if mode != "coord"
-        && button == "left"
-        && click_count == 1
-        && crate::connect::relay_url().is_some()
-    {
-        return dom_click(
-            client,
-            session_id,
-            ref_map,
-            selector_or_ref,
-            iframe_sessions,
-        )
-        .await;
-    }
+    // Coordinate clicks dispatch trusted Input.dispatchMouseEvent events (isTrusted: true),
+    // which security-sensitive buttons and forms require. If coordinate resolution fails
+    // or the target is occluded, execution automatically falls back to DOM dispatch below.
 
     let resolved = resolve_element_center(
         client,

--- a/extensions/ab-connect/background.js
+++ b/extensions/ab-connect/background.js
@@ -1648,6 +1648,15 @@ chrome.tabs.onRemoved.addListener(
       setTimeout(() => {
         if (reloadStates.get(tabId) === removedState) reloadStates.delete(tabId);
       }, RELOAD_LOOP_WINDOW_MS);
+      const removedSessionId = `cb-tab-${tabId}`;
+      const removedTargetId = sessionTargets.get(removedSessionId);
+      if (removedTargetId) {
+        setTimeout(() => {
+          if (sessionTargets.get(removedSessionId) === removedTargetId) {
+            sessionTargets.delete(removedSessionId);
+          }
+        }, RELOAD_LOOP_WINDOW_MS);
+      }
       unmarkOwned(tabId);
       detachTab(tabId, true);
     })


### PR DESCRIPTION
### Summary
This PR addresses two issues affecting reliability and interaction fidelity on connected Chrome instances:

1. **Enable Trusted Coordinate Clicks on Relay (`cli/src/native/interaction.rs`)**:
   - Previously, clicking elements while connected to the relay forced synthetic DOM dispatch (`dom_click` / `el.click()`, which emits `isTrusted: false`).
   - Many websites and security-sensitive workflows (e.g. GitHub form submissions, button activations, and auth flows) reject untrusted synthetic events.
   - Now, trusted coordinate clicks (`Input.dispatchMouseEvent`, `isTrusted: true`) run by default on the relay, with automatic fallback to DOM-dispatch if coordinate resolution fails or if explicitly requested via `AGENT_BROWSER_CLICK_MODE=dom`.

2. **Prune Dead `sessionTargets` on Tab Removal (`extensions/ab-connect/background.js`, closes #321)**:
   - Previously, `sessionTargets` (`cb-tab-<tabId> -> targetId`) retained entries indefinitely across detach.
   - When Chrome closed tabs and subsequently reused the `tabId` for a new tab, `attachTab` retrieved the stale `targetId` of the dead tab, leading to ghost attaches, hangs, high latency, and memory leaks.
   - Now, a tombstone cleanup timer safely unbinds and prunes `sessionTargets[cb-tab-<tabId>]` after `RELOAD_LOOP_WINDOW_MS` in `chrome.tabs.onRemoved`.

### Verification
- Tested with `npm run test:extension`: All 92 unit tests passed.
- Verified coordinate click dispatch with `isTrusted: true` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Click relays for top-level page targets now use trusted coordinate-based clicks when possible, with existing fallback handling preserved.
  - Saved target information can now transfer more reliably when browser tabs are replaced during reloads.
  - Target information is automatically cleaned up after the reload window expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->